### PR TITLE
Enforce directory boundaries for path resolution

### DIFF
--- a/crates/jcode-config-types/src/lib.rs
+++ b/crates/jcode-config-types/src/lib.rs
@@ -721,6 +721,8 @@ pub struct SafetyConfig {
     pub discord_bot_user_id: Option<String>,
     /// Enable Discord reply → agent directive feature (default: false)
     pub discord_reply_enabled: bool,
+    /// Enforce a directory boundary for path resolution (default: false)
+    pub restrict_path_resolution: bool,
 }
 
 impl Default for SafetyConfig {
@@ -747,6 +749,7 @@ impl Default for SafetyConfig {
             discord_channel_id: None,
             discord_bot_user_id: None,
             discord_reply_enabled: false,
+            restrict_path_resolution: false,
         }
     }
 }

--- a/src/agent/turn_execution.rs
+++ b/src/agent/turn_execution.rs
@@ -335,6 +335,7 @@ impl Agent {
             stdin_request_tx: self.stdin_request_tx.clone(),
             graceful_shutdown_signal: Some(self.graceful_shutdown.clone()),
             execution_mode: ToolExecutionMode::Direct,
+            restrict_path_resolution: crate::config::config().safety.restrict_path_resolution,
         };
         self.registry.execute(name, input, ctx).await
     }

--- a/src/agent/turn_loops.rs
+++ b/src/agent/turn_loops.rs
@@ -437,6 +437,7 @@ impl Agent {
                             stdin_request_tx: self.stdin_request_tx.clone(),
                             graceful_shutdown_signal: Some(self.graceful_shutdown.clone()),
                             execution_mode: ToolExecutionMode::AgentTurn,
+                            restrict_path_resolution: crate::config::config().safety.restrict_path_resolution,
                         };
                         crate::telemetry::record_tool_call();
                         let tool_result = self.registry.execute(&tool_name, input, ctx).await;
@@ -747,6 +748,7 @@ impl Agent {
                     stdin_request_tx: self.stdin_request_tx.clone(),
                     graceful_shutdown_signal: Some(self.graceful_shutdown.clone()),
                     execution_mode: ToolExecutionMode::AgentTurn,
+                    restrict_path_resolution: crate::config::config().safety.restrict_path_resolution,
                 };
 
                 if trace {

--- a/src/agent/turn_streaming_broadcast.rs
+++ b/src/agent/turn_streaming_broadcast.rs
@@ -448,6 +448,7 @@ impl Agent {
                             stdin_request_tx: self.stdin_request_tx.clone(),
                             graceful_shutdown_signal: Some(self.graceful_shutdown.clone()),
                             execution_mode: ToolExecutionMode::AgentTurn,
+                            restrict_path_resolution: crate::config::config().safety.restrict_path_resolution,
                         };
                         crate::telemetry::record_tool_call();
                         let tool_result = self.registry.execute(&tool_name, input, ctx).await;
@@ -770,6 +771,7 @@ impl Agent {
                     stdin_request_tx: self.stdin_request_tx.clone(),
                     graceful_shutdown_signal: Some(self.graceful_shutdown.clone()),
                     execution_mode: ToolExecutionMode::AgentTurn,
+                    restrict_path_resolution: crate::config::config().safety.restrict_path_resolution,
                 };
 
                 if trace {

--- a/src/agent/turn_streaming_mpsc.rs
+++ b/src/agent/turn_streaming_mpsc.rs
@@ -450,6 +450,7 @@ impl Agent {
                             stdin_request_tx: self.stdin_request_tx.clone(),
                             graceful_shutdown_signal: Some(self.graceful_shutdown.clone()),
                             execution_mode: ToolExecutionMode::AgentTurn,
+                            restrict_path_resolution: crate::config::config().safety.restrict_path_resolution,
                         };
                         crate::telemetry::record_tool_call();
                         let tool_result = self.registry.execute(&tool_name, input, ctx).await;
@@ -798,6 +799,7 @@ impl Agent {
                     stdin_request_tx: self.stdin_request_tx.clone(),
                     graceful_shutdown_signal: Some(self.graceful_shutdown.clone()),
                     execution_mode: ToolExecutionMode::AgentTurn,
+                    restrict_path_resolution: crate::config::config().safety.restrict_path_resolution,
                 };
 
                 if trace {

--- a/src/bin/harness.rs
+++ b/src/bin/harness.rs
@@ -84,6 +84,7 @@ async fn main() -> Result<()> {
         stdin_request_tx: None,
         graceful_shutdown_signal: None,
         execution_mode: ToolExecutionMode::Direct,
+        restrict_path_resolution: false,
     };
 
     let mut cases = Vec::new();

--- a/src/server/client_actions.rs
+++ b/src/server/client_actions.rs
@@ -366,6 +366,7 @@ pub(super) fn handle_run_subagent(
             stdin_request_tx: None,
             graceful_shutdown_signal: None,
             execution_mode: crate::tool::ToolExecutionMode::Direct,
+            restrict_path_resolution: crate::config::config().safety.restrict_path_resolution,
         };
 
         let started = Instant::now();

--- a/src/tool/mod.rs
+++ b/src/tool/mod.rs
@@ -134,6 +134,7 @@ pub struct ToolContext {
     pub stdin_request_tx: Option<tokio::sync::mpsc::UnboundedSender<StdinInputRequest>>,
     pub graceful_shutdown_signal: Option<InterruptSignal>,
     pub execution_mode: ToolExecutionMode,
+    pub restrict_path_resolution: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -152,17 +153,74 @@ impl ToolContext {
             stdin_request_tx: self.stdin_request_tx.clone(),
             graceful_shutdown_signal: self.graceful_shutdown_signal.clone(),
             execution_mode: self.execution_mode,
+            restrict_path_resolution: self.restrict_path_resolution,
         }
     }
 
     pub fn resolve_path(&self, path: &Path) -> PathBuf {
-        if path.is_absolute() {
+        let resolved = if path.is_absolute() {
             path.to_path_buf()
         } else if let Some(ref base) = self.working_dir {
             base.join(path)
         } else {
             path.to_path_buf()
+        };
+
+        if self.restrict_path_resolution {
+            if let Some(ref base) = self.working_dir {
+                // To securely resolve a path without relying on canonicalize (which fails
+                // if the file does not exist), we normalize the path components in memory.
+                let base_canon = base.canonicalize().unwrap_or_else(|_| base.to_path_buf());
+                
+                // Normalizing paths (like path-clean) by resolving `..` components manually.
+                let mut resolved_components = Vec::new();
+                for component in resolved.components() {
+                    match component {
+                        std::path::Component::Prefix(p) => resolved_components.push(std::path::Component::Prefix(p)),
+                        std::path::Component::RootDir => resolved_components.push(std::path::Component::RootDir),
+                        std::path::Component::CurDir => {}
+                        std::path::Component::ParentDir => {
+                            let last = resolved_components.last().copied();
+                            match last {
+                                Some(std::path::Component::RootDir) | Some(std::path::Component::Prefix(_)) => {}
+                                Some(std::path::Component::Normal(_)) => {
+                                    resolved_components.pop();
+                                }
+                                _ => {
+                                    resolved_components.push(std::path::Component::ParentDir);
+                                }
+                            }
+                        }
+                        std::path::Component::Normal(c) => resolved_components.push(std::path::Component::Normal(c)),
+                    }
+                }
+                let resolved_clean: PathBuf = resolved_components.into_iter().collect();
+
+                // Canonicalization of cleaned path may still fail for non-existent files.
+                // However, our clean path prevents simple bypasses via literal '..' prefixes.
+                if !resolved_clean.starts_with(&base_canon) {
+                    crate::logging::warn(&format!(
+                        "Path resolution restricted: {:?} is outside {:?}",
+                        resolved, base
+                    ));
+                    return base.to_path_buf();
+                }
+
+                // Make sure we also check against `canonicalize` when the file does exist,
+                // to prevent symlink bypasses.
+                if let Ok(resolved_canon) = resolved.canonicalize() {
+                    if !resolved_canon.starts_with(&base_canon) {
+                        crate::logging::warn(&format!(
+                            "Path resolution restricted (via symlink): {:?} is outside {:?}",
+                            resolved, base
+                        ));
+                        return base.to_path_buf();
+                    }
+                }
+            }
         }
+
+        resolved
     }
 }
 

--- a/src/tool/tests.rs
+++ b/src/tool/tests.rs
@@ -415,3 +415,45 @@ async fn test_request_permission_is_ambient_only() {
         "request_permission should be available after ambient tool registration"
     );
 }
+
+#[tokio::test]
+async fn test_resolve_path_restrict_path_resolution() {
+    let temp_dir = std::env::temp_dir();
+    let temp_dir_str = temp_dir.to_string_lossy().to_string();
+
+    let mut ctx = ToolContext {
+        session_id: "test".to_string(),
+        message_id: "test".to_string(),
+        tool_call_id: "test".to_string(),
+        working_dir: Some(temp_dir.clone()),
+        stdin_request_tx: None,
+        graceful_shutdown_signal: None,
+        execution_mode: ToolExecutionMode::Direct,
+        restrict_path_resolution: true,
+    };
+
+    // 1. Valid path within working_dir
+    let valid_path = Path::new("valid.txt");
+    let resolved = ctx.resolve_path(valid_path);
+    assert_eq!(resolved, temp_dir.join("valid.txt"));
+
+    // 2. Absolute path outside working_dir (rejected/clamped)
+    let absolute_path = Path::new("/etc/malicious");
+    let resolved = ctx.resolve_path(absolute_path);
+    assert_eq!(resolved, temp_dir);
+
+    // 3. Relative path containing `..` that escapes working_dir (rejected/clamped)
+    let escape_path = Path::new("../malicious");
+    let resolved = ctx.resolve_path(escape_path);
+    assert_eq!(resolved, temp_dir);
+
+    // 4. Relative path containing `..` that escapes, directed at non-existent files
+    let non_existent_escape = Path::new("../../non_existent/malicious");
+    let resolved = ctx.resolve_path(non_existent_escape);
+    assert_eq!(resolved, temp_dir);
+    
+    // 5. Valid path using `..` but staying within working_dir
+    let valid_dots = Path::new("sub/../valid.txt");
+    let resolved = ctx.resolve_path(valid_dots);
+    assert_eq!(resolved, temp_dir.join("sub/../valid.txt"));
+}

--- a/src/tui/app/commands.rs
+++ b/src/tui/app/commands.rs
@@ -640,6 +640,7 @@ fn launch_manual_subagent(app: &mut App, spec: ManualSubagentSpec) {
             stdin_request_tx: None,
             graceful_shutdown_signal: None,
             execution_mode: crate::tool::ToolExecutionMode::Direct,
+            restrict_path_resolution: crate::config::config().safety.restrict_path_resolution,
         };
 
         let start = Instant::now();

--- a/src/tui/app/turn.rs
+++ b/src/tui/app/turn.rs
@@ -766,6 +766,7 @@ impl App {
                                             stdin_request_tx: None,
                                             graceful_shutdown_signal: None,
                                             execution_mode: crate::tool::ToolExecutionMode::AgentTurn,
+                                            restrict_path_resolution: crate::config::config().safety.restrict_path_resolution,
                                         };
                                         let tool_result = self.registry.execute(&tool_name, input, ctx).await;
                                         crate::telemetry::record_tool_call();
@@ -976,6 +977,7 @@ impl App {
                     stdin_request_tx: None,
                     graceful_shutdown_signal: None,
                     execution_mode: crate::tool::ToolExecutionMode::AgentTurn,
+                    restrict_path_resolution: crate::config::config().safety.restrict_path_resolution,
                 };
 
                 Bus::global().publish(BusEvent::ToolUpdated(ToolEvent {


### PR DESCRIPTION
## Summary
- Adds a `restrict_path_resolution` feature flag to prevent tools from accessing files outside the working directory.
- Safely handles directory traversal attempts (`../`) and absolute path escapes for both existing and non-existent files.

## What Changed
- Added the `restrict_path_resolution` flag to `SafetyConfig` (default: false).
- Implemented an in-memory stack-based path component normalizer in `ToolContext::resolve_path` to securely evaluate `.` and `..` without relying solely on `canonicalize()`.
- Preserved a secondary `canonicalize()` check for existing files to prevent symlink bypasses.
- Plumbed the configuration flag into `ToolContext` across all agent turn execution loops, the TUI, and server client actions.
- Added comprehensive unit tests in `src/tool/tests.rs` for path resolution boundary checks.

## Verification
- Manually validated the path resolution logic against various traversal inputs using bash scripts.
- Verified unit tests for valid workspace paths, absolute path escapes, relative `..` escapes, and non-existent file traversal attempts.

## Publish Notes
- Target repository: 1jehuang/jcode
- Publishing path: fork sashimikun/jcode -> 1jehuang/jcode