### PR TITLE
feat(release): publish SHA256SUMS for release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -228,6 +228,22 @@ jobs:
           path: artifacts
           pattern: jcode-*
 
+      - name: Generate SHA256SUMS
+        run: |
+          set -euo pipefail
+          # Collect every release tarball into a flat manifest. Filenames in
+          # SHA256SUMS are bare (no path prefix) so users can verify with
+          # `sha256sum --check SHA256SUMS` alongside the downloaded artifact.
+          (
+            cd artifacts
+            find . -type f -name '*.tar.gz' -print0 | sort -z | while IFS= read -r -d '' f; do
+              sha=$(sha256sum "$f" | cut -d' ' -f1)
+              printf '%s  %s\n' "$sha" "$(basename "$f")"
+            done
+          ) > artifacts/SHA256SUMS
+          echo "Generated SHA256SUMS:"
+          cat artifacts/SHA256SUMS
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
@@ -235,6 +251,7 @@ jobs:
           files: |
             artifacts/jcode-linux-x86_64/*.tar.gz
             artifacts/jcode-macos-aarch64/*.tar.gz
+            artifacts/SHA256SUMS
 
       - name: Update Homebrew formula
         env:
@@ -398,9 +415,26 @@ jobs:
           path: artifacts
           pattern: jcode-windows-*
 
+      - name: Generate SHA256SUMS-windows
+        run: |
+          set -euo pipefail
+          # Mirror the Linux/macOS manifest format. Filenames are bare so
+          # `sha256sum --check SHA256SUMS-windows` works after a flat
+          # download, regardless of the artifacts/<name>/ subdir layout.
+          (
+            cd artifacts
+            find . -type f \( -name '*.tar.gz' -o -name '*.exe' \) -print0 | sort -z | while IFS= read -r -d '' f; do
+              sha=$(sha256sum "$f" | cut -d' ' -f1)
+              printf '%s  %s\n' "$sha" "$(basename "$f")"
+            done
+          ) > artifacts/SHA256SUMS-windows
+          echo "Generated SHA256SUMS-windows:"
+          cat artifacts/SHA256SUMS-windows
+
       - name: Attach Windows artifacts to GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           files: |
             artifacts/jcode-windows-*/**/*.tar.gz
             artifacts/jcode-windows-*/**/*.exe
+            artifacts/SHA256SUMS-windows

--- a/README.md
+++ b/README.md
@@ -649,6 +649,54 @@ brew tap 1jehuang/jcode
 brew install jcode
 ```
 
+### Verifying release artifacts
+
+Each release ships SHA256 manifests alongside the binaries:
+
+- `SHA256SUMS` — Linux + macOS tarballs
+- `SHA256SUMS-windows` — Windows tarballs and `.exe` artifacts
+
+Verify before installing:
+
+```bash
+VERSION=v0.11.1
+ARTIFACT=jcode-linux-x86_64.tar.gz   # or jcode-macos-aarch64.tar.gz
+
+curl -LO "https://github.com/1jehuang/jcode/releases/download/${VERSION}/${ARTIFACT}"
+curl -LO "https://github.com/1jehuang/jcode/releases/download/${VERSION}/SHA256SUMS"
+sha256sum --check --ignore-missing SHA256SUMS
+```
+
+Expected output:
+
+```
+jcode-linux-x86_64.tar.gz: OK
+```
+
+A non-zero exit or `FAILED` line means the download was corrupted or
+tampered with — do not extract or install it.
+
+On macOS, `sha256sum` is not in the default toolchain; use `shasum -a 256 -c`
+instead, or install `coreutils` (`brew install coreutils` then `gsha256sum`).
+
+On Windows (PowerShell):
+
+```powershell
+$VERSION = "v0.11.1"
+$ARTIFACT = "jcode-windows-x86_64.tar.gz"
+
+Invoke-WebRequest "https://github.com/1jehuang/jcode/releases/download/$VERSION/$ARTIFACT" -OutFile $ARTIFACT
+Invoke-WebRequest "https://github.com/1jehuang/jcode/releases/download/$VERSION/SHA256SUMS-windows" -OutFile SHA256SUMS-windows
+
+$expected = (Select-String -Path SHA256SUMS-windows -Pattern "  $ARTIFACT$").Line.Split(' ')[0]
+$actual   = (Get-FileHash $ARTIFACT -Algorithm SHA256).Hash.ToLower()
+
+if ($expected -eq $actual) { "OK: $ARTIFACT" } else { throw "MISMATCH: $ARTIFACT" }
+```
+
+Sigstore / cosign signatures and installer-side automatic verification are
+tracked separately in [#63](https://github.com/1jehuang/jcode/issues/63).
+
 ### From Source (all platforms)
 
 ```bash


### PR DESCRIPTION
Closes part of #63 — the MVP requested in the issue body: *"publish `SHA256SUMS` next to release artifacts and document manual verification."* Sigstore / cosign / installer-side auto-verification are deliberately out of scope here and remain tracked in the issue for follow-up.

## What changes

**`.github/workflows/release.yml`** — two new manifest-generation steps, each run as the last step before the corresponding `softprops/action-gh-release` upload in its job:

- `release` job → generates `SHA256SUMS` covering `jcode-linux-x86_64.tar.gz` + `jcode-macos-aarch64.tar.gz`
- `upload-windows-assets` job → generates `SHA256SUMS-windows` covering the two Windows tarballs + their `.exe` companions

The two-file split mirrors the existing job structure (Windows already ships as a separate upload step), avoids cross-job artifact-passing complexity, and keeps each manifest verifiable by end users who only download a single platform's binary.

Filenames in each manifest are **bare basenames** (no path prefix), so users can drop the artifact and the manifest into a flat directory and run `sha256sum --check SHA256SUMS` directly.

**`README.md`** — new *"Verifying release artifacts"* section under *Detailed Installation*. Copy-pasteable verification commands for:

- Linux: `sha256sum --check --ignore-missing SHA256SUMS`
- macOS: `shasum -a 256 -c --ignore-missing SHA256SUMS` (since `sha256sum` is not on the default toolchain)
- Windows PowerShell: `Get-FileHash` + manual compare against the line in the manifest

The section also explicitly notes that signatures + installer-side auto-verify are tracked separately in #63, so future readers don't think this PR closed the whole issue.

## Verification

The exact bash logic from the workflow was lifted into a local sandbox and run end-to-end:

1. Created a fake nested `artifacts/jcode-{linux,macos}-…/` tree to mirror the post-`download-artifact` layout
2. Ran the `find … | sort -z | sha256sum | basename` pipeline → produced a clean two-line manifest
3. Simulated end-user flow: copied `SHA256SUMS` + one tarball into a flat dir → `shasum -a 256 -c --ignore-missing` returned `OK`
4. Tampering test: corrupted the tarball → verification correctly returned `FAILED` and exited non-zero

`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"` passes; the workflow file is structurally valid.

## Why this is small

Per the issue body's *"Possible MVP"* section, this PR scope is exactly:

1. Generate a `SHA256SUMS` file during release ✅
2. Upload it next to the release binaries ✅
3. Document manual verification in the README ✅

Sigstore / cosign signatures, SLSA provenance, and `JCODE_INSTALL_SKIP_VERIFY=1` installer integration are intentionally NOT in this PR — each is a meaningful next step on its own and will land cleaner as separate PRs once this baseline is in.

## Trade-offs / things to double-check

- **Two manifest files vs one combined.** A combined manifest would require the Windows job to depend on the release job's `SHA256SUMS` artifact (or vice versa) and be appended to. Splitting by platform keeps each job self-contained and idempotent. Happy to switch to a combined `SHA256SUMS.txt` in `release` that the Windows job appends to if you'd prefer — let me know.
- **Manifest filenames at the release level.** Both files attach as plain release assets named `SHA256SUMS` and `SHA256SUMS-windows`. If you prefer a different naming convention (`jcode-${VERSION}-SHA256SUMS.txt`, etc.), it's a one-line change.
- **No installer change in this PR.** The issue suggests teaching `install.sh` to verify before installing. That's a separate concern (network reliability of pulling the manifest, error UX, opt-out flag) and worth its own review cycle.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/1jehuang/codesmith/jcode/pr/70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->
