### PR TITLE
feat(installer): add SHA256 checksum verification for release artifacts

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -7,6 +7,47 @@ IS_WINDOWS=false
 info() { printf '\033[1;34m%s\033[0m\n' "$*"; }
 err()  { printf '\033[1;31merror: %s\033[0m\n' "$*" >&2; exit 1; }
 
+verify_checksum() {
+  local file="$1"
+  local sums_file="$2"
+  local basename
+  basename="$(basename "$file")"
+
+  if [ "${JCODE_INSTALL_SKIP_VERIFY:-0}" = "1" ]; then
+    info "Skipping checksum verification (JCODE_INSTALL_SKIP_VERIFY=1)"
+    return 0
+  fi
+
+  if [ ! -f "$sums_file" ]; then
+    info "No checksum file available — skipping verification"
+    info "  To verify manually: sha256sum '$basename' and compare with the release page"
+    return 0
+  fi
+
+  local expected
+  expected="$(grep -F "$basename" "$sums_file" | head -1 | awk '{print $1}')"
+  if [ -z "$expected" ]; then
+    info "Checksum entry for '$basename' not found in SHA256SUMS — skipping verification"
+    return 0
+  fi
+
+  local actual
+  if command -v sha256sum >/dev/null 2>&1; then
+    actual="$(sha256sum "$file" | awk '{print $1}')"
+  elif command -v shasum >/dev/null 2>&1; then
+    actual="$(shasum -a 256 "$file" | awk '{print $1}')"
+  else
+    info "Neither sha256sum nor shasum found — skipping checksum verification"
+    return 0
+  fi
+
+  if [ "$actual" != "$expected" ]; then
+    err "Checksum mismatch for '$basename'!\n  Expected: $expected\n  Actual:   $actual\n  This could indicate a corrupted or tampered download."
+  fi
+
+  info "Checksum verified ✓"
+}
+
 OS="$(uname -s)"
 ARCH="$(uname -m)"
 
@@ -48,6 +89,7 @@ VERSION=$(curl -fsSL "https://api.github.com/repos/$REPO/releases/latest" | grep
 
 URL_TGZ="https://github.com/$REPO/releases/download/$VERSION/$ARTIFACT.tar.gz"
 URL_BIN="https://github.com/$REPO/releases/download/$VERSION/$ARTIFACT"
+URL_SUMS="https://github.com/$REPO/releases/download/$VERSION/SHA256SUMS"
 
 if [ "$IS_WINDOWS" = true ]; then
   EXE=".exe"
@@ -85,6 +127,16 @@ if curl -fsSL "$URL_TGZ" -o "$tmpdir/jcode.download" 2>/dev/null; then
   download_mode="tar"
 elif curl -fsSL "$URL_BIN" -o "$tmpdir/jcode.download" 2>/dev/null; then
   download_mode="bin"
+fi
+
+# Download and verify checksums
+SUMS_FILE="$tmpdir/SHA256SUMS"
+curl -fsSL "$URL_SUMS" -o "$SUMS_FILE" 2>/dev/null || true
+
+if [ "$download_mode" = "tar" ]; then
+  verify_checksum "$tmpdir/jcode.download" "$SUMS_FILE"
+elif [ "$download_mode" = "bin" ]; then
+  verify_checksum "$tmpdir/jcode.download" "$SUMS_FILE"
 fi
 
 mkdir -p "$INSTALL_DIR" "$stable_dir" "$current_dir" "$version_dir"


### PR DESCRIPTION
## Summary

Adds SHA256 checksum verification to the install script, addressing #63.

### Changes

- **`verify_checksum()` function**: Validates downloaded artifacts against a `SHA256SUMS` file from the release
- **Downloads `SHA256SUMS`** alongside release binaries (gracefully skips if unavailable)
- **Cross-platform**: supports `sha256sum` (Linux) and `shasum` (macOS)
- **Graceful fallback**: skips verification if SHA256SUMS not available, no checksum tool found, or entry missing for the artifact
- **Opt-out**: `JCODE_INSTALL_SKIP_VERIFY=1` to skip verification
- **Hard fail on mismatch**: aborts installation if checksum doesn't match (potential tampering)

### How it works

1. After downloading the release artifact, the installer fetches `SHA256SUMS` from the same release
2. Computes the SHA256 hash of the downloaded file
3. Compares against the expected hash in SHA256SUMS
4. Aborts with a clear error on mismatch

### For the maintainer

To enable verification for future releases, publish a `SHA256SUMS` file alongside release binaries:

```bash
cd release-artifacts/
sha256sum jcode-* > SHA256SUMS
# Upload SHA256SUMS alongside the binaries in the GitHub release
```

The installer is backward-compatible: if no SHA256SUMS file exists for a release, it prints a message and continues normally.

### Test plan

- [x] Shell syntax check passes (`bash -n scripts/install.sh`)
- [ ] Tested with a mock SHA256SUMS file containing correct checksums
- [ ] Tested with a mock SHA256SUMS file containing wrong checksums (should abort)
- [ ] Tested without SHA256SUMS file (should skip gracefully)
- [ ] Tested with `JCODE_INSTALL_SKIP_VERIFY=1` (should skip)

Relates to #63

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/1jehuang/codesmith/jcode/pr/84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->