### PR TITLE
docs(tui/remote): justify unused_imports allow on pub(super) re-exports

### DIFF
--- a/docs/CODE_QUALITY_TODO.md
+++ b/docs/CODE_QUALITY_TODO.md
@@ -444,7 +444,7 @@ Generated from `docs/CODE_QUALITY_AUDIT_2026-04-18.md`. This section enumerates 
 - [ ] Remove or justify suppressions in `src/server/comm_sync.rs` (clippy::too_many_arguments)
 - [ ] Remove or justify suppressions in `src/server/debug_swarm_write.rs` (clippy::too_many_arguments)
 - [ ] Remove or justify suppressions in `src/server/startup_tests.rs` (unused_mut)
-- [ ] Remove or justify suppressions in `src/tui/app/remote.rs` (unused_imports, unused_imports)
+- [x] Remove or justify suppressions in `src/tui/app/remote.rs` (unused_imports, unused_imports)
 - [ ] Remove or justify suppressions in `src/tui/app/state_ui.rs` (unused_mut)
 - [ ] Remove or justify suppressions in `src/tui/info_widget.rs` (deprecated)
 

--- a/src/tui/app/remote.rs
+++ b/src/tui/app/remote.rs
@@ -27,6 +27,9 @@ mod workspace;
 use queue_recovery::{recover_local_interleave_to_queue, recover_stranded_soft_interrupts};
 // Re-export for sibling modules and tests that access reconnect state and helpers
 // through `super::remote::*` without reaching into private submodules directly.
+// `#[allow(unused_imports)]` is required because rustc flags re-exports as unused
+// when none of the names are referenced within *this* module; they are consumed by
+// sibling modules and the compiler does not look across module boundaries here.
 #[allow(unused_imports)]
 pub(super) use reconnect::{
     ConnectOutcome, PostConnectOutcome, ReloadReconnectHints, RemoteRunState, connect_with_retry,
@@ -42,6 +45,8 @@ use workspace::{handle_workspace_command, handle_workspace_navigation_key};
 
 // Re-export the remote input dispatch helpers for sibling modules/tests that go
 // through the `remote` facade instead of private submodule paths.
+// Same rationale as above: `#[allow(unused_imports)]` silences the false-positive
+// lint for re-exports that are only consumed outside this module.
 #[allow(unused_imports)]
 pub(super) use input_dispatch::{
     apply_remote_transcript_event, apply_transcript_event, begin_remote_send,


### PR DESCRIPTION
The two #[allow(unused_imports)] attributes on the re-export blocks in src/tui/app/remote.rs suppress a false-positive lint: rustc flags pub(super) re-exports as unused when none of the re-exported names are referenced within the declaring module itself, even though they are consumed by sibling modules and tests via the remote facade.

Add comments explaining this so the suppression is self-documenting and mark the corresponding CODE_QUALITY_TODO backlog item as complete.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/1jehuang/codesmith/jcode/pr/125"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->