### PR TITLE
Add DeepSeek context fallback

### DIFF
--- a/src/provider/models.rs
+++ b/src/provider/models.rs
@@ -376,6 +376,10 @@ fn fallback_context_limit_for_model(model: &str, provider_hint: Option<&str>) ->
         return Some(limit);
     }
 
+    if model.starts_with("deepseek") {
+        return Some(1_000_000);
+    }
+
     if model.starts_with("gemini-2.0-flash")
         || model.starts_with("gemini-2.5")
         || model.starts_with("gemini-3")

--- a/src/provider/tests/model_resolution.rs
+++ b/src/provider/tests/model_resolution.rs
@@ -344,6 +344,15 @@ fn test_context_limit_gpt_5_4() {
 }
 
 #[test]
+fn test_context_limit_deepseek() {
+    assert_eq!(
+        context_limit_for_model("deepseek-v4-flash"),
+        Some(1_000_000)
+    );
+    assert_eq!(context_limit_for_model("deepseek-chat"), Some(1_000_000));
+}
+
+#[test]
 fn test_context_limit_respects_provider_hint() {
     assert_eq!(
         context_limit_for_model_with_provider("gpt-5.4", Some("openai")),


### PR DESCRIPTION
## Summary
- add a hardcoded 1M token fallback for DeepSeek model IDs
- cover deepseek-v4-flash and deepseek-chat in context limit tests

Fixes #87.

## Tests
- cargo test test_context_limit_deepseek

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/1jehuang/codesmith/jcode/pr/92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->