### PR TITLE
Fix invisible mermaid labels on Linux (font fallback)

### DIFF
--- a/crates/jcode-tui-mermaid/src/mermaid_content.rs
+++ b/crates/jcode-tui-mermaid/src/mermaid_content.rs
@@ -217,7 +217,7 @@ pub fn terminal_theme() -> Theme {
         // Uses transparent canvas so the rendered PNG integrates with the TUI,
         // while keeping nodes/labels readable against dark panes.
         background: "#00000000".to_string(),
-        font_family: "Inter, ui-sans-serif, system-ui, -apple-system, Segoe UI, sans-serif"
+        font_family: "Inter, ui-sans-serif, system-ui, -apple-system, Segoe UI, \"DejaVu Sans\", \"Liberation Sans\", sans-serif"
             .to_string(),
         font_size: 15.0,
         primary_color: "#313244".to_string(),


### PR DESCRIPTION
# PR Body Draft

## Summary

On Linux, mermaid diagrams rendered by jcode show only the box outlines and arrows — node labels are invisible. This PR adds Linux-native font fallbacks (`DejaVu Sans`, `Liberation Sans`) to `terminal_theme()` so the bundled `resvg`/`usvg` renderer can resolve a real font face for SVG `<text>` elements.

## Reproduction (before fix)

```mermaid
graph LR
    A[Start] --> B[Middle] --> C[End]
```

On Arch Linux + kitty + tmux + jcode v0.11.9, the rendered diagram pinned in the side panel shows three box outlines connected by arrows but **no text inside the boxes**.

Verified on:
- `jcode v0.11.9` (release build) and `v0.11.6-dev` (built from `f071bc2a`)
- `resvg 0.46`, `usvg 0.46`
- Linux fonts present: `DejaVu Sans`, `Liberation Sans`, `Noto Sans CJK KR`, `Noto Color Emoji`, etc.

## Root cause

`crates/jcode-tui-mermaid/src/mermaid_content.rs::terminal_theme()` declares the SVG `font-family` as:

```
Inter, ui-sans-serif, system-ui, -apple-system, Segoe UI, sans-serif
```

`mermaid-rs-renderer` emits real SVG `<text>` elements with this font-family verbatim. `resvg`/`usvg`'s embedded `fontdb` then tries to resolve those names:

| Family requested | Linux match |
|------------------|-------------|
| `Inter`          | not installed by default |
| `ui-sans-serif`  | not a real face name |
| `system-ui`      | not a real face name |
| `-apple-system`  | macOS only |
| `Segoe UI`       | Windows only |
| `sans-serif`     | resvg's `fontdb` does **not** resolve generic CSS families |

→ resvg falls through every name and emits `Warning (in usvg::text:129): No match for '...' font-family.` Then it skips drawing the text glyphs entirely while still drawing the rect/path/marker elements. Result: empty boxes.

I verified this by:
1. Generating an SVG with the original font list and feeding it through `/usr/bin/resvg` directly → identical empty output, identical OCR (zero text).
2. Replacing the font-family with `"DejaVu Sans"` → resvg renders text correctly, OCR picks up "Start", "Middle", "End".
3. Confirming `mermaid-rs-renderer` itself emits proper SVG `<text>` with the labels — the SVG is fine, the renderer's fontdb is the bottleneck.

This is **not** the same as the well-known mermaid `<foreignObject>`/`htmlLabels` issue, since `mermaid-rs-renderer` (a pure Rust mermaid implementation, not `mmdc`) emits real SVG `<text>` elements rather than embedded HTML.

## Fix

Add `DejaVu Sans` and `Liberation Sans` between `Segoe UI` and `sans-serif`. These are present on essentially every Linux desktop install (Debian/Ubuntu/Fedora/Arch/openSUSE all ship one or both via base font packages), and are absent on macOS/Windows so the existing platform-preferred families still win there.

```diff
-font_family: "Inter, ui-sans-serif, system-ui, -apple-system, Segoe UI, sans-serif"
+font_family: "Inter, ui-sans-serif, system-ui, -apple-system, Segoe UI, \"DejaVu Sans\", \"Liberation Sans\", sans-serif"
```

## After fix

Same diagram, same machine, with the patched binary (`v0.11.6-dev (dirty)`):

- All three box labels visible
- No `usvg::text` warnings in stderr
- Rendered PNG OCR ("Start", "Middle", "End")

## Notes / alternatives considered

- **fontconfig alias** (`trebuchet ms` → `DejaVu Sans` etc.) does not work because `usvg::fontdb::Database::load_system_fonts()` only scans font directories, it does not interpret fontconfig alias rules.
- **Bundling Inter** in jcode would be more invasive (binary size, license review).
- **Patching `mermaid-rs-renderer`** has analogous font-fallback issues in its `Theme::mermaid_default()` and `Theme::modern()` — happy to send a follow-up PR there too if helpful.
- **Not changing the order before `Inter`** keeps macOS/Windows behavior unchanged: `Inter`/`Segoe UI`/`-apple-system` still win first when present.

## Test plan

- [x] `cargo build --release` (nightly toolchain) succeeds
- [x] OCR of rendered cache PNG goes from empty → readable
- [x] No regression in other diagram types (verified against `tests/fixtures/*` corpus via `mmdr` CLI)
- [x] macOS/Windows behavior unchanged in principle (DejaVu/Liberation only chosen when prior fonts unavailable)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/1jehuang/codesmith/jcode/pr/108"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->