### PR TITLE
feat: expose system_prompt in config + fix VSCode keyboard layout  

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -162,7 +162,7 @@ impl Agent {
             cache_tracker: CacheTracker::new(),
             last_usage: TokenUsage::default(),
             locked_tools: None,
-            system_prompt_override: None,
+            system_prompt_override: crate::config::config().provider.system_prompt.clone(),
             memory_enabled: crate::config::config().features.memory,
             stdin_request_tx: None,
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -599,6 +599,8 @@ pub struct ProviderConfig {
     /// Copilot premium request mode: "normal", "one", or "zero"
     /// "zero" means all requests are free (no premium requests consumed)
     pub copilot_premium: Option<String>,
+    /// Custom system prompt to use instead of the default.
+    pub system_prompt: Option<String>,
 }
 
 impl Default for ProviderConfig {
@@ -614,6 +616,7 @@ impl Default for ProviderConfig {
             cross_provider_failover: CrossProviderFailoverMode::Countdown,
             same_provider_account_failover: true,
             copilot_premium: None,
+            system_prompt: None,
         }
     }
 }

--- a/src/perf.rs
+++ b/src/perf.rs
@@ -118,6 +118,10 @@ impl SystemProfile {
     pub fn is_wsl_windows_terminal(&self) -> bool {
         self.is_wsl && self.is_windows_terminal()
     }
+
+    pub fn is_vscode_terminal(&self) -> bool {
+        self.terminal == "vscode"
+    }
 }
 
 static PROFILE: OnceLock<SystemProfile> = OnceLock::new();
@@ -209,6 +213,14 @@ pub fn tui_policy_for(
         enable_keyboard_enhancement = false;
         simplified_model_picker = true;
         linked_side_panel_refresh_interval = std::time::Duration::from_millis(1000);
+    }
+
+    if profile.is_vscode_terminal() {
+        // VSCodium/VSCode terminal (xterm.js) translates keys via the OS keyboard layout
+        // before sending escape sequences. Enabling keyboard enhancement causes crossterm to
+        // reconstruct shifted characters using a hardcoded US layout, breaking international
+        // keyboard layouts (e.g. Finnish Shift+7 = '/' becomes '&').
+        enable_keyboard_enhancement = false;
     }
 
     match profile.tier {


### PR DESCRIPTION
**feat: expose system_prompt in config**
Add optional system_prompt field to ProviderConfig and wire it into agent init, replacing the hardcoded None with the config value.

**fix: disable keyboard enhancement in VSCode terminal**
xterm.js translates keys via OS keyboard layout before sending escape sequences. Keyboard enhancement causes crossterm to reconstruct shifted chars using a hardcoded US layout, breaking international keyboards
(e.g. Finnish Shift+7='/' becomes '&').