### PR TITLE
Implement set_read_timeout for Windows SyncStream (named pipe)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,7 +111,7 @@ embeddings = ["tract-onnx", "tract-hir", "tokenizers"]
 pdf = ["pdf-extract"]
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.59", features = ["Win32_Foundation", "Win32_System_Threading"] }
+windows-sys = { version = "0.59", features = ["Win32_Foundation", "Win32_System_Threading", "Win32_System_Pipes"] }
 
 [profile.release]
 opt-level = 1

--- a/src/transport/windows.rs
+++ b/src/transport/windows.rs
@@ -313,6 +313,7 @@ impl<'a> AsyncWrite for SplitWriteRef<'a> {
 /// Synchronous named pipe stream for blocking IPC (used by communicate tool).
 pub struct SyncStream {
     handle: std::fs::File,
+    read_timeout: Option<std::time::Duration>,
 }
 
 impl SyncStream {
@@ -320,12 +321,45 @@ impl SyncStream {
         use std::fs::OpenOptions;
         let pipe_name = path_to_pipe_name(path);
         let file = OpenOptions::new().read(true).write(true).open(&pipe_name)?;
-        Ok(Self { handle: file })
+        Ok(Self { handle: file, read_timeout: None })
+    }
+
+    pub fn set_read_timeout(&mut self, timeout: Option<std::time::Duration>) -> io::Result<()> {
+        self.read_timeout = timeout;
+        Ok(())
     }
 }
 
 impl io::Read for SyncStream {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        if let Some(timeout) = self.read_timeout {
+            use std::os::windows::io::AsRawHandle;
+            let handle = self.handle.as_raw_handle() as windows_sys::Win32::Foundation::HANDLE;
+            let deadline = std::time::Instant::now() + timeout;
+            loop {
+                let mut available: u32 = 0;
+                let ok = unsafe {
+                    windows_sys::Win32::System::Pipes::PeekNamedPipe(
+                        handle,
+                        std::ptr::null_mut(),
+                        0,
+                        std::ptr::null_mut(),
+                        &mut available,
+                        std::ptr::null_mut(),
+                    )
+                };
+                if ok == 0 {
+                    return Err(io::Error::last_os_error());
+                }
+                if available > 0 {
+                    break;
+                }
+                if std::time::Instant::now() >= deadline {
+                    return Err(io::Error::new(io::ErrorKind::TimedOut, "read timed out"));
+                }
+                std::thread::sleep(std::time::Duration::from_millis(10));
+            }
+        }
         self.handle.read(buf)
     }
 }


### PR DESCRIPTION
## Problem

Building jcode from source on Windows fails with:

```
error[E0599]: no method named `set_read_timeout` found for struct `SyncStream` in the current scope
  --> src\tool\communicate.rs:26:16
   |
26 |         stream.set_read_timeout(Some(t))?;
   |                ^^^^^^^^^^^^^^^^ method not found in `SyncStream`
```

On Unix, `SyncStream` re-exports `std::os::unix::net::UnixStream` which has `set_read_timeout` natively. On Windows, `SyncStream` wraps `std::fs::File` (a named pipe handle) which does not provide this method.

## Fix

- Add a `read_timeout: Option<Duration>` field to the Windows `SyncStream`
- Implement `set_read_timeout()` to store the timeout value
- In the `Read::read` implementation, use `PeekNamedPipe` to poll for available data before performing a blocking read, returning `io::ErrorKind::TimedOut` if the deadline expires
- Add `Win32_System_Pipes` to the `windows-sys` features in `Cargo.toml`

`PeekNamedPipe` is documented by Microsoft to [return immediately](https://learn.microsoft.com/en-us/windows/win32/api/namedpipeapi/nf-namedpipeapi-peeknamedpipe) without blocking, making it suitable for implementing a timeout polling loop.

## Changes

- `Cargo.toml`: Added `"Win32_System_Pipes"` to `windows-sys` features
- `src/transport/windows.rs`: Added `read_timeout` field, `set_read_timeout` method, and `PeekNamedPipe`-based timeout in `Read::read`

## Testing

- `cargo build --release` on Windows completes successfully
- `jcode` binary runs and functions correctly after the fix