### PR TITLE
fix(openai): disable image generation tool for Codex models

### DIFF
--- a/src/provider/openai.rs
+++ b/src/provider/openai.rs
@@ -686,6 +686,14 @@ impl OpenAIProvider {
         format!("{}/compact", Self::responses_url(credentials))
     }
 
+    fn supports_native_image_generation(model_id: &str) -> bool {
+        let normalized = model_id
+            .strip_suffix("[1m]")
+            .unwrap_or(model_id)
+            .to_ascii_lowercase();
+        !normalized.contains("codex")
+    }
+
     #[expect(
         clippy::too_many_arguments,
         reason = "request construction threads explicit per-request OpenAI settings without hidden state"
@@ -704,7 +712,7 @@ impl OpenAIProvider {
         native_compaction_threshold: Option<usize>,
     ) -> Value {
         let mut tools = api_tools.to_vec();
-        if is_chatgpt_mode {
+        if is_chatgpt_mode && Self::supports_native_image_generation(model_id) {
             tools.push(serde_json::json!({ "type": "image_generation" }));
         }
 

--- a/src/provider/openai_tests/payloads.rs
+++ b/src/provider/openai_tests/payloads.rs
@@ -18,6 +18,57 @@ fn test_build_response_request_includes_stream_for_http() {
 }
 
 #[test]
+fn test_chatgpt_payload_includes_native_image_generation_for_non_codex_models() {
+    let request = OpenAIProvider::build_response_request(
+        "gpt-5.5",
+        "system".to_string(),
+        &[],
+        &[],
+        true,
+        Some(DEFAULT_MAX_OUTPUT_TOKENS),
+        None,
+        None,
+        None,
+        None,
+        None,
+    );
+
+    assert!(request["tools"]
+        .as_array()
+        .expect("tools array")
+        .iter()
+        .any(|tool| tool["type"] == "image_generation"));
+}
+
+#[test]
+fn test_chatgpt_payload_excludes_native_image_generation_for_codex_models() {
+    for model in ["gpt-5.3-codex", "gpt-5.3-codex-spark", "gpt-5.3-codex-spark[1m]"] {
+        let request = OpenAIProvider::build_response_request(
+            model,
+            "system".to_string(),
+            &[],
+            &[],
+            true,
+            Some(DEFAULT_MAX_OUTPUT_TOKENS),
+            None,
+            None,
+            None,
+            None,
+            None,
+        );
+
+        assert!(
+            request["tools"]
+                .as_array()
+                .expect("tools array")
+                .iter()
+                .all(|tool| tool["type"] != "image_generation"),
+            "{model} should not receive the unsupported native image_generation tool"
+        );
+    }
+}
+
+#[test]
 fn test_websocket_payload_strips_stream_and_background() {
     let mut request = OpenAIProvider::build_response_request(
         "gpt-5.4",


### PR DESCRIPTION
## Summary

- Do not attach the provider-native `image_generation` tool when the active OpenAI/ChatGPT model is a Codex model.
- Preserve native image generation for non-Codex ChatGPT models.
- Add payload regression tests for both supported and unsupported model families.

## Why

ChatGPT/Codex routes such as `gpt-5.3-codex-spark` can reject requests with:

```text
invalid_request_error: Tool 'image_generation' is not supported with gpt-5.3-codex-spark-1p-codexswic-ev3.
```

This happens because Jcode currently adds `image_generation` for all ChatGPT-mode OpenAI requests. Codex models do not support that native tool, so requests can fail before the assistant can respond.

## Validation

- `cargo fmt --all`
- `cargo test test_chatgpt_payload_ --lib`
- `cargo build --release`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/1jehuang/codesmith/jcode/pr/148"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->