### PR TITLE
fix: remove stale reasoning_effort field access on Session

### DIFF
--- a/src/overnight.rs
+++ b/src/overnight.rs
@@ -381,7 +381,6 @@ fn create_coordinator_session(parent: &Session, mission: &Option<String>) -> Res
     child.replace_messages(parent.messages.clone());
     child.compaction = parent.compaction.clone();
     child.provider_key = parent.provider_key.clone();
-    child.reasoning_effort = parent.reasoning_effort.clone();
     child.subagent_model = parent.subagent_model.clone();
     child.improve_mode = parent.improve_mode;
     child.autoreview_enabled = Some(false);


### PR DESCRIPTION
## Summary

Fix a compile error on master caused by a stale field access.

`reasoning_effort` was refactored from `Session` to the provider layer, but `overnight.rs:384` was still trying to copy it from a parent session. This causes:

```
error[E0609]: no field `reasoning_effort` on type `session::Session`
   --> src/overnight.rs:384:11
    |
384 |     child.reasoning_effort = parent.reasoning_effort.clone();
    |           ^^^^^^^^^^^^^^^^ unknown field
```

The child session already inherits `reasoning_effort` from the provider associated with `provider_key`, which is copied on the preceding line. The field assignment is unnecessary and was missed during refactoring.

## Changes

- `src/overnight.rs`: delete 1 line

## Test plan

- [ ] `cargo check` passes (was failing on master before this fix)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/1jehuang/codesmith/jcode/pr/103"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->