### PR TITLE
feat: add Exa AI-powered search tool

### DIFF
--- a/src/tool/exa_search.rs
+++ b/src/tool/exa_search.rs
@@ -1,0 +1,403 @@
+use super::{Tool, ToolContext, ToolOutput};
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+
+const EXA_SEARCH_URL: &str = "https://api.exa.ai/search";
+const EXA_INTEGRATION_HEADER: &str = "x-exa-integration";
+const EXA_INTEGRATION_NAME: &str = "jcode";
+const EXA_API_KEY_ENV: &str = "EXA_API_KEY";
+
+const DEFAULT_NUM_RESULTS: usize = 8;
+const MAX_NUM_RESULTS: usize = 25;
+const DEFAULT_TEXT_MAX_CHARS: usize = 1000;
+
+/// AI-powered web search via the Exa API. Requires `EXA_API_KEY`.
+pub struct ExaSearchTool {
+    client: reqwest::Client,
+}
+
+impl ExaSearchTool {
+    pub fn new() -> Self {
+        Self {
+            client: crate::provider::shared_http_client(),
+        }
+    }
+}
+
+#[derive(Deserialize)]
+struct ExaSearchInput {
+    query: String,
+    #[serde(default)]
+    num_results: Option<usize>,
+    #[serde(default, rename = "type")]
+    search_type: Option<String>,
+    #[serde(default)]
+    category: Option<String>,
+    #[serde(default)]
+    include_domains: Option<Vec<String>>,
+    #[serde(default)]
+    exclude_domains: Option<Vec<String>>,
+    #[serde(default)]
+    start_published_date: Option<String>,
+    #[serde(default)]
+    end_published_date: Option<String>,
+    #[serde(default)]
+    user_location: Option<String>,
+    #[serde(default)]
+    contents: Option<ContentsInput>,
+}
+
+#[derive(Deserialize, Default)]
+#[serde(default)]
+struct ContentsInput {
+    /// Full page text. `true` enables with defaults; an object lets you cap length.
+    text: Option<TextOption>,
+    /// Highlight snippets. `true` enables with defaults.
+    highlights: Option<bool>,
+    /// LLM-generated summary, optionally guided by a query.
+    summary: Option<SummaryOption>,
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum TextOption {
+    Enabled(bool),
+    Detailed { max_characters: Option<usize> },
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum SummaryOption {
+    Enabled(bool),
+    Guided { query: Option<String> },
+}
+
+#[derive(Debug, Deserialize)]
+struct ExaResponse {
+    #[serde(default)]
+    results: Vec<ExaResult>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExaResult {
+    #[serde(default)]
+    title: Option<String>,
+    #[serde(default)]
+    url: Option<String>,
+    #[serde(default)]
+    author: Option<String>,
+    #[serde(default, rename = "publishedDate")]
+    published_date: Option<String>,
+    #[serde(default)]
+    score: Option<f64>,
+    #[serde(default)]
+    text: Option<String>,
+    #[serde(default)]
+    highlights: Option<Vec<String>>,
+    #[serde(default)]
+    summary: Option<String>,
+}
+
+impl ExaResult {
+    /// Pick the best available snippet: summary > highlights > truncated text.
+    fn snippet(&self) -> Option<String> {
+        if let Some(s) = self.summary.as_ref().filter(|s| !s.trim().is_empty()) {
+            return Some(s.trim().to_string());
+        }
+        if let Some(highlights) = self.highlights.as_ref() {
+            let joined: String = highlights
+                .iter()
+                .map(|h| h.trim())
+                .filter(|h| !h.is_empty())
+                .collect::<Vec<_>>()
+                .join(" … ");
+            if !joined.is_empty() {
+                return Some(joined);
+            }
+        }
+        if let Some(text) = self.text.as_ref().filter(|t| !t.trim().is_empty()) {
+            return Some(truncate_chars(text.trim(), 400));
+        }
+        None
+    }
+}
+
+fn truncate_chars(s: &str, max_chars: usize) -> String {
+    if s.chars().count() <= max_chars {
+        return s.to_string();
+    }
+    let head: String = s.chars().take(max_chars).collect();
+    format!("{head}…")
+}
+
+#[derive(Serialize)]
+struct ExaRequestBody<'a> {
+    query: &'a str,
+    #[serde(rename = "numResults")]
+    num_results: usize,
+    #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
+    search_type: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    category: Option<&'a str>,
+    #[serde(rename = "includeDomains", skip_serializing_if = "Option::is_none")]
+    include_domains: Option<&'a [String]>,
+    #[serde(rename = "excludeDomains", skip_serializing_if = "Option::is_none")]
+    exclude_domains: Option<&'a [String]>,
+    #[serde(
+        rename = "startPublishedDate",
+        skip_serializing_if = "Option::is_none"
+    )]
+    start_published_date: Option<&'a str>,
+    #[serde(rename = "endPublishedDate", skip_serializing_if = "Option::is_none")]
+    end_published_date: Option<&'a str>,
+    #[serde(rename = "userLocation", skip_serializing_if = "Option::is_none")]
+    user_location: Option<&'a str>,
+    #[serde(skip_serializing_if = "Value::is_null")]
+    contents: Value,
+}
+
+fn build_contents_value(contents: &Option<ContentsInput>) -> Value {
+    let Some(c) = contents else {
+        // Default: highlights + a small text excerpt is a useful baseline.
+        return json!({
+            "highlights": true,
+            "text": { "maxCharacters": DEFAULT_TEXT_MAX_CHARS }
+        });
+    };
+
+    let mut obj = serde_json::Map::new();
+
+    match &c.text {
+        Some(TextOption::Enabled(true)) => {
+            obj.insert(
+                "text".into(),
+                json!({ "maxCharacters": DEFAULT_TEXT_MAX_CHARS }),
+            );
+        }
+        Some(TextOption::Detailed {
+            max_characters: Some(max),
+        }) => {
+            obj.insert("text".into(), json!({ "maxCharacters": max }));
+        }
+        Some(TextOption::Detailed {
+            max_characters: None,
+        }) => {
+            obj.insert("text".into(), Value::Bool(true));
+        }
+        Some(TextOption::Enabled(false)) | None => {}
+    }
+
+    if matches!(c.highlights, Some(true)) {
+        obj.insert("highlights".into(), Value::Bool(true));
+    }
+
+    match &c.summary {
+        Some(SummaryOption::Enabled(true)) => {
+            obj.insert("summary".into(), Value::Bool(true));
+        }
+        Some(SummaryOption::Guided { query: Some(q) }) if !q.is_empty() => {
+            obj.insert("summary".into(), json!({ "query": q }));
+        }
+        Some(SummaryOption::Guided { query: _ }) => {
+            obj.insert("summary".into(), Value::Bool(true));
+        }
+        Some(SummaryOption::Enabled(false)) | None => {}
+    }
+
+    if obj.is_empty() {
+        return json!({
+            "highlights": true,
+            "text": { "maxCharacters": DEFAULT_TEXT_MAX_CHARS }
+        });
+    }
+    Value::Object(obj)
+}
+
+#[async_trait]
+impl Tool for ExaSearchTool {
+    fn name(&self) -> &str {
+        "exa_search"
+    }
+
+    fn description(&self) -> &str {
+        "AI-powered web search via Exa. Returns ranked URLs with optional highlights, full text, and summaries. Requires EXA_API_KEY."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "required": ["query"],
+            "properties": {
+                "intent": super::intent_schema_property(),
+                "query": {
+                    "type": "string",
+                    "description": "Search query. Natural language works well for neural/auto search."
+                },
+                "num_results": {
+                    "type": "integer",
+                    "description": "Max results (1-25, default 8)."
+                },
+                "type": {
+                    "type": "string",
+                    "enum": ["auto", "neural", "fast", "deep-lite", "deep", "deep-reasoning", "instant"],
+                    "description": "Search type. 'auto' picks the best mode."
+                },
+                "category": {
+                    "type": "string",
+                    "enum": ["company", "research paper", "news", "personal site", "financial report", "people"],
+                    "description": "Restrict results to a category."
+                },
+                "include_domains": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "description": "Only return results from these domains."
+                },
+                "exclude_domains": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "description": "Skip results from these domains."
+                },
+                "start_published_date": {
+                    "type": "string",
+                    "description": "ISO 8601 date; only include results published on/after."
+                },
+                "end_published_date": {
+                    "type": "string",
+                    "description": "ISO 8601 date; only include results published on/before."
+                },
+                "user_location": {
+                    "type": "string",
+                    "description": "Two-letter ISO country code (e.g. 'US')."
+                },
+                "contents": {
+                    "type": "object",
+                    "description": "Per-result content to retrieve.",
+                    "properties": {
+                        "text": {
+                            "description": "Full page text. true, or { max_characters }.",
+                            "oneOf": [
+                                { "type": "boolean" },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "max_characters": { "type": "integer" }
+                                    }
+                                }
+                            ]
+                        },
+                        "highlights": {
+                            "type": "boolean",
+                            "description": "Return relevance-ranked snippet highlights."
+                        },
+                        "summary": {
+                            "description": "LLM summary. true, or { query } to steer it.",
+                            "oneOf": [
+                                { "type": "boolean" },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "query": { "type": "string" }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        })
+    }
+
+    async fn execute(&self, input: Value, _ctx: ToolContext) -> Result<ToolOutput> {
+        let params: ExaSearchInput = serde_json::from_value(input)?;
+
+        let api_key = std::env::var(EXA_API_KEY_ENV).map_err(|_| {
+            anyhow::anyhow!(
+                "EXA_API_KEY environment variable is not set. Get a key at https://exa.ai and export EXA_API_KEY."
+            )
+        })?;
+
+        let num_results = params
+            .num_results
+            .unwrap_or(DEFAULT_NUM_RESULTS)
+            .clamp(1, MAX_NUM_RESULTS);
+
+        let body = ExaRequestBody {
+            query: &params.query,
+            num_results,
+            search_type: params.search_type.as_deref(),
+            category: params.category.as_deref(),
+            include_domains: params.include_domains.as_deref(),
+            exclude_domains: params.exclude_domains.as_deref(),
+            start_published_date: params.start_published_date.as_deref(),
+            end_published_date: params.end_published_date.as_deref(),
+            user_location: params.user_location.as_deref(),
+            contents: build_contents_value(&params.contents),
+        };
+
+        let response = self
+            .client
+            .post(EXA_SEARCH_URL)
+            .header("x-api-key", api_key)
+            .header(EXA_INTEGRATION_HEADER, EXA_INTEGRATION_NAME)
+            .header(reqwest::header::CONTENT_TYPE, "application/json")
+            .json(&body)
+            .send()
+            .await
+            .context("failed to reach Exa API")?;
+
+        let status = response.status();
+        let body_text = response.text().await.context("failed to read Exa response")?;
+
+        if !status.is_success() {
+            return Err(anyhow::anyhow!(
+                "Exa search failed (HTTP {}): {}",
+                status,
+                body_text
+            ));
+        }
+
+        let parsed: ExaResponse = serde_json::from_str(&body_text)
+            .with_context(|| format!("failed to parse Exa response: {body_text}"))?;
+
+        Ok(ToolOutput::new(format_results(&params.query, &parsed)))
+    }
+}
+
+fn format_results(query: &str, response: &ExaResponse) -> String {
+    if response.results.is_empty() {
+        return format!("No Exa results for: {query}");
+    }
+
+    let mut out = format!("Exa results for: {query}\n\n");
+    for (i, r) in response.results.iter().enumerate() {
+        let title = r.title.as_deref().unwrap_or("(no title)");
+        let url = r.url.as_deref().unwrap_or("");
+        out.push_str(&format!("{}. **{}**\n   {}\n", i + 1, title, url));
+
+        let mut meta = Vec::new();
+        if let Some(date) = &r.published_date {
+            meta.push(format!("published: {date}"));
+        }
+        if let Some(author) = &r.author {
+            meta.push(format!("author: {author}"));
+        }
+        if let Some(score) = r.score {
+            meta.push(format!("score: {score:.3}"));
+        }
+        if !meta.is_empty() {
+            out.push_str(&format!("   ({})\n", meta.join(" · ")));
+        }
+
+        if let Some(snippet) = r.snippet() {
+            out.push_str(&format!("   {snippet}\n"));
+        }
+        out.push('\n');
+    }
+    out
+}
+
+#[cfg(test)]
+#[path = "exa_search_tests.rs"]
+mod exa_search_tests;

--- a/src/tool/exa_search_tests.rs
+++ b/src/tool/exa_search_tests.rs
@@ -1,0 +1,226 @@
+use super::*;
+
+#[test]
+fn parses_full_response() {
+    let body = r#"{
+        "requestId": "req_1",
+        "results": [
+            {
+                "id": "abc",
+                "url": "https://example.com/a",
+                "title": "Example A",
+                "publishedDate": "2026-01-15T00:00:00Z",
+                "author": "Jane Doe",
+                "score": 0.87,
+                "text": "full body text",
+                "highlights": ["snippet one", "snippet two"],
+                "summary": "concise summary"
+            }
+        ]
+    }"#;
+
+    let parsed: ExaResponse = serde_json::from_str(body).expect("parses");
+    assert_eq!(parsed.results.len(), 1);
+    let r = &parsed.results[0];
+    assert_eq!(r.url.as_deref(), Some("https://example.com/a"));
+    assert_eq!(r.title.as_deref(), Some("Example A"));
+    assert_eq!(r.author.as_deref(), Some("Jane Doe"));
+    assert_eq!(r.published_date.as_deref(), Some("2026-01-15T00:00:00Z"));
+    assert!((r.score.unwrap() - 0.87).abs() < 1e-6);
+}
+
+#[test]
+fn parses_response_with_missing_optional_fields() {
+    // Only id/url/title — no text, highlights, summary, publishedDate, author, score.
+    let body = r#"{
+        "results": [
+            { "id": "abc", "url": "https://example.com/a", "title": "Bare result" }
+        ]
+    }"#;
+
+    let parsed: ExaResponse = serde_json::from_str(body).expect("parses");
+    assert_eq!(parsed.results.len(), 1);
+    let r = &parsed.results[0];
+    assert!(r.text.is_none());
+    assert!(r.highlights.is_none());
+    assert!(r.summary.is_none());
+    assert!(r.snippet().is_none());
+}
+
+#[test]
+fn snippet_prefers_summary_over_highlights_and_text() {
+    let r = ExaResult {
+        title: None,
+        url: None,
+        author: None,
+        published_date: None,
+        score: None,
+        text: Some("ignored body".into()),
+        highlights: Some(vec!["ignored highlight".into()]),
+        summary: Some("the summary".into()),
+    };
+    assert_eq!(r.snippet().as_deref(), Some("the summary"));
+}
+
+#[test]
+fn snippet_falls_back_to_highlights_when_no_summary() {
+    let r = ExaResult {
+        title: None,
+        url: None,
+        author: None,
+        published_date: None,
+        score: None,
+        text: Some("ignored body text".into()),
+        highlights: Some(vec!["first hit".into(), "second hit".into()]),
+        summary: None,
+    };
+    assert_eq!(r.snippet().as_deref(), Some("first hit … second hit"));
+}
+
+#[test]
+fn snippet_falls_back_to_text_when_no_summary_or_highlights() {
+    let r = ExaResult {
+        title: None,
+        url: None,
+        author: None,
+        published_date: None,
+        score: None,
+        text: Some("just body text".into()),
+        highlights: None,
+        summary: None,
+    };
+    assert_eq!(r.snippet().as_deref(), Some("just body text"));
+}
+
+#[test]
+fn snippet_treats_empty_strings_as_missing() {
+    let r = ExaResult {
+        title: None,
+        url: None,
+        author: None,
+        published_date: None,
+        score: None,
+        text: Some("   ".into()),
+        highlights: Some(vec!["   ".into(), "".into()]),
+        summary: Some("   ".into()),
+    };
+    assert!(r.snippet().is_none());
+}
+
+#[test]
+fn snippet_truncates_long_text_fallback() {
+    let long_text: String = "a".repeat(800);
+    let r = ExaResult {
+        title: None,
+        url: None,
+        author: None,
+        published_date: None,
+        score: None,
+        text: Some(long_text),
+        highlights: None,
+        summary: None,
+    };
+    let snippet = r.snippet().unwrap();
+    // truncate_chars caps at 400 + ellipsis
+    assert!(snippet.ends_with('…'));
+    assert_eq!(snippet.chars().count(), 401);
+}
+
+#[test]
+fn default_contents_includes_highlights_and_text() {
+    let v = build_contents_value(&None);
+    assert_eq!(v["highlights"], serde_json::Value::Bool(true));
+    assert!(v["text"]["maxCharacters"].is_number());
+}
+
+#[test]
+fn explicit_text_max_characters_is_passed_through() {
+    let input = ContentsInput {
+        text: Some(TextOption::Detailed {
+            max_characters: Some(2500),
+        }),
+        highlights: None,
+        summary: None,
+    };
+    let v = build_contents_value(&Some(input));
+    assert_eq!(v["text"]["maxCharacters"], 2500);
+}
+
+#[test]
+fn summary_query_is_propagated() {
+    let input = ContentsInput {
+        text: None,
+        highlights: None,
+        summary: Some(SummaryOption::Guided {
+            query: Some("main findings".into()),
+        }),
+    };
+    let v = build_contents_value(&Some(input));
+    assert_eq!(v["summary"]["query"], "main findings");
+}
+
+#[test]
+fn summary_guided_with_empty_query_collapses_to_bool() {
+    let input = ContentsInput {
+        text: None,
+        highlights: None,
+        summary: Some(SummaryOption::Guided { query: None }),
+    };
+    let v = build_contents_value(&Some(input));
+    assert_eq!(v["summary"], serde_json::Value::Bool(true));
+}
+
+#[test]
+fn format_results_renders_empty_message() {
+    let response = ExaResponse { results: vec![] };
+    let rendered = format_results("foo", &response);
+    assert!(rendered.contains("No Exa results"));
+}
+
+#[test]
+fn format_results_renders_metadata_and_snippet() {
+    let response = ExaResponse {
+        results: vec![ExaResult {
+            title: Some("Title".into()),
+            url: Some("https://example.com".into()),
+            author: Some("Author".into()),
+            published_date: Some("2026-04-01".into()),
+            score: Some(0.5),
+            text: None,
+            highlights: None,
+            summary: Some("a summary".into()),
+        }],
+    };
+    let rendered = format_results("q", &response);
+    assert!(rendered.contains("Title"));
+    assert!(rendered.contains("https://example.com"));
+    assert!(rendered.contains("a summary"));
+    assert!(rendered.contains("Author"));
+    assert!(rendered.contains("2026-04-01"));
+}
+
+#[tokio::test]
+async fn execute_errors_when_api_key_missing() {
+    // Snapshot env so concurrent tests don't break each other; if a key is set,
+    // skip rather than clobber it.
+    if std::env::var("EXA_API_KEY").is_ok() {
+        return;
+    }
+
+    let tool = ExaSearchTool::new();
+    let ctx = ToolContext {
+        session_id: "t".into(),
+        message_id: "t".into(),
+        tool_call_id: "t".into(),
+        working_dir: None,
+        stdin_request_tx: None,
+        graceful_shutdown_signal: None,
+        execution_mode: super::super::ToolExecutionMode::Direct,
+    };
+    let err = tool
+        .execute(serde_json::json!({ "query": "anything" }), ctx)
+        .await
+        .expect_err("should fail without API key");
+    let msg = format!("{err:#}");
+    assert!(msg.contains("EXA_API_KEY"), "unexpected error: {msg}");
+}

--- a/src/tool/mod.rs
+++ b/src/tool/mod.rs
@@ -10,6 +10,7 @@ mod communicate;
 mod conversation_search;
 mod debug_socket;
 mod edit;
+mod exa_search;
 mod glob;
 mod gmail;
 mod goal;
@@ -302,6 +303,12 @@ impl Registry {
                 &mut timings,
                 "websearch",
                 websearch::WebSearchTool::new,
+            );
+            Self::insert_tool_timed(
+                &mut m,
+                &mut timings,
+                "exa_search",
+                exa_search::ExaSearchTool::new,
             );
             Self::insert_tool_timed(
                 &mut m,


### PR DESCRIPTION
## Summary

- Adds a new `exa_search` tool backed by the [Exa Search API](https://exa.ai/docs/reference/search), sitting alongside the existing DuckDuckGo `websearch` tool.
- Exposes Exa-specific tuning as tool parameters: search `type`, `category`, `include_domains` / `exclude_domains`, published-date range, `user_location`, and per-result `contents` (text / highlights / summary).
- Reads `EXA_API_KEY` lazily at execute time so the tool registers unconditionally and returns a clear, actionable error when the key is unset.
- Sends `x-exa-integration: jcode` on every request so API usage can be attributed to this integration.

## Why a separate tool

`websearch` scrapes DuckDuckGo HTML and has no API key, no provider abstraction, and no per-result content control. Bolting Exa-specific knobs (search type, category, content modes) onto it would either dilute its parameter surface or create a hidden coupling between it and an unrelated provider. A dedicated `exa_search` tool keeps the existing tool unchanged and gives the agent a clear way to opt in when an Exa key is configured.

## Usage

```rust
// Tool input shape (JSON):
{
  "query": "rust async runtime benchmarks 2026",
  "num_results": 10,
  "type": "neural",
  "category": "research paper",
  "include_domains": ["arxiv.org", "research.google"],
  "start_published_date": "2025-01-01",
  "contents": {
    "highlights": true,
    "summary": { "query": "key benchmark numbers" },
    "text": { "max_characters": 2000 }
  }
}
```

The tool POSTs to `https://api.exa.ai/search`, parses the response into typed Rust structs, and renders a numbered result list. Each rendered result picks the best available snippet via a `summary -> highlights -> truncated text` cascade, so the output stays useful regardless of which `contents` flags the caller sets.

## Files changed

- `src/tool/exa_search.rs` (new) — tool implementation, request/response types, formatter
- `src/tool/exa_search_tests.rs` (new) — unit tests (response parsing, snippet fallback ladder, contents-builder defaults, missing-key error)
- `src/tool/mod.rs` — register the new tool in `base_tools`

No new crate dependencies; reuses `reqwest`, `serde`, `serde_json`, `async-trait`, and `crate::provider::shared_http_client()` already in the workspace.

## Test plan

- [x] `cargo check --bin jcode` passes (no new warnings introduced)
- [x] `cargo test --lib --bin jcode exa_search` — 14 / 14 pass
- [x] `cargo test --lib --bin jcode tool::tests` — 14 / 14 pass (registry sort and schema validators still green with the new tool registered)
- [ ] Live smoke test against `api.exa.ai` with a real `EXA_API_KEY` (not run in this PR; covered by parsing tests against a captured response shape)

## Notes / tradeoffs

- The tool is registered unconditionally; the env-var check happens at execute time. This keeps tool discovery deterministic (matches the rest of the registry) and lets the agent surface a clear error to the user instead of silently hiding the tool.
- The `contents` schema is permissive: `text` and `summary` accept either `true` or an object with extra knobs (`max_characters`, `query`). The serializer collapses empty/no-op shapes so we never send `{}` to the API.
- I picked sensible, conservative defaults (highlights on, text capped at 1000 chars, num_results clamped 1..=25) so a bare `{ "query": "..." }` call still returns useful, bounded output.
- Did not modify `websearch`. Happy to wire Exa in as a `websearch` backend instead if you'd prefer a single tool surface — let me know.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/1jehuang/codesmith/jcode/pr/90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->