### PR TITLE
fix: add DeepSeek 1M context limit + fix opencode setup_url

### DIFF
--- a/crates/jcode-provider-metadata/src/lib.rs
+++ b/crates/jcode-provider-metadata/src/lib.rs
@@ -142,7 +142,7 @@ pub const OPENCODE_PROFILE: OpenAiCompatibleProfile = OpenAiCompatibleProfile {
     api_base: "https://opencode.ai/zen/v1",
     api_key_env: "OPENCODE_API_KEY",
     env_file: "opencode.env",
-    setup_url: "https://opencode.ai/docs/providers#opencode-zen",
+    setup_url: "https://github.com/1jehuang/jcode#installation",
     default_model: Some("qwen/qwen3-coder-plus"),
     requires_api_key: true,
 };
@@ -153,7 +153,7 @@ pub const OPENCODE_GO_PROFILE: OpenAiCompatibleProfile = OpenAiCompatibleProfile
     api_base: "https://opencode.ai/zen/go/v1",
     api_key_env: "OPENCODE_GO_API_KEY",
     env_file: "opencode-go.env",
-    setup_url: "https://opencode.ai/docs/providers#opencode-go",
+    setup_url: "https://github.com/1jehuang/jcode#installation",
     default_model: Some("THUDM/GLM-4.5"),
     requires_api_key: true,
 };

--- a/src/provider/models.rs
+++ b/src/provider/models.rs
@@ -383,6 +383,10 @@ fn fallback_context_limit_for_model(model: &str, provider_hint: Option<&str>) ->
         return Some(1_000_000);
     }
 
+    if model.starts_with("deepseek") {
+        return Some(1_000_000);
+    }
+
     None
 }
 


### PR DESCRIPTION
## Summary

Two small fixes:

### 1. Add DeepSeek to context limit fallback (fixes #87)
DeepSeek V4 models support a 1M token context window, but `fallback_context_limit_for_model()` had no entry for them. Direct DeepSeek API users were capped at the 200k default instead of getting the full 1M context.

### 2. Fix opencode-zen / opencode-go setup_url (fixes #89)
The `setup_url` for these profiles pointed to `opencode.ai/docs/providers`, which was confusing for jcode users who saw opencode documentation links in jcode's UI. Changed to point to the jcode installation docs.

### Changes
- `src/provider/models.rs`: +4 lines for deepseek 1M context
- `crates/jcode-provider-metadata/src/lib.rs`: 2 lines, updated setup_url strings

## Test plan
- [ ] DeepSeek models now resolve to 1,000,000 context limit instead of 200,000
- [ ] opencode-zen and opencode-go setup_url no longer contains `opencode.ai`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/1jehuang/codesmith/jcode/pr/102"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->