### PR TITLE
Fix opencode setup docs links

### DIFF
--- a/crates/jcode-provider-metadata/src/lib.rs
+++ b/crates/jcode-provider-metadata/src/lib.rs
@@ -142,7 +142,7 @@ pub const OPENCODE_PROFILE: OpenAiCompatibleProfile = OpenAiCompatibleProfile {
     api_base: "https://opencode.ai/zen/v1",
     api_key_env: "OPENCODE_API_KEY",
     env_file: "opencode.env",
-    setup_url: "https://opencode.ai/docs/providers#opencode-zen",
+    setup_url: "https://github.com/1jehuang/jcode#openai-compatible-providers",
     default_model: Some("qwen/qwen3-coder-plus"),
     requires_api_key: true,
 };
@@ -153,8 +153,8 @@ pub const OPENCODE_GO_PROFILE: OpenAiCompatibleProfile = OpenAiCompatibleProfile
     api_base: "https://opencode.ai/zen/go/v1",
     api_key_env: "OPENCODE_GO_API_KEY",
     env_file: "opencode-go.env",
-    setup_url: "https://opencode.ai/docs/providers#opencode-go",
-    default_model: Some("THUDM/GLM-4.5"),
+    setup_url: "https://github.com/1jehuang/jcode#openai-compatible-providers",
+    default_model: Some("THUDM/GLM-4.9"),
     requires_api_key: true,
 };
 

--- a/src/provider_catalog_tests.rs
+++ b/src/provider_catalog_tests.rs
@@ -91,6 +91,15 @@ fn auth_issue_profile_metadata_matches_direct_provider_endpoints() {
     assert_eq!(DEEPSEEK_PROFILE.api_base, "https://api.deepseek.com");
     assert_eq!(DEEPSEEK_PROFILE.default_model, Some("deepseek-v4-flash"));
     assert_eq!(DEEPSEEK_PROFILE.setup_url, "https://api-docs.deepseek.com/");
+    assert_eq!(
+        OPENCODE_PROFILE.setup_url,
+        "https://github.com/1jehuang/jcode#openai-compatible-providers"
+    );
+    assert_eq!(
+        OPENCODE_GO_PROFILE.setup_url,
+        "https://github.com/1jehuang/jcode#openai-compatible-providers"
+    );
+    assert_eq!(OPENCODE_GO_PROFILE.default_model, Some("THUDM/GLM-4.9"));
     assert!(!OPENAI_COMPAT_PROFILE.setup_url.contains("opencode.ai"));
 }
 


### PR DESCRIPTION
## Summary
- point OpenCode Zen and OpenCode Go setup URLs at the jcode OpenAI-compatible provider docs
- update the OpenCode Go default model to THUDM/GLM-4.9
- add regression coverage for these provider metadata values

Fixes #89.

## Tests
- cargo test -p jcode-provider-metadata
- cargo test auth_issue_profile_metadata_matches_direct_provider_endpoints

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/1jehuang/codesmith/jcode/pr/91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->