### PR TITLE
Notify running server on CLI login + add Ghostty terminal restore arm

### DIFF
--- a/src/cli/login.rs
+++ b/src/cli/login.rs
@@ -333,7 +333,18 @@ pub async fn run_login_provider(
         ));
     }
     auth::AuthStatus::invalidate_cache();
+    notify_running_server_auth_changed_best_effort().await;
     Ok(())
+}
+
+/// Best-effort: tell a running jcode server that on-disk auth has changed so it
+/// hot-initializes any newly-configured providers. No-op if no server is running.
+async fn notify_running_server_auth_changed_best_effort() {
+    let mut client = match crate::server::Client::connect().await {
+        Ok(client) => client,
+        Err(_) => return,
+    };
+    let _ = client.notify_auth_changed().await;
 }
 
 fn login_jcode_flow() -> Result<()> {

--- a/src/cli/tui_launch.rs
+++ b/src/cli/tui_launch.rs
@@ -140,6 +140,19 @@ fn focus_title_best_effort(title: &str) {
 #[cfg(any(not(unix), target_os = "macos"))]
 fn focus_title_best_effort(_title: &str) {}
 
+#[cfg(target_os = "macos")]
+fn macos_ghostty_app_installed() -> bool {
+    if std::path::Path::new("/Applications/Ghostty.app").is_dir() {
+        return true;
+    }
+    if let Some(home) = dirs::home_dir()
+        && home.join("Applications/Ghostty.app").is_dir()
+    {
+        return true;
+    }
+    false
+}
+
 fn push_unique_terminal(candidates: &mut Vec<String>, term: impl Into<String>) {
     let term = term.into();
     if term.trim().is_empty() {
@@ -174,10 +187,16 @@ fn detected_resume_terminal() -> Option<&'static str> {
 
     #[cfg(target_os = "macos")]
     {
+        if std::env::var("GHOSTTY_RESOURCES_DIR").is_ok()
+            || std::env::var("GHOSTTY_BIN_DIR").is_ok()
+        {
+            return Some("ghostty");
+        }
         let term_program = std::env::var("TERM_PROGRAM")
             .ok()
             .map(|value| value.to_ascii_lowercase());
         return match term_program.as_deref() {
+            Some("ghostty") => Some("ghostty"),
             Some("kitty") => Some("kitty"),
             Some("wezterm") => Some("wezterm"),
             Some("alacritty") => Some("alacritty"),
@@ -205,6 +224,9 @@ fn resume_terminal_candidates_unix() -> Vec<String> {
 
     #[cfg(target_os = "macos")]
     {
+        if macos_ghostty_app_installed() {
+            push_unique_terminal(&mut candidates, "ghostty");
+        }
         for term in ["kitty", "wezterm", "alacritty", "iterm2", "terminal"] {
             push_unique_terminal(&mut candidates, term);
         }
@@ -671,6 +693,22 @@ pub fn spawn_resume_in_new_terminal(
                 ]);
                 cmd.args(["--standalone", "--backend", "gpu", "--exec", &command]);
             }
+            "ghostty" => {
+                cmd = Command::new("open");
+                let command = shell_command(&[
+                    exe.to_string_lossy().into_owned(),
+                    "--fresh-spawn".to_string(),
+                    "--resume".to_string(),
+                    session_id.to_string(),
+                ]);
+                cmd.current_dir(cwd)
+                    .env("JCODE_FRESH_SPAWN", "1")
+                    .stdin(Stdio::null())
+                    .stdout(Stdio::null())
+                    .stderr(Stdio::null())
+                    .args(["-na", "Ghostty", "--args", "-e", "/bin/bash", "-lc"])
+                    .arg(command);
+            }
             "kitty" => {
                 let title = resumed_window_title(session_id);
                 cmd.args(["--title", &title, "-e"])
@@ -795,6 +833,23 @@ pub fn spawn_selfdev_in_new_terminal(
                     "self-dev".to_string(),
                 ]);
                 cmd.args(["--standalone", "--backend", "gpu", "--exec", &command]);
+            }
+            "ghostty" => {
+                cmd = Command::new("open");
+                let command = shell_command(&[
+                    exe.to_string_lossy().into_owned(),
+                    "--fresh-spawn".to_string(),
+                    "--resume".to_string(),
+                    session_id.to_string(),
+                    "self-dev".to_string(),
+                ]);
+                cmd.current_dir(cwd)
+                    .env("JCODE_FRESH_SPAWN", "1")
+                    .stdin(Stdio::null())
+                    .stdout(Stdio::null())
+                    .stderr(Stdio::null())
+                    .args(["-na", "Ghostty", "--args", "-e", "/bin/bash", "-lc"])
+                    .arg(command);
             }
             "kitty" => {
                 cmd.args(["--title", selfdev_title.as_str(), "-e"])
@@ -1244,6 +1299,21 @@ pub fn list_sessions() -> Result<()> {
                             .collect::<Vec<_>>(),
                     );
                     cmd.args(["--standalone", "--backend", "gpu", "--exec", &command]);
+                }
+                #[cfg(target_os = "macos")]
+                "ghostty" => {
+                    let command = shell_command(
+                        &std::iter::once(program.to_string_lossy().into_owned())
+                            .chain(args.iter().cloned())
+                            .collect::<Vec<_>>(),
+                    );
+                    cmd = Command::new("open");
+                    cmd.current_dir(cwd)
+                        .stdin(Stdio::null())
+                        .stdout(Stdio::null())
+                        .stderr(Stdio::null())
+                        .args(["-na", "Ghostty", "--args", "-e", "/bin/bash", "-lc"])
+                        .arg(command);
                 }
                 "kitty" => {
                     cmd.args(["--title", &title, "-e"])

--- a/src/server/client_api.rs
+++ b/src/server/client_api.rs
@@ -276,6 +276,16 @@ impl Client {
         Ok(id)
     }
 
+    pub async fn notify_auth_changed(&mut self) -> Result<u64> {
+        let id = self.next_id;
+        self.next_id += 1;
+
+        let request = Request::NotifyAuthChanged { id };
+        let json = serde_json::to_string(&request)? + "\n";
+        self.writer.write_all(json.as_bytes()).await?;
+        Ok(id)
+    }
+
     pub async fn debug_command(&mut self, command: &str, session_id: Option<&str>) -> Result<u64> {
         let id = self.next_id;
         self.next_id += 1;

--- a/src/tui/app/helpers.rs
+++ b/src/tui/app/helpers.rs
@@ -470,6 +470,21 @@ fn spawn_command_in_new_terminal(
                 );
                 cmd.args(["--standalone", "--backend", "gpu", "--exec", &command]);
             }
+            #[cfg(target_os = "macos")]
+            "ghostty" => {
+                let command = shell_command(
+                    &std::iter::once(program.to_string_lossy().into_owned())
+                        .chain(args.iter().cloned())
+                        .collect::<Vec<_>>(),
+                );
+                cmd = Command::new("open");
+                cmd.current_dir(cwd)
+                    .stdin(Stdio::null())
+                    .stdout(Stdio::null())
+                    .stderr(Stdio::null())
+                    .args(["-na", "Ghostty", "--args", "-e", "/bin/bash", "-lc"])
+                    .arg(command);
+            }
             "kitty" => {
                 cmd.args(["--title", title, "-e"]).arg(program).args(args);
             }
@@ -581,6 +596,19 @@ fn shell_command(args: &[String]) -> String {
     }
 }
 
+#[cfg(target_os = "macos")]
+fn macos_ghostty_app_installed() -> bool {
+    if std::path::Path::new("/Applications/Ghostty.app").is_dir() {
+        return true;
+    }
+    if let Some(home) = dirs::home_dir()
+        && home.join("Applications/Ghostty.app").is_dir()
+    {
+        return true;
+    }
+    false
+}
+
 fn push_unique_terminal(candidates: &mut Vec<String>, term: impl Into<String>) {
     let term = term.into();
     if term.trim().is_empty() {
@@ -616,10 +644,16 @@ fn detected_resume_terminal() -> Option<&'static str> {
 
         #[cfg(target_os = "macos")]
         {
+            if std::env::var("GHOSTTY_RESOURCES_DIR").is_ok()
+                || std::env::var("GHOSTTY_BIN_DIR").is_ok()
+            {
+                return Some("ghostty");
+            }
             let term_program = std::env::var("TERM_PROGRAM")
                 .ok()
                 .map(|value| value.to_ascii_lowercase());
             return match term_program.as_deref() {
+                Some("ghostty") => Some("ghostty"),
                 Some("kitty") => Some("kitty"),
                 Some("wezterm") => Some("wezterm"),
                 Some("alacritty") => Some("alacritty"),
@@ -661,6 +695,9 @@ fn resume_terminal_candidates_unix() -> Vec<String> {
 
     #[cfg(target_os = "macos")]
     {
+        if macos_ghostty_app_installed() {
+            push_unique_terminal(&mut candidates, "ghostty");
+        }
         for term in ["kitty", "wezterm", "alacritty", "iterm2", "terminal"] {
             push_unique_terminal(&mut candidates, term);
         }


### PR DESCRIPTION
## Summary

Two related fixes surfaced from a single bug report ("after `jcode login --provider claude`, restoring the window prints an AppleScript syntax error and `/model` says Claude credentials aren't available"):

- **Spawn restored jcode windows in Ghostty when available.** The macOS resume terminal candidate list was hardcoded to `[kitty, wezterm, alacritty, iterm2, terminal]` with no Ghostty arm. On a Ghostty-only host the loop fell through to the iterm2 osascript path, which fails with `(-2741) Expected end of line but found class name` when iTerm2 isn't installed (AppleScript can't load iTerm2's scripting dictionary). `spawn_detached` only checks that osascript started, so jcode reported "Restored 1 jcode window(s)" while no window opened. Detect Ghostty via `TERM_PROGRAM`/`GHOSTTY_RESOURCES_DIR`; gate the static fallback push on `/Applications/Ghostty.app` being present so non-Ghostty hosts don't regress; add `ghostty` arms to all four spawn sites using `open -na Ghostty --args -e /bin/bash -lc <command>`, mirroring `setup_hints/macos_terminal.rs`.

- **Notify running server when CLI login completes.** `jcode login --provider <X>` writes credentials to disk and exits, but never tells a long-running `jcode --provider auto serve` process. The server's `MultiProvider` was constructed before login, so its `anthropic` (or `openai`/`copilot`/etc) slot stays `None`. Picking opus then bails with `"Claude credentials not available"` in `set_model_on_provider`, even though credentials on disk are valid. Every `BusEvent::LoginCompleted` publisher today is in the in-process TUI auth flow (`tui/app/auth.rs`); none in the standalone CLI. The hot-init path in `MultiProvider::on_auth_changed` already handles this case correctly — it just never fired from the CLI. Add `Client::notify_auth_changed` mirroring the existing request methods, and call it best-effort at the end of `run_login_provider`. If no server is running, `Client::connect()` returns `Err` and we no-op silently.

Repro for the AppleScript piece is direct: `osascript -e 'tell application "iTerm2" ... end tell'` on a host without iTerm2 installed reproduces `61:67: syntax error: Expected end of line but found class name. (-2741)`.

## Test plan

- [ ] `cargo build --release` succeeds (the local box doing the report doesn't have a Rust toolchain; CI will be the real check).
- [ ] On a Ghostty-only macOS box: trigger the crash-restore path and confirm a Ghostty window opens for the restored session, no AppleScript error.
- [ ] On a non-Ghostty macOS box without `/Applications/Ghostty.app`: confirm the candidate list still falls through to iTerm2/Terminal as before (no regression — the static fallback push is gated).
- [ ] Long-running `jcode --provider auto serve` already up, run `jcode login --provider claude`, verify `/model` can switch to opus immediately without restarting the server. Server log should show `Hot-initialized Anthropic provider after auth change`.
- [ ] `jcode login --provider claude` with no server running stays silent (best-effort no-op).
- [ ] `cargo test -p jcode` passes (existing `detected_resume_terminal_recognizes_handterm_term_program` still hits the handterm short-circuit before any Ghostty check).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/1jehuang/codesmith/jcode/pr/72"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->