### PR TITLE
fix: accept stringified ambient cycle counts

### DIFF
--- a/src/tool/ambient.rs
+++ b/src/tool/ambient.rs
@@ -122,7 +122,9 @@ impl EndAmbientCycleTool {
 #[derive(Deserialize)]
 struct EndCycleInput {
     summary: String,
+    #[serde(deserialize_with = "deserialize_u32_from_number_or_string")]
     memories_modified: u32,
+    #[serde(deserialize_with = "deserialize_u32_from_number_or_string")]
     compactions: u32,
     #[serde(default)]
     proactive_work: Option<String>,
@@ -132,12 +134,57 @@ struct EndCycleInput {
 
 #[derive(Deserialize)]
 struct NextScheduleInput {
-    #[serde(default)]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_optional_u32_from_number_or_string"
+    )]
     wake_in_minutes: Option<u32>,
     #[serde(default)]
     context: Option<String>,
     #[serde(default)]
     priority: Option<String>,
+}
+
+fn deserialize_u32_from_number_or_string<'de, D>(deserializer: D) -> Result<u32, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    match serde_json::Value::deserialize(deserializer)? {
+        Value::Number(number) => number
+            .as_u64()
+            .and_then(|value| u32::try_from(value).ok())
+            .ok_or_else(|| serde::de::Error::custom("expected u32-compatible integer")),
+        Value::String(value) => value
+            .parse::<u32>()
+            .map_err(|_| serde::de::Error::custom("expected u32-compatible integer string")),
+        other => Err(serde::de::Error::custom(format!(
+            "expected integer or integer string, got {other}"
+        ))),
+    }
+}
+
+fn deserialize_optional_u32_from_number_or_string<'de, D>(
+    deserializer: D,
+) -> Result<Option<u32>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    Option::<serde_json::Value>::deserialize(deserializer)?
+        .map(|value| deserialize_u32_value(value).map_err(serde::de::Error::custom))
+        .transpose()
+}
+
+fn deserialize_u32_value(value: Value) -> Result<u32, String> {
+    match value {
+        Value::Number(number) => number
+            .as_u64()
+            .and_then(|value| u32::try_from(value).ok())
+            .ok_or_else(|| "expected u32-compatible integer".to_string()),
+        Value::String(value) => value
+            .parse::<u32>()
+            .map_err(|_| "expected u32-compatible integer string".to_string()),
+        other => Err(format!("expected integer or integer string, got {other}")),
+    }
 }
 
 #[async_trait]

--- a/src/tool/ambient/tests.rs
+++ b/src/tool/ambient/tests.rs
@@ -75,6 +75,23 @@ fn test_end_cycle_input_minimal() {
 }
 
 #[test]
+fn test_end_cycle_input_accepts_stringified_counts() {
+    let input = json!({
+        "summary": "Done",
+        "memories_modified": "2",
+        "compactions": "1",
+        "next_schedule": {
+            "wake_in_minutes": "15"
+        }
+    });
+
+    let parsed: EndCycleInput = serde_json::from_value(input).unwrap();
+    assert_eq!(parsed.memories_modified, 2);
+    assert_eq!(parsed.compactions, 1);
+    assert_eq!(parsed.next_schedule.unwrap().wake_in_minutes, Some(15));
+}
+
+#[test]
 fn test_schedule_input_deserialization() {
     let input = json!({
         "wake_in_minutes": 15,


### PR DESCRIPTION
## Summary
- allow the ambient cycle tool to deserialize numeric counters from either JSON numbers or integer strings
- apply the same lenient handling to `next_schedule.wake_in_minutes`
- add regression coverage for stringified counts

Fixes #106

## Test Plan
- `cargo fmt --all`
- `cargo test -q test_end_cycle_input` *(blocked locally: missing `pkg-config`/OpenSSL development metadata; sudo requires a password on this host)*

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/1jehuang/codesmith/jcode/pr/116"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->