### PR TITLE
Add tmux pane spawning support

### DIFF
--- a/src/cli/tui_launch.rs
+++ b/src/cli/tui_launch.rs
@@ -683,16 +683,16 @@ pub fn spawn_resume_in_new_terminal(
                 cmd.args(["--standalone", "--backend", "gpu", "--exec", &command]);
             }
             "tmux" => {
-                let title = resumed_window_title(session_id);
                 let command = shell_command(&[
                     exe.to_string_lossy().into_owned(),
                     "--fresh-spawn".to_string(),
                     "--resume".to_string(),
                     session_id.to_string(),
                 ]);
-                cmd.args(["new-window", "-c"])
+                cmd.args(["split-window", "-d", "-c"])
                     .arg(cwd)
-                    .args(["-n", &title, &command]);
+                    .arg(&command)
+                    .args([";", "select-layout", "tiled"]);
             }
             "kitty" => {
                 let title = resumed_window_title(session_id);
@@ -827,11 +827,10 @@ pub fn spawn_selfdev_in_new_terminal(
                     session_id.to_string(),
                     "self-dev".to_string(),
                 ]);
-                cmd.args(["new-window", "-c"]).arg(cwd).args([
-                    "-n",
-                    selfdev_title.as_str(),
-                    &command,
-                ]);
+                cmd.args(["split-window", "-d", "-c"])
+                    .arg(cwd)
+                    .arg(&command)
+                    .args([";", "select-layout", "tiled"]);
             }
             "kitty" => {
                 cmd.args(["--title", selfdev_title.as_str(), "-e"])
@@ -1288,9 +1287,10 @@ pub fn list_sessions() -> Result<()> {
                             .chain(args.iter().cloned())
                             .collect::<Vec<_>>(),
                     );
-                    cmd.args(["new-window", "-c"])
+                    cmd.args(["split-window", "-d", "-c"])
                         .arg(cwd)
-                        .args(["-n", &title, &command]);
+                        .arg(&command)
+                        .args([";", "select-layout", "tiled"]);
                 }
                 "kitty" => {
                     cmd.args(["--title", &title, "-e"])

--- a/src/cli/tui_launch.rs
+++ b/src/cli/tui_launch.rs
@@ -162,6 +162,9 @@ fn detected_resume_terminal() -> Option<&'static str> {
     {
         return Some("handterm");
     }
+    if std::env::var("TMUX").is_ok() {
+        return Some("tmux");
+    }
     if std::env::var("KITTY_PID").is_ok() {
         return Some("kitty");
     }
@@ -205,7 +208,14 @@ fn resume_terminal_candidates_unix() -> Vec<String> {
 
     #[cfg(target_os = "macos")]
     {
-        for term in ["kitty", "wezterm", "alacritty", "iterm2", "terminal"] {
+        for term in [
+            "tmux",
+            "kitty",
+            "wezterm",
+            "alacritty",
+            "iterm2",
+            "terminal",
+        ] {
             push_unique_terminal(&mut candidates, term);
         }
     }
@@ -214,6 +224,7 @@ fn resume_terminal_candidates_unix() -> Vec<String> {
     {
         for term in [
             "handterm",
+            "tmux",
             "kitty",
             "wezterm",
             "alacritty",
@@ -671,6 +682,18 @@ pub fn spawn_resume_in_new_terminal(
                 ]);
                 cmd.args(["--standalone", "--backend", "gpu", "--exec", &command]);
             }
+            "tmux" => {
+                let title = resumed_window_title(session_id);
+                let command = shell_command(&[
+                    exe.to_string_lossy().into_owned(),
+                    "--fresh-spawn".to_string(),
+                    "--resume".to_string(),
+                    session_id.to_string(),
+                ]);
+                cmd.args(["new-window", "-c"])
+                    .arg(cwd)
+                    .args(["-n", &title, &command]);
+            }
             "kitty" => {
                 let title = resumed_window_title(session_id);
                 cmd.args(["--title", &title, "-e"])
@@ -795,6 +818,20 @@ pub fn spawn_selfdev_in_new_terminal(
                     "self-dev".to_string(),
                 ]);
                 cmd.args(["--standalone", "--backend", "gpu", "--exec", &command]);
+            }
+            "tmux" => {
+                let command = shell_command(&[
+                    exe.to_string_lossy().into_owned(),
+                    "--fresh-spawn".to_string(),
+                    "--resume".to_string(),
+                    session_id.to_string(),
+                    "self-dev".to_string(),
+                ]);
+                cmd.args(["new-window", "-c"]).arg(cwd).args([
+                    "-n",
+                    selfdev_title.as_str(),
+                    &command,
+                ]);
             }
             "kitty" => {
                 cmd.args(["--title", selfdev_title.as_str(), "-e"])
@@ -1244,6 +1281,16 @@ pub fn list_sessions() -> Result<()> {
                             .collect::<Vec<_>>(),
                     );
                     cmd.args(["--standalone", "--backend", "gpu", "--exec", &command]);
+                }
+                "tmux" => {
+                    let command = shell_command(
+                        &std::iter::once(program.to_string_lossy().into_owned())
+                            .chain(args.iter().cloned())
+                            .collect::<Vec<_>>(),
+                    );
+                    cmd.args(["new-window", "-c"])
+                        .arg(cwd)
+                        .args(["-n", &title, &command]);
                 }
                 "kitty" => {
                     cmd.args(["--title", &title, "-e"])

--- a/src/cli/tui_launch/tests.rs
+++ b/src/cli/tui_launch/tests.rs
@@ -130,7 +130,7 @@ fn spawn_resume_in_new_terminal_uses_handterm_exec_mode() {
 
 #[cfg(unix)]
 #[test]
-fn spawn_resume_in_new_terminal_uses_tmux_new_window() {
+fn spawn_resume_in_new_terminal_uses_tmux_split_pane_grid() {
     let temp = tempfile::tempdir().expect("temp dir");
     let output_path = temp.path().join("tmux-launch.txt");
     write_fake_tmux(&temp, &output_path);
@@ -150,20 +150,22 @@ fn spawn_resume_in_new_terminal_uses_tmux_new_window() {
         spawn_resume_in_new_terminal(&exe, "ses_tmux_123", &cwd).expect("spawn should work");
     assert!(launched);
 
-    let lines = wait_for_lines(&output_path, 7);
+    let lines = wait_for_lines(&output_path, 9);
     assert_eq!(
         Path::new(&lines[0]).canonicalize().expect("canonical pwd"),
         cwd.canonicalize().expect("canonical cwd")
     );
-    assert_eq!(lines[1], "new-window");
-    assert_eq!(lines[2], "-c");
-    assert_eq!(lines[3], cwd.to_string_lossy());
-    assert_eq!(lines[4], "-n");
-    assert_eq!(lines[5], resumed_window_title("ses_tmux_123"));
-    assert!(lines[6].contains("'--fresh-spawn'"));
-    assert!(lines[6].contains("'--resume'"));
-    assert!(lines[6].contains("'ses_tmux_123'"));
-    assert!(lines[6].contains("jcode bin"));
+    assert_eq!(lines[1], "split-window");
+    assert_eq!(lines[2], "-d");
+    assert_eq!(lines[3], "-c");
+    assert_eq!(lines[4], cwd.to_string_lossy());
+    assert!(lines[5].contains("'--fresh-spawn'"));
+    assert!(lines[5].contains("'--resume'"));
+    assert!(lines[5].contains("'ses_tmux_123'"));
+    assert!(lines[5].contains("jcode bin"));
+    assert_eq!(lines[6], ";");
+    assert_eq!(lines[7], "select-layout");
+    assert_eq!(lines[8], "tiled");
 }
 
 #[cfg(unix)]

--- a/src/cli/tui_launch/tests.rs
+++ b/src/cli/tui_launch/tests.rs
@@ -63,6 +63,18 @@ fn write_fake_handterm(temp: &tempfile::TempDir, output_path: &Path) {
 }
 
 #[cfg(unix)]
+fn write_fake_tmux(temp: &tempfile::TempDir, output_path: &Path) {
+    let script_path = temp.path().join("tmux");
+    let script = format!(
+        "#!/bin/sh\nprintf '%s\n' \"$PWD\" > {}\nprintf '%s\n' \"$@\" >> {}\n",
+        output_path.display(),
+        output_path.display()
+    );
+    fs::write(&script_path, script).expect("write fake tmux script");
+    set_permissions_executable(&script_path).expect("make fake tmux executable");
+}
+
+#[cfg(unix)]
 fn wait_for_lines(path: &Path, min_lines: usize) -> Vec<String> {
     let deadline = Instant::now() + Duration::from_secs(3);
     while Instant::now() < deadline {
@@ -103,7 +115,10 @@ fn spawn_resume_in_new_terminal_uses_handterm_exec_mode() {
     assert!(launched);
 
     let lines = wait_for_lines(&output_path, 5);
-    assert_eq!(lines[0], cwd.to_string_lossy());
+    assert_eq!(
+        Path::new(&lines[0]).canonicalize().expect("canonical pwd"),
+        cwd.canonicalize().expect("canonical cwd")
+    );
     assert_eq!(lines[1], "--standalone");
     assert_eq!(lines[2], "--backend");
     assert_eq!(lines[3], "gpu");
@@ -111,6 +126,44 @@ fn spawn_resume_in_new_terminal_uses_handterm_exec_mode() {
     assert!(lines[5].contains("--resume"));
     assert!(lines[5].contains("ses_test_123"));
     assert!(lines[5].contains(exe.to_string_lossy().as_ref()));
+}
+
+#[cfg(unix)]
+#[test]
+fn spawn_resume_in_new_terminal_uses_tmux_new_window() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let output_path = temp.path().join("tmux-launch.txt");
+    write_fake_tmux(&temp, &output_path);
+    let path = format!(
+        "{}:{}",
+        temp.path().display(),
+        std::env::var("PATH").unwrap_or_default()
+    );
+    let _path_guard = EnvVarGuard::set_value("PATH", &path);
+    let _term_guard = EnvVarGuard::set_value("JCODE_TERMINAL", "tmux");
+
+    let exe = temp.path().join("jcode bin");
+    let cwd = temp.path().join("cwd");
+    fs::create_dir_all(&cwd).expect("create cwd");
+
+    let launched =
+        spawn_resume_in_new_terminal(&exe, "ses_tmux_123", &cwd).expect("spawn should work");
+    assert!(launched);
+
+    let lines = wait_for_lines(&output_path, 7);
+    assert_eq!(
+        Path::new(&lines[0]).canonicalize().expect("canonical pwd"),
+        cwd.canonicalize().expect("canonical cwd")
+    );
+    assert_eq!(lines[1], "new-window");
+    assert_eq!(lines[2], "-c");
+    assert_eq!(lines[3], cwd.to_string_lossy());
+    assert_eq!(lines[4], "-n");
+    assert_eq!(lines[5], resumed_window_title("ses_tmux_123"));
+    assert!(lines[6].contains("'--fresh-spawn'"));
+    assert!(lines[6].contains("'--resume'"));
+    assert!(lines[6].contains("'ses_tmux_123'"));
+    assert!(lines[6].contains("jcode bin"));
 }
 
 #[cfg(unix)]

--- a/src/tui/app/helpers.rs
+++ b/src/tui/app/helpers.rs
@@ -470,6 +470,16 @@ fn spawn_command_in_new_terminal(
                 );
                 cmd.args(["--standalone", "--backend", "gpu", "--exec", &command]);
             }
+            "tmux" => {
+                let command = shell_command(
+                    &std::iter::once(program.to_string_lossy().into_owned())
+                        .chain(args.iter().cloned())
+                        .collect::<Vec<_>>(),
+                );
+                cmd.args(["new-window", "-c"])
+                    .arg(cwd)
+                    .args(["-n", title, &command]);
+            }
             "kitty" => {
                 cmd.args(["--title", title, "-e"]).arg(program).args(args);
             }
@@ -604,6 +614,9 @@ fn detected_resume_terminal() -> Option<&'static str> {
         {
             return Some("handterm");
         }
+        if std::env::var("TMUX").is_ok() {
+            return Some("tmux");
+        }
         if std::env::var("KITTY_PID").is_ok() {
             return Some("kitty");
         }
@@ -661,7 +674,14 @@ fn resume_terminal_candidates_unix() -> Vec<String> {
 
     #[cfg(target_os = "macos")]
     {
-        for term in ["kitty", "wezterm", "alacritty", "iterm2", "terminal"] {
+        for term in [
+            "tmux",
+            "kitty",
+            "wezterm",
+            "alacritty",
+            "iterm2",
+            "terminal",
+        ] {
             push_unique_terminal(&mut candidates, term);
         }
     }
@@ -670,6 +690,7 @@ fn resume_terminal_candidates_unix() -> Vec<String> {
     {
         for term in [
             "handterm",
+            "tmux",
             "kitty",
             "wezterm",
             "alacritty",

--- a/src/tui/app/helpers.rs
+++ b/src/tui/app/helpers.rs
@@ -476,9 +476,10 @@ fn spawn_command_in_new_terminal(
                         .chain(args.iter().cloned())
                         .collect::<Vec<_>>(),
                 );
-                cmd.args(["new-window", "-c"])
+                cmd.args(["split-window", "-d", "-c"])
                     .arg(cwd)
-                    .args(["-n", title, &command]);
+                    .arg(&command)
+                    .args([";", "select-layout", "tiled"]);
             }
             "kitty" => {
                 cmd.args(["--title", title, "-e"]).arg(program).args(args);

--- a/src/tui/app/helpers_tests.rs
+++ b/src/tui/app/helpers_tests.rs
@@ -77,6 +77,28 @@ fn detected_resume_terminal_recognizes_handterm_term_program() {
 
 #[cfg(unix)]
 #[test]
+fn detected_resume_terminal_recognizes_tmux_session() {
+    let _guard = EnvVarGuard::set_value("TMUX", "/tmp/tmux-501/default,123,0");
+    assert_eq!(detected_resume_terminal(), Some("tmux"));
+}
+
+#[cfg(unix)]
+#[test]
+fn resume_terminal_candidates_include_tmux_once_when_requested() {
+    let _guard = EnvVarGuard::set_value("JCODE_TERMINAL", "tmux");
+    let candidates = super::resume_terminal_candidates_unix();
+    assert_eq!(candidates.first().map(String::as_str), Some("tmux"));
+    assert_eq!(
+        candidates
+            .iter()
+            .filter(|term| term.as_str() == "tmux")
+            .count(),
+        1
+    );
+}
+
+#[cfg(unix)]
+#[test]
 fn shell_command_quotes_single_quotes_for_handterm_exec() {
     let command = shell_command(&[
         "/tmp/jcode binary".to_string(),


### PR DESCRIPTION
## Summary
- Detect tmux as a supported terminal backend for spawning resumed/self-dev/swarm sessions.
- Spawn tmux sessions as split panes in the current window instead of opening new terminal windows.
- Keep focus on the current pane and reflow panes into a tiled grid with `select-layout tiled`.

## Validation
- `cargo test -p jcode tmux -- --nocapture`
- `selfdev build`
- Live tmux smoke test launching three swarm agents, confirming a 2x2 tiled pane grid and original pane focus retention.

<img width="2101" height="1139" alt="CleanShot 2026-04-29 at 10 56 45" src="https://github.com/user-attachments/assets/116434aa-534e-461e-ac75-719bdd39a437" />

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/1jehuang/codesmith/jcode/pr/78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->