### PR TITLE
docs(main): justify non_upper_case_globals allow in jemalloc malloc_conf symbols

### DIFF
--- a/docs/CODE_QUALITY_TODO.md
+++ b/docs/CODE_QUALITY_TODO.md
@@ -433,7 +433,7 @@ Generated from `docs/CODE_QUALITY_AUDIT_2026-04-18.md`. This section enumerates 
 - [ ] Remove or justify suppressions in `src/agent/turn_loops.rs` (unused_variables)
 - [ ] Remove or justify suppressions in `src/auth/mod.rs` (unused_mut)
 - [ ] Remove or justify suppressions in `src/cli/dispatch.rs` (deprecated, unused_mut, unused_mut)
-- [ ] Remove or justify suppressions in `src/main.rs` (non_upper_case_globals, non_upper_case_globals)
+- [x] Remove or justify suppressions in `src/main.rs` (non_upper_case_globals, non_upper_case_globals)
 - [ ] Remove or justify suppressions in `src/perf.rs` (non_snake_case)
 - [ ] Remove or justify suppressions in `src/server.rs` (unused_mut, unused_mut)
 - [ ] Remove or justify suppressions in `src/server/client_actions.rs` (clippy::too_many_arguments)

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,14 +12,18 @@ static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 // prof:true            — enable profiling support in jemalloc-prof builds
 // prof_active:false    — keep sampling disabled until explicitly enabled at runtime
 #[cfg(all(feature = "jemalloc", not(feature = "jemalloc-prof")))]
-// jemalloc reads this exact exported symbol name at startup.
+// jemalloc locates its configuration by looking up the exported C symbol `malloc_conf`
+// at process startup. The symbol name is defined by the jemalloc ABI and must be exactly
+// `malloc_conf` (lower_snake_case). `#[allow(non_upper_case_globals)]` is therefore
+// load-bearing and cannot be removed.
 #[allow(non_upper_case_globals)]
 #[unsafe(no_mangle)]
 pub static malloc_conf: Option<&'static [u8; 50]> =
     Some(b"dirty_decay_ms:1000,muzzy_decay_ms:1000,narenas:4\0");
 
 #[cfg(feature = "jemalloc-prof")]
-// jemalloc reads this exact exported symbol name at startup.
+// Same as above: `malloc_conf` is an ABI-defined symbol name required by jemalloc.
+// `#[allow(non_upper_case_globals)]` is load-bearing and cannot be removed.
 #[allow(non_upper_case_globals)]
 #[unsafe(no_mangle)]
 pub static malloc_conf: Option<&'static [u8; 78]> =


### PR DESCRIPTION
Part of the suppression cleanup backlog in docs/CODE_QUALITY_TODO.md.
`malloc_conf` is an ABI-defined C symbol name looked up by jemalloc at process startup. The name must be exactly `malloc_conf` (lower_snake_case) per the  jemalloc ABI, so `#[allow(non_upper_case_globals)]` is load-bearing and cannot be removed.
Replace the terse one-line comments with an explanation that makes this clear to future readers, and mark the corresponding TODO item as complete.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/1jehuang/codesmith/jcode/pr/123"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->