### PR TITLE
Add MAS-inspired project skills

### DIFF
--- a/.jcode/skills/network-traffic-drops/SKILL.md
+++ b/.jcode/skills/network-traffic-drops/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: network-traffic-drops
+description: Troubleshoot packet drops on gateway, compute, bond, tap, NIC, softnet, OVS, or OVN networking paths. Use this skill whenever the user mentions packet drops, rx_dropped, softnet, ring buffers, NIC drops, bond imbalance, TAP interfaces, OVS drops, OVN datapath issues, or network congestion.
+allowed-tools: read, grep, bash
+---
+
+# Network Traffic Drops Troubleshooting
+
+Use this runbook to diagnose packet drops in gateway, compute, virtualization, OVS, or OVN network paths. Keep commands read-only until the user explicitly approves a mitigation.
+
+## Entry Decision Tree
+
+```text
+User symptom -> what is dropping?
+  - rx_dropped increasing on bond/NIC -> Phase 1: Interface diagnosis
+  - softnet drops or squeezes high -> Phase 2: Softnet analysis
+  - specific VM/container suspected -> Phase 3: Source correlation
+  - OVS/OVN datapath involved -> Phase 4: OVS/OVN correlation
+  - unknown/general -> Phase 1 -> Phase 2 -> Phase 3
+```
+
+## Phase 1: Interface Diagnosis
+
+Goal: identify drop type and affected interfaces.
+
+```bash
+ip -s link show <interface>
+ethtool -S <nic> | grep -Ei "drop|miss|buffer|fifo|error"
+ethtool -g <nic>
+ethtool -k <nic> | grep -Ei "gro|lro|tso|gso|rx|tx"
+```
+
+Drop classification:
+
+| Counter | Likely meaning | Next action |
+|---|---|---|
+| `rx_dropped` on interface | Kernel path dropped packets | Check softnet and CPU budget. |
+| NIC-specific `rx_dropped` | Hardware or driver path dropped packets | Check ring buffers and driver counters. |
+| `rx_missed_errors` | FIFO overflow or receive pressure | Check RX ring size and interrupt distribution. |
+| `rx_fifo_errors` | Ring or FIFO pressure | Check ring size, offloads, and packet rate. |
+
+Decision:
+
+- If NIC hardware counters are increasing, inspect the hardware/driver path first.
+- If interface drops increase but NIC counters do not, inspect softnet and CPU processing.
+
+## Phase 2: Softnet Analysis
+
+Goal: determine whether packet processing is CPU-budget constrained.
+
+```bash
+cat /proc/net/softnet_stat
+nproc
+mpstat -P ALL 1 5
+```
+
+For `/proc/net/softnet_stat`, the second column is commonly used to identify `time_squeeze` pressure. Growing values suggest the CPU could not process all packets within budget.
+
+Decision:
+
+- Growing `time_squeeze` plus high CPU means CPU/network processing pressure.
+- Drops with low CPU may point back to ring buffers, interrupt affinity, offloads, or driver behavior.
+
+## Phase 3: Source Correlation
+
+Goal: identify whether a VM, container, TAP, or workload is causing bursts.
+
+```bash
+for tap in /sys/class/net/tap*; do
+  name=$(basename "$tap")
+  rx=$(cat "$tap/statistics/rx_bytes" 2>/dev/null || echo 0)
+  tx=$(cat "$tap/statistics/tx_bytes" 2>/dev/null || echo 0)
+  printf "%s rx=%s tx=%s\n" "$name" "$rx" "$tx"
+done | sort -k2 -nr | head
+```
+
+Adapt the mapping command to the local platform:
+
+```bash
+incus list -c nsN4
+virsh domiflist <domain>
+ip link show
+```
+
+Correlation pattern:
+
+1. Identify the timestamp when gateway or NIC drops increased.
+2. Find TAP/container/VM interfaces with traffic spikes in the same window.
+3. Map interface to workload.
+4. Classify the source as expected burst, misconfiguration, abuse, or capacity issue.
+
+## Phase 4: OVS/OVN Correlation
+
+Goal: identify whether virtual switch or OVN datapath behavior is involved.
+
+```bash
+ovs-appctl dpctl/show
+ovs-appctl dpctl/dump-flows | wc -l
+ovs-vsctl list interface | grep -Ei "name|error|statistics"
+ovs-appctl coverage/show
+```
+
+If OVN is present, inspect control-plane health separately before changing datapath settings:
+
+```bash
+ovn-nbctl show
+ovn-sbctl show
+ovn-sbctl list chassis
+```
+
+Decision:
+
+- High datapath misses may indicate flow churn or cache pressure.
+- OVS interface errors require interface-level investigation.
+- OVN topology or route issues should be handled as an OVN troubleshooting task, not as a NIC tuning task.
+
+## Phase 5: Mitigation Ranking
+
+Do not apply mitigations without explicit user approval.
+
+Low risk:
+
+- Increase RX/TX ring buffer within documented NIC maximums.
+- Adjust a single clearly implicated offload when evidence supports it.
+- Rate-limit or move a clearly identified noisy workload.
+
+Medium risk:
+
+- RSS or IRQ affinity tuning.
+- Flow steering changes.
+- Planned workload evacuation.
+
+High risk:
+
+- Maximum ring sizes without latency analysis.
+- Major OVS/OVN reconfiguration.
+- Driver, firmware, or kernel changes.
+
+Avoid jumping directly to very large ring buffers. They may hide drops while increasing latency and buffering.
+
+## Phase 6: Verification
+
+After an approved mitigation:
+
+```bash
+ip -s link show <interface>
+cat /proc/net/softnet_stat
+ethtool -S <nic> | grep -Ei "drop|miss|buffer|fifo|error"
+```
+
+Compare counters before and after the change over a defined interval. Report whether the same counters stopped increasing, slowed down, or continued unchanged.
+
+## Output Format
+
+Return:
+
+1. Symptom summary.
+2. Evidence gathered, with commands and relevant counters.
+3. Probable root cause and confidence.
+4. Correlated source workload, if identified.
+5. Ranked mitigations with risk level.
+6. Verification plan.
+7. Any commands that require explicit approval before execution.

--- a/.jcode/skills/promptify/SKILL.md
+++ b/.jcode/skills/promptify/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: promptify
+description: Convert vague or raw engineering requests into structured, anti-hallucination implementation prompts. Use this skill whenever the user asks to improve, rewrite, clarify, harden, or prepare a task prompt for an agent, even if they only paste a rough request.
+allowed-tools: read, grep, agentgrep, codesearch, ls, bash
+---
+
+# Promptify
+
+Turn raw user input into a technical prompt that is specific, testable, and suitable for engineering agents.
+
+## Goal
+
+Generate a final prompt that:
+
+- Reduces ambiguity.
+- Prevents invented files, APIs, endpoints, tables, libraries, or behavior.
+- Requires repository evidence before implementation.
+- Requires verifiable evidence after implementation: diff, tests, and results.
+- Includes acceptance criteria that can be checked by tests, commands, diff review, or inspection.
+
+## Step 1: Completeness Check
+
+Evaluate the raw input against these criteria.
+
+| Criterion | Rule |
+|---|---|
+| Word count | Fewer than 60 words means low information. |
+| Action verb | Missing a clear verb such as implement, fix, add, create, migrate, refactor, optimize, or integrate means low information. |
+| Technical domain | Missing a domain such as backend, frontend, database, auth, infra, API, DevOps, Kubernetes, CLI, TUI, provider, memory, browser, safety, or protocol means low information. |
+| Constraints | Missing a constraint, acceptance criterion, validation requirement, or output format means low information. |
+
+Set `needs_research=true` if any criterion fails. Otherwise set `needs_research=false`.
+
+Always begin the response with:
+
+```text
+Completeness evaluation: needs_research=true|false
+Reason: <brief reason>
+```
+
+## Step 2: Research Before Prompting When Needed
+
+When `needs_research=true`, inspect local context before generating the final prompt.
+
+Required local research:
+
+- Map manifests: `Cargo.toml`, `package.json`, `pyproject.toml`, `go.mod`, or equivalents.
+- Identify entrypoints, CLIs, servers, tools, providers, protocols, or UI surfaces.
+- Identify test locations and patterns.
+- Search for similar implementations.
+- Cite real files and modules. Do not invent paths.
+
+External research is optional and only allowed when tools and network access are available. If unavailable, say so in the assumptions instead of inventing references.
+
+## Step 3: Generate The Structured Prompt
+
+After the completeness evaluation, include exactly these sections.
+
+## 1) Final Prompt
+
+```xml
+<objective>
+Clear objective derived from the user input and any repository research.
+</objective>
+
+<anti_hallucination_constraints>
+- Do not invent files, commands, endpoints, tables, providers, tools, libraries, or behavior.
+- Map and cite real repository files before coding.
+- If a critical requirement is missing, stop and list "Requirement Blockers".
+- Require verifiable evidence: diff by file, tests/checks run, and results.
+- Do not claim completion without acceptance-check evidence.
+</anti_hallucination_constraints>
+
+<minimum_functional_scope>
+Smallest useful scope derived from the request and research.
+</minimum_functional_scope>
+
+<required_deliverables>
+Concrete deliverables such as code, tests, docs, config, migrations, prompts, skills, or scripts.
+</required_deliverables>
+
+<required_response_format>
+The agent must respond with:
+1. Repository context found, with real files.
+2. Implementation plan with small steps.
+3. Changes applied, file by file.
+4. Tests/checks executed and results.
+5. Gaps, risks, and next steps.
+</required_response_format>
+
+<acceptance_criteria>
+Objective criteria that can be validated by test, command, diff, or inspection.
+</acceptance_criteria>
+```
+
+## 2) Assumptions
+
+List all assumptions used to fill gaps. Separate what was stated by the user from what was inferred from repository context.
+
+## 3) Open Questions
+
+List only questions that block safe execution. Do not list nice-to-haves.
+
+## Quality Checklist
+
+Before answering, verify:
+
+- The completeness evaluation appears at the top.
+- The prompt is specific to the request.
+- Anti-hallucination constraints are present.
+- Acceptance criteria are testable.
+- The required response format is present.
+- If `needs_research=true`, repository context and assumptions are present.
+- Open questions are limited to execution blockers.

--- a/.jcode/skills/search-first/SKILL.md
+++ b/.jcode/skills/search-first/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: search-first
+description: Research-before-coding workflow. Use this skill whenever a task may already be solved by existing repository code, an existing skill, a built-in jcode tool, MCP integration, or a maintained dependency, even if the user jumps straight to implementation.
+allowed-tools: read, grep, agentgrep, codesearch, ls, bash
+---
+
+# Search First
+
+Use this workflow before adding new code, dependencies, abstractions, or project structure.
+
+## When To Use
+
+- Starting a feature with likely existing patterns.
+- Adding a dependency, provider, MCP server, adapter, wrapper, or tool.
+- Creating a helper, utility, command, prompt, or skill.
+- Fixing behavior where similar behavior may already exist elsewhere.
+- Choosing between direct code changes and a built-in jcode capability.
+
+## Decision Order
+
+1. Existing repository code or pattern.
+2. Existing project-local skill in `.jcode/skills/`.
+3. Existing jcode tool or runtime feature.
+4. Existing MCP server or configured integration.
+5. Maintained external dependency or reference implementation.
+6. Net-new custom code.
+
+## Repository-First Workflow
+
+1. Identify manifests and project shape: `Cargo.toml`, `package.json`, `pyproject.toml`, `go.mod`, or equivalents.
+2. Identify entrypoints, command handlers, services, CLIs, tools, tests, and docs related to the request.
+3. Search for similar nouns, verbs, protocol messages, error strings, config names, and test fixtures.
+4. Read the smallest set of files needed to understand the local pattern.
+5. Implement the smallest viable change that matches that pattern.
+
+Useful starting commands:
+
+```bash
+rg -n "keyword|type|command|error|config" .
+rg --files
+```
+
+Prefer `agentgrep` or `codesearch` when semantic or structural context would reduce the amount of file reading.
+
+## Adopt Vs Build
+
+Adopt or wrap existing behavior when:
+
+- The capability already exists in repo code.
+- A jcode tool, command, provider, skill, or MCP integration already provides the behavior.
+- A small maintained dependency replaces a larger custom implementation without broad coupling.
+
+Build custom code when:
+
+- No existing tool or package matches the requirement.
+- Project constraints require tighter control.
+- The wrapper would be smaller and easier to maintain than introducing a broad dependency.
+
+## Anti-Patterns
+
+- Creating utilities without searching the repo first.
+- Adding a dependency before checking existing code and configured tools.
+- Building a new workflow when a skill, prompt, or small config change is enough.
+- Inventing file paths, commands, APIs, or runtime behavior before verifying they exist.
+
+## Output Expectations
+
+When closing the task, include:
+
+- Repository context found, with real file paths.
+- Existing patterns reused or intentionally not reused.
+- Files changed.
+- Tests or checks run.
+- Gaps, risks, and follow-up work.

--- a/.jcode/skills/verification-loop/SKILL.md
+++ b/.jcode/skills/verification-loop/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: verification-loop
+description: Deliberate verification workflow. Use this skill after meaningful changes, before preparing a PR, after refactoring, or whenever the user needs a reliable build-test-lint-review loop, even if they do not explicitly ask for verification.
+allowed-tools: read, grep, bash
+---
+
+# Verification Loop
+
+Use this workflow to verify changes before handing work back to the user or preparing a PR.
+
+## When To Use
+
+- After completing a feature or bug fix.
+- Before preparing a PR or handoff.
+- After refactoring shared code, protocols, tools, prompts, skills, docs, providers, memory behavior, or safety behavior.
+- After editing configuration, command surfaces, wrappers, or integration docs.
+
+## Verification Order
+
+1. Run the narrowest checks that directly cover the changed area.
+2. Run broader validation if the change affects shared behavior.
+3. Review the diff for accidental scope growth.
+4. Report anything not verified and why.
+
+## Common jcode Checks
+
+Prefer the narrowest relevant subset first:
+
+```bash
+cargo test <module_or_test_name>
+cargo test
+cargo clippy --all-targets --all-features
+cargo fmt --check
+```
+
+For documentation-only or skill-only changes, run structural checks that prove the files are parseable and placed where jcode loads them:
+
+```bash
+find .jcode/skills -name SKILL.md -print
+rg -n "^name:|^description:" .jcode/skills
+```
+
+If a full Rust build is too expensive or unrelated, say that explicitly and run the strongest cheap checks available.
+
+## Diff Review
+
+Before closing the task, inspect:
+
+```bash
+git diff --stat
+git diff
+git status --short
+```
+
+Check for:
+
+- Unrelated file churn.
+- Generated or cached files.
+- Formatting-only changes mixed with behavior changes.
+- Missing tests for changed behavior.
+- Documentation that no longer matches implementation.
+
+## Stop Conditions
+
+Stop and fix before closing the task if:
+
+- Syntax, parser, formatting, or lint checks fail.
+- Relevant tests fail.
+- The change introduces an undocumented command, config, protocol field, or user-facing behavior.
+- Skill or prompt files are missing required frontmatter.
+
+## Output Expectations
+
+Close with:
+
+- Context read.
+- Files changed.
+- Tests or checks run.
+- Result.
+- Relevant logs or command output.
+- Risks.
+- Next steps.

--- a/README.md
+++ b/README.md
@@ -509,6 +509,8 @@ image of /Resume for codex sessions
 
 Skills are not all loaded on startup. The conversation is embedded as a semantic vector, and will automatically inject a skill if there is an embedding hit similar to memories. The agent has a skill tool for you to manually activate a skill at anytime. You may also activate via slash commands. 
 
+This repository also includes a small project-local MAS/Codex-inspired skill pack under `.jcode/skills/`; see `docs/MAS_SKILL_PACK.md`.
+
 ---
 
 ## iOS Application / Native OpenClaw

--- a/docs/MAS_SKILL_PACK.md
+++ b/docs/MAS_SKILL_PACK.md
@@ -1,0 +1,52 @@
+# MAS Skill Pack
+
+This repository includes a small project-local skill pack adapted from MAS/Codex engineering workflows. The skills live under `.jcode/skills/`, so jcode can load them as project-local skills without adding runtime dependencies.
+
+## Included Skills
+
+| Skill | Purpose |
+|---|---|
+| `search-first` | Research existing repository patterns, tools, skills, MCP integrations, and dependencies before adding new code. |
+| `verification-loop` | Close implementation work with deliberate checks, diff review, and residual-risk reporting. |
+| `promptify` | Convert raw or vague engineering requests into structured, anti-hallucination prompts with acceptance criteria. |
+| `network-traffic-drops` | Diagnose packet drops across NIC, bond, TAP, softnet, OVS, and OVN paths with ranked mitigations. |
+
+## Why Project-Local Skills
+
+Project-local skills keep the change low-risk:
+
+- They use jcode's existing `.jcode/skills/<skill-name>/SKILL.md` loading path.
+- They do not change providers, memory, MCP, swarm, browser, safety, or server behavior.
+- They can be activated manually with slash commands such as `/search-first`.
+- They can also participate in jcode's existing skill discovery and semantic injection behavior.
+
+## Usage
+
+List or inspect skills from inside jcode with the skill tool:
+
+```text
+skill_manage action=list
+skill_manage action=read name=promptify
+```
+
+Manual activation examples:
+
+```text
+/search-first
+/verification-loop
+/promptify
+/network-traffic-drops
+```
+
+## Maintenance Notes
+
+Keep each skill self-contained and small. If a workflow needs scripts, fixtures, or long references, place those under the corresponding skill directory and reference them from `SKILL.md` instead of expanding the always-loaded skill body.
+
+When changing skills, verify that every file has valid YAML frontmatter with at least:
+
+```yaml
+---
+name: skill-name
+description: What triggers the skill and what it does.
+---
+```


### PR DESCRIPTION
## Summary

Adds a small project-local skill pack adapted from MAS/Codex engineering workflows. The skills live under `.jcode/skills/` and do not change runtime behavior.

Included skills:
- `search-first`
- `verification-loop`
- `promptify`
- `network-traffic-drops`

Also adds `docs/MAS_SKILL_PACK.md` and a short README pointer.

## Validation

Passed:
- Parsed all `.jcode/skills/*/SKILL.md` frontmatter with Ruby/YAML.
- `git diff --check`
- `cargo test skill --quiet` -> 19 passed
- `cargo clippy --all-targets --all-features --quiet` -> exit 0, existing warnings emitted

Known pre-existing/global failures observed while validating:
- `cargo fmt --check` fails on `src/auth/tests.rs`; same failure reproduced in a clean `origin/master` worktree.
- `cargo test --quiet` fails across unrelated modules. One representative failure, `agent::tests::env_snapshot_detail_is_minimal_for_empty_sessions_and_full_after_history`, was reproduced in a clean `origin/master` worktree.

## Risk

Low. This is docs/project-local skills only, using jcode's existing `.jcode/skills/<skill>/SKILL.md` loading path.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/1jehuang/codesmith/jcode/pr/113"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->