### PR TITLE
provider: hot-init OpenAI provider lazily on set_model / complete

### DIFF
--- a/src/provider/accessors.rs
+++ b/src/provider/accessors.rs
@@ -60,4 +60,27 @@ impl MultiProvider {
     pub(super) fn has_claude_runtime(&self) -> bool {
         self.anthropic_provider().is_some() || self.claude_provider().is_some()
     }
+
+    /// Lazy hot-init: if `self.openai` is currently `None` but valid OpenAI
+    /// credentials exist on disk (or via `OPENAI_API_KEY`), attach a fresh
+    /// `OpenAIProvider`. Used by credential-check paths in `set_model` and
+    /// `complete*` so the dispatcher recovers when credentials become valid
+    /// after startup without an in-process `LoginCompleted` event reaching
+    /// this server (e.g. the user ran `jcode login --provider openai` from a
+    /// separate shell).
+    pub(super) fn try_hot_init_openai_from_disk(&self) {
+        if self.openai_provider().is_some() {
+            return;
+        }
+        crate::auth::AuthStatus::invalidate_cache();
+        let Ok(credentials) = crate::auth::codex::load_credentials() else {
+            return;
+        };
+        crate::logging::info("Hot-initialized OpenAI provider lazily on demand");
+        *self
+            .openai
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) =
+            Some(Arc::new(openai::OpenAIProvider::new(credentials)));
+    }
 }

--- a/src/provider/dispatch.rs
+++ b/src/provider/dispatch.rs
@@ -79,6 +79,9 @@ impl MultiProvider {
                 }
             }
             ActiveProvider::OpenAI => {
+                if self.openai_provider().is_none() {
+                    self.try_hot_init_openai_from_disk();
+                }
                 if let Some(openai) = self.openai_provider() {
                     openai
                         .complete(messages, tools, system, resume_session_id)
@@ -206,6 +209,9 @@ impl MultiProvider {
                 }
             }
             ActiveProvider::OpenAI => {
+                if self.openai_provider().is_none() {
+                    self.try_hot_init_openai_from_disk();
+                }
                 if let Some(openai) = self.openai_provider() {
                     openai
                         .complete_split(

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -703,6 +703,9 @@ impl MultiProvider {
                 Ok(())
             }
             ActiveProvider::OpenAI => {
+                if self.openai_provider().is_none() {
+                    self.try_hot_init_openai_from_disk();
+                }
                 let Some(openai) = self.openai_provider() else {
                     anyhow::bail!(
                         "OpenAI credentials not available. Run `jcode login --provider openai` first."


### PR DESCRIPTION
## Summary
- Fix `/model gpt-…` failing with "OpenAI credentials not available" while the TUI header shows `openai(oauth)` green.
- Add `MultiProvider::try_hot_init_openai_from_disk()` and call it from the credential-check paths in `set_model_on_provider`, `complete_on_provider`, and `complete_split_on_provider`.

## RCA
The dispatcher caches `Arc<OpenAIProvider>` in `self.openai`, populated **only** at startup (`src/provider/startup.rs`) or via `on_auth_changed()` (`src/provider/mod.rs`).

`on_auth_changed` is wired up on the server through `Request::NotifyAuthChanged` (`src/server/provider_control.rs`), which the TUI client sends in response to a `LoginCompleted` bus event in its own process (`src/tui/app/remote.rs`).

If credentials become valid on disk by any path that doesn't fire `LoginCompleted` on the running client — e.g. you ran `jcode login --provider openai` from a separate shell, or the daemon outlived a previous client — the dispatcher's `openai` field stays `None` indefinitely.

The TUI header refreshes from `AuthStatus::check_fast()` which reads `~/.jcode/openai-auth.json` directly, so it correctly shows `openai(oauth)` green. But `set_model_on_provider` still bails:

> OpenAI credentials not available. Run `jcode login --provider openai` first.

## Reproduction
1. Start `jcode` with no OpenAI credentials.
2. From a separate shell: `jcode login --provider openai` (or write a valid `~/.jcode/openai-auth.json` by any means).
3. In the running TUI, the header eventually shows `openai(oauth)` green.
4. `/model gpt-5` → fails with the error above.

## Fix
`try_hot_init_openai_from_disk()` (in `src/provider/accessors.rs`) is a no-op when the provider is already attached or when no credentials are reachable on disk; otherwise it invalidates the auth-status cache, loads via `auth::codex::load_credentials()`, and attaches a fresh `OpenAIProvider`. Called before every "credentials not available" OpenAI bail:

- `set_model_on_provider` OpenAI branch (`src/provider/mod.rs`)
- `complete_on_provider` dispatch (`src/provider/dispatch.rs`)
- `complete_split_on_provider` dispatch (`src/provider/dispatch.rs`)

3 files, +32/−0.

## Notes / follow-ups
The same structural pattern affects Anthropic / Gemini / Antigravity / Cursor / OpenRouter — same `is_some()` check with no lazy hot-init. Out of scope for this PR; addressed surgically for OpenAI since that's what was reported. Worth a follow-up to generalize the helper.

## Test plan
- [x] `cargo check -q` passes
- [x] `cargo fmt --all -- --check` clean
- [ ] Manual repro: start `jcode` with no OpenAI creds, log in from a separate shell, then `/model gpt-5` in the TUI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/1jehuang/codesmith/jcode/pr/69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->