### PR TITLE
fix(sidecar): correct Haiku 4.5 model identifier in Claude OAuth fallback

### DIFF
--- a/src/sidecar.rs
+++ b/src/sidecar.rs
@@ -5,7 +5,7 @@
 //!
 //! Automatically selects the best available backend:
 //! - OpenAI (gpt-5.3-codex-spark) if Codex credentials are available
-//! - Claude (claude-haiku-4-5-20241022) if Claude credentials are available
+//! - Claude (claude-haiku-4-5-20251001) if Claude credentials are available
 
 use crate::auth;
 use anyhow::{Context, Result};
@@ -18,7 +18,7 @@ const SIDECAR_OPENAI_OAUTH_FALLBACK_MODEL: &str = "gpt-5.4";
 const SIDECAR_OPENAI_OAUTH_FALLBACK_REASONING: &str = "low";
 
 /// Fast/cheap Claude model used when only Claude credentials are available.
-const SIDECAR_CLAUDE_MODEL: &str = "claude-haiku-4-5-20241022";
+const SIDECAR_CLAUDE_MODEL: &str = "claude-haiku-4-5-20251001";
 
 /// OpenAI Responses API
 const OPENAI_API_BASE: &str = "https://api.openai.com/v1";


### PR DESCRIPTION
## Summary

The Claude OAuth fallback path in [`src/sidecar.rs:21`](https://github.com/1jehuang/jcode/blob/v0.11.16/src/sidecar.rs#L21) declares a model identifier that returns HTTP 404 from Anthropic:

```rust
const SIDECAR_CLAUDE_MODEL: &str = "claude-haiku-4-5-20241022";
```

The actual Haiku 4.5 release is `claude-haiku-4-5-20251001`, verifiable via:

```bash
$ jcode model list --provider claude
claude-haiku-4-5-20251001    # ← canonical
claude-opus-4-7
claude-sonnet-4-6
...
```

## Symptom

For users on Claude OAuth without OpenAI/Codex credentials (the common case for Claude Pro subscribers), **every sidecar call fails:**

```
[2026-05-06 11:01:51] Incremental extraction failed: Claude API error (404 Not Found):
  {"error":{"type":"not_found_error",
            "message":"model: claude-haiku-4-5-20241022"},
   "request_id":"req_011CakmUNUtFctyxdT5eNUb3"}
```

Topic-change detection still fires, `extraction_started` events still log, but the actual Haiku call returns 404. Memory extraction is fully blocked. Users with `[agents] memory_sidecar_enabled = true` see no memories accumulate despite the architecture being correctly configured.

## The fix

Two-line constant change in `src/sidecar.rs`:

```diff
-//! - Claude (claude-haiku-4-5-20241022) if Claude credentials are available
+//! - Claude (claude-haiku-4-5-20251001) if Claude credentials are available
-const SIDECAR_CLAUDE_MODEL: &str = "claude-haiku-4-5-20241022";
+const SIDECAR_CLAUDE_MODEL: &str = "claude-haiku-4-5-20251001";
```

The preferred OpenAI Codex path (`gpt-5.3-codex-spark`) is unaffected.

## Verification

After applying:

1. Rebuilt: `cargo install --path . jcode --locked --force --features embeddings`
2. Re-OAuth'd against Anthropic.
3. Ran a 4-turn plant + topic-shift session in a Next.js project.
4. Result:
   - `extraction_complete {count: 3}` event fired (was never reaching this state pre-fix)
   - 3 memories persisted to `~/.jcode/memory/projects/<hash>.json` with correct `preference`/`fact`/`entity` categorization and `trust: "high"`
   - 384-dim embeddings stored alongside each entry
   - `jcode memory search --semantic <paraphrased>` returns hits at 59-74% similarity

Logs before fix:
```
Incremental extraction failed: Claude API error (404 Not Found): {...20241022...}
```

Logs after fix:
```
Final extraction starting for session ... (3362 chars)
Final extraction for session ...: stored 3 memories
```

## Notes

- This affects the Claude-only auth path (the fallback when `provider::is_model_available_for_account(SIDECAR_OPENAI_MODEL)` returns `Some(false)` or no Codex credentials are configured per `resolve_openai_request_model`).
- I considered a model alias (e.g., `claude-haiku-4-5`) instead of a dated snapshot ID, matching the spirit of [`e0fd83dc`](https://github.com/1jehuang/jcode/commit/e0fd83dc) ('Use model aliases instead of dated snapshot IDs'), but kept the dated form to match the surrounding `SIDECAR_OPENAI_MODEL` style. Happy to switch to an alias if preferred — let me know.
- No tests touched; the constant is referenced via `Sidecar::with_configured_model(None)` and downstream OAuth-gated request construction. End-to-end exercise was via real OAuth in `--features embeddings` build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)