### PR TITLE
telemetry: runtime endpoint config + opt-in by default

### DIFF
--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -11,7 +11,10 @@ use std::sync::Mutex;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::time::{Duration, Instant};
 
-const TELEMETRY_ENDPOINT: &str = "https://jcode-telemetry.jeremyhuang55555.workers.dev/v1/event";
+// Telemetry endpoint is now resolved at runtime — see telemetry_endpoint().
+// Default in this fork is no endpoint, which disables telemetry. Set
+// JCODE_TELEMETRY_ENDPOINT or write `endpoint = "..."` to
+// `${JCODE_HOME:-~/.jcode}/telemetry.toml` to enable.
 const ASYNC_SEND_TIMEOUT: Duration = Duration::from_secs(5);
 const BLOCKING_INSTALL_TIMEOUT: Duration = Duration::from_millis(1200);
 const BLOCKING_LIFECYCLE_TIMEOUT: Duration = Duration::from_millis(800);
@@ -668,7 +671,46 @@ pub fn is_enabled() -> bool {
     {
         return false;
     }
-    true
+    // Opt-in by default in this fork: a telemetry endpoint must be configured
+    // (env var or config file) before any event is sent.
+    telemetry_endpoint().is_some()
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct TelemetryConfig {
+    endpoint: Option<String>,
+}
+
+/// Resolve the telemetry endpoint at runtime.
+///
+/// Resolution order:
+/// 1. `JCODE_TELEMETRY_ENDPOINT` environment variable (highest precedence).
+/// 2. `endpoint = "..."` in `${JCODE_HOME:-~/.jcode}/telemetry.toml`.
+/// 3. `None` — telemetry is disabled.
+///
+/// Empty / whitespace-only values are treated as `None` so that explicitly
+/// setting `JCODE_TELEMETRY_ENDPOINT=""` reliably disables telemetry without
+/// needing the separate `JCODE_NO_TELEMETRY` knob.
+fn telemetry_endpoint() -> Option<String> {
+    if let Ok(value) = std::env::var("JCODE_TELEMETRY_ENDPOINT") {
+        let trimmed = value.trim();
+        return if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed.to_string())
+        };
+    }
+    let dir = storage::jcode_dir().ok()?;
+    let path = dir.join("telemetry.toml");
+    let contents = std::fs::read_to_string(&path).ok()?;
+    let config: TelemetryConfig = toml::from_str(&contents).unwrap_or_default();
+    let endpoint = config.endpoint?;
+    let trimmed = endpoint.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
 }
 
 fn telemetry_envelope() -> (u32, String, bool, bool, bool) {
@@ -1169,6 +1211,10 @@ fn mcp_server_name(name: &str, input: &Value) -> Option<String> {
 }
 
 fn post_payload(payload: serde_json::Value, timeout: Duration) -> bool {
+    let endpoint = match telemetry_endpoint() {
+        Some(value) => value,
+        None => return false,
+    };
     let client = match reqwest::blocking::Client::builder()
         .timeout(timeout)
         .build()
@@ -1176,7 +1222,7 @@ fn post_payload(payload: serde_json::Value, timeout: Duration) -> bool {
         Ok(client) => client,
         Err(_) => return false,
     };
-    match client.post(TELEMETRY_ENDPOINT).json(&payload).send() {
+    match client.post(&endpoint).json(&payload).send() {
         Ok(response) => response.error_for_status().is_ok(),
         Err(_) => false,
     }
@@ -2031,11 +2077,11 @@ pub enum ErrorCategory {
 
 fn show_first_run_notice() {
     eprintln!("\x1b[90m");
-    eprintln!("  jcode collects anonymous usage statistics (install count, version, OS,");
-    eprintln!("  session activity, tool counts, and crash/exit reasons). No code, filenames,");
-    eprintln!("  prompts, or personal data is sent.");
-    eprintln!("  To opt out: export JCODE_NO_TELEMETRY=1");
-    eprintln!("  Details: https://github.com/1jehuang/jcode/blob/master/TELEMETRY.md");
+    eprintln!("  Telemetry is OFF by default in this build.");
+    eprintln!("  To enable, set JCODE_TELEMETRY_ENDPOINT or write");
+    eprintln!("    endpoint = \"https://your-collector/v1/event\"");
+    eprintln!("  to ${{JCODE_HOME:-~/.jcode}}/telemetry.toml.");
+    eprintln!("  Schema and field reference: TELEMETRY.md");
     eprintln!("\x1b[0m");
 }
 

--- a/src/telemetry/tests.rs
+++ b/src/telemetry/tests.rs
@@ -27,6 +27,52 @@ fn test_do_not_track() {
 }
 
 #[test]
+fn test_default_no_endpoint_disables() {
+    let _guard = lock_test_env();
+    crate::env::remove_var("JCODE_NO_TELEMETRY");
+    crate::env::remove_var("DO_NOT_TRACK");
+    crate::env::remove_var("JCODE_TELEMETRY_ENDPOINT");
+    assert!(!is_enabled());
+}
+
+#[test]
+fn test_endpoint_via_env_var_enables() {
+    let _guard = lock_test_env();
+    crate::env::remove_var("JCODE_NO_TELEMETRY");
+    crate::env::remove_var("DO_NOT_TRACK");
+    crate::env::set_var(
+        "JCODE_TELEMETRY_ENDPOINT",
+        "https://collector.example.com/v1/event",
+    );
+    assert!(is_enabled());
+    crate::env::remove_var("JCODE_TELEMETRY_ENDPOINT");
+}
+
+#[test]
+fn test_endpoint_empty_string_disables() {
+    let _guard = lock_test_env();
+    crate::env::remove_var("JCODE_NO_TELEMETRY");
+    crate::env::remove_var("DO_NOT_TRACK");
+    crate::env::set_var("JCODE_TELEMETRY_ENDPOINT", "   ");
+    assert!(!is_enabled());
+    crate::env::remove_var("JCODE_TELEMETRY_ENDPOINT");
+}
+
+#[test]
+fn test_no_telemetry_flag_overrides_endpoint() {
+    let _guard = lock_test_env();
+    crate::env::remove_var("DO_NOT_TRACK");
+    crate::env::set_var(
+        "JCODE_TELEMETRY_ENDPOINT",
+        "https://collector.example.com/v1/event",
+    );
+    crate::env::set_var("JCODE_NO_TELEMETRY", "1");
+    assert!(!is_enabled());
+    crate::env::remove_var("JCODE_NO_TELEMETRY");
+    crate::env::remove_var("JCODE_TELEMETRY_ENDPOINT");
+}
+
+#[test]
 fn test_error_counters() {
     let _guard = lock_telemetry_test_state();
     reset_counters();
@@ -225,7 +271,9 @@ fn test_session_end_event_serialization() {
 
 #[test]
 fn test_record_token_usage_aggregates_session_and_turn() {
+    let _env_guard = lock_test_env();
     let _guard = lock_telemetry_test_state();
+    crate::env::set_var("JCODE_TELEMETRY_ENDPOINT", "https://test.example/v1/event");
     reset_counters();
     if let Ok(mut session) = SESSION_STATE.lock() {
         *session = None;
@@ -254,11 +302,14 @@ fn test_record_token_usage_aggregates_session_and_turn() {
         *session = None;
     }
     reset_counters();
+    crate::env::remove_var("JCODE_TELEMETRY_ENDPOINT");
 }
 
 #[test]
 fn test_record_connection_type_buckets_transport() {
+    let _env_guard = lock_test_env();
     let _guard = lock_telemetry_test_state();
+    crate::env::set_var("JCODE_TELEMETRY_ENDPOINT", "https://test.example/v1/event");
     reset_counters();
     if let Ok(mut session) = SESSION_STATE.lock() {
         *session = None;


### PR DESCRIPTION
## What

Replace the hardcoded `TELEMETRY_ENDPOINT` constant with a runtime resolver: env var → `~/.jcode/telemetry.toml` → `None`. When no endpoint is configured, telemetry is disabled.

## Why

Two motivations, both about giving operators more control without changing what's collected.

1. **Operator-routable endpoint.** Today the collector URL is baked into the binary. Operators who want to keep usage data inside their own infrastructure (org-wide rollout, air-gapped, compliance-driven) have no path other than patching the source. Adding `JCODE_TELEMETRY_ENDPOINT` (env) and a `[telemetry] endpoint = "..."` config field (in `~/.jcode/telemetry.toml`, alongside the existing `mcp.json` / `openai-compatible.env` conventions) gives them a clean, documented knob.

2. **Opt-in default.** With the endpoint now a config value, the natural default for "no endpoint configured" is "no events sent." This means a fresh install doesn't begin phoning home before the user has had a chance to read TELEMETRY.md. Existing opt-out mechanisms (`JCODE_NO_TELEMETRY`, `DO_NOT_TRACK`, `~/.jcode/no_telemetry`) are unchanged and continue to work.

The instrumentation itself is unchanged — same schema, same fields, same coarseness guarantees. This patch only affects the destination.

## Behavior matrix

| Configuration | Result |
|---|---|
| Nothing set (default) | telemetry disabled |
| `JCODE_TELEMETRY_ENDPOINT=https://...` | telemetry enabled, sends to that URL |
| `endpoint = "https://..."` in `~/.jcode/telemetry.toml` | telemetry enabled, sends to that URL |
| Both set | env var wins |
| `JCODE_TELEMETRY_ENDPOINT=""` | telemetry disabled (explicit) |
| `JCODE_NO_TELEMETRY=1` or `DO_NOT_TRACK=1` | telemetry disabled (overrides endpoint) |

## Tests

Added positive coverage:

- `test_default_no_endpoint_disables` — fresh install with nothing configured does not emit.
- `test_endpoint_via_env_var_enables` — env var enables telemetry.
- `test_endpoint_empty_string_disables` — explicit empty string disables.
- `test_no_telemetry_flag_overrides_endpoint` — opt-out flag still wins.

Two pre-existing session-state tests (`test_record_token_usage_aggregates_session_and_turn`, `test_record_connection_type_buckets_transport`) now explicitly set `JCODE_TELEMETRY_ENDPOINT` before calling `begin_session_with_mode`, since that function correctly short-circuits when telemetry is disabled. They use the existing `lock_test_env` + `lock_telemetry_test_state` mutexes to stay isolated.

`cargo test --lib telemetry` — 16/16 pass locally on `rustc 1.93.0`. `cargo fmt` clean.

## Compatibility

- Existing operators who relied on the prior default endpoint can restore that behavior by exporting `JCODE_TELEMETRY_ENDPOINT=https://jcode-telemetry.jeremyhuang55555.workers.dev/v1/event` or writing it to their `telemetry.toml`. Suggest documenting this in TELEMETRY.md as a follow-up so existing users have a clear migration path.
- All opt-out paths preserved.
- Schema version unchanged.

## Splitting if you'd prefer

Happy to split this into two PRs if the default-flip is the controversial part:

1. Just the env var + config-file plumbing, default unchanged.
2. The default flip from on → off.

Either way, the `JCODE_TELEMETRY_ENDPOINT` knob is independently useful for operators running jcode at scale.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/1jehuang/codesmith/jcode/pr/77"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->