### PR TITLE
fix(skill+gemini): forgive Skill schema confusion + sanitize JSON-Schema for Gemini

### DIFF
--- a/src/provider/gemini.rs
+++ b/src/provider/gemini.rs
@@ -890,22 +890,79 @@ pub(crate) fn build_tools(tools: &[ToolDefinition]) -> Option<Vec<GeminiTool>> {
 }
 
 fn gemini_compatible_schema(schema: &Value) -> Value {
+    // Gemini's generateContent uses an OpenAPI 3.0 schema subset and rejects
+    // standard JSON-Schema metadata ($defs, $ref, $schema, etc.).
+    // MCP servers like notion and supabase emit schemas with $defs+$ref.
+    // We extract $defs from the root, then recursively inline $ref references
+    // and strip metadata keywords Gemini doesn't accept.
+    let defs = schema
+        .as_object()
+        .and_then(|m| m.get("$defs").or_else(|| m.get("definitions")))
+        .and_then(|v| v.as_object())
+        .cloned()
+        .unwrap_or_default();
+    sanitize_for_gemini(schema, &defs, 0)
+}
+
+const GEMINI_SCHEMA_MAX_DEPTH: usize = 24;
+
+fn sanitize_for_gemini(
+    schema: &Value,
+    defs: &serde_json::Map<String, Value>,
+    depth: usize,
+) -> Value {
+    if depth > GEMINI_SCHEMA_MAX_DEPTH {
+        // Avoid blow-up on circular schemas — return permissive empty object
+        return Value::Object(serde_json::Map::new());
+    }
     match schema {
         Value::Object(map) => {
+            // Resolve $ref by replacing the entire object with the target definition
+            if let Some(ref_str) = map.get("$ref").and_then(|v| v.as_str()) {
+                let name = ref_str
+                    .strip_prefix("#/$defs/")
+                    .or_else(|| ref_str.strip_prefix("#/definitions/"));
+                if let Some(target_name) = name
+                    && let Some(target) = defs.get(target_name)
+                {
+                    return sanitize_for_gemini(target, defs, depth + 1);
+                }
+                // Unresolvable $ref → permissive empty object
+                return Value::Object(serde_json::Map::new());
+            }
+
             let mut out = serde_json::Map::new();
             for (key, value) in map {
+                // Strip JSON-Schema metadata not supported by Gemini
+                if matches!(
+                    key.as_str(),
+                    "$defs"
+                        | "definitions"
+                        | "$schema"
+                        | "$id"
+                        | "$comment"
+                        | "$anchor"
+                        | "title"
+                ) {
+                    continue;
+                }
                 if key == "const" {
                     out.insert(
                         "enum".to_string(),
-                        Value::Array(vec![gemini_compatible_schema(value)]),
+                        Value::Array(vec![sanitize_for_gemini(value, defs, depth + 1)]),
                     );
                 } else {
-                    out.insert(key.clone(), gemini_compatible_schema(value));
+                    out.insert(key.clone(), sanitize_for_gemini(value, defs, depth + 1));
                 }
             }
             Value::Object(out)
         }
-        Value::Array(items) => Value::Array(items.iter().map(gemini_compatible_schema).collect()),
+        Value::Array(items) => Value::Array(
+            items
+                .iter()
+                .map(|i| sanitize_for_gemini(i, defs, depth + 1))
+                .collect(),
+        ),
         _ => schema.clone(),
     }
 }

--- a/src/tool/mod.rs
+++ b/src/tool/mod.rs
@@ -38,7 +38,7 @@ use crate::provider::Provider;
 use crate::skill::SkillRegistry;
 use anyhow::Result;
 use jcode_message_types::ToolDefinition;
-use serde_json::Value;
+use serde_json::{Value, json};
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use tokio::sync::RwLock;
@@ -328,7 +328,30 @@ impl Registry {
             "file_glob" => "glob",
             "file_grep" => "grep",
             "todoread" | "todowrite" | "todo_read" | "todo_write" => "todo",
+            // The API-facing "Skill" tool maps to the internal "skill_manage" tool.
+            "Skill" | "skill" => "skill_manage",
             other => other,
+        }
+    }
+
+    /// Transform tool input when the API-facing name differs from the internal tool name.
+    ///
+    /// The `Skill` tool exposed to the model uses `{skill, args}` parameters, but the
+    /// internal `skill_manage` tool expects `{action, name}`. This translates between them.
+    fn transform_input(name: &str, input: Value) -> Value {
+        match name {
+            "Skill" | "skill" => {
+                // {skill: "brain", args: "..."} -> {action: "load", name: "brain"}
+                if let Some(skill_name) = input.get("skill").and_then(|v| v.as_str()) {
+                    json!({
+                        "action": "load",
+                        "name": skill_name
+                    })
+                } else {
+                    input
+                }
+            }
+            _ => input,
         }
     }
 
@@ -356,6 +379,9 @@ impl Registry {
 
         // Drop the lock before executing
         drop(tools);
+
+        // Transform input for tools whose API-facing schema differs from the internal one.
+        let input = Self::transform_input(name, input);
 
         let started_at = std::time::Instant::now();
         let result = tool.execute(input.clone(), ctx).await;

--- a/src/tool/skill.rs
+++ b/src/tool/skill.rs
@@ -24,8 +24,10 @@ struct SkillInput {
     /// Action to perform: load (default), list, reload, reload_all, read
     #[serde(default = "default_action")]
     action: String,
-    /// Skill name (required for load, reload, read)
-    #[serde(default)]
+    /// Skill name (required for load, reload, read).
+    /// Accepts `skill` as alias so models confused between the public `Skill` tool
+    /// schema (`{skill}`) and the internal `skill_manage` schema (`{name}`) still work.
+    #[serde(default, alias = "skill")]
     name: Option<String>,
 }
 
@@ -89,7 +91,12 @@ impl Tool for SkillTool {
 
 impl SkillTool {
     async fn load_skill(&self, name: Option<String>) -> Result<ToolOutput> {
-        let name = name.ok_or_else(|| anyhow::anyhow!("'name' is required for load action"))?;
+        let name = name.ok_or_else(|| {
+            anyhow::anyhow!(
+                "'name' is required for load action. Pass {{\"action\":\"load\",\"name\":\"<skill>\"}} \
+                 or use the public Skill tool with {{\"skill\":\"<skill>\"}}."
+            )
+        })?;
 
         let registry = self.registry.read().await;
         let skill = registry


### PR DESCRIPTION
This PR fixes two model-side / provider-side bugs surfaced when running v0.12.0 against MCP servers (notion, supabase) on macOS.

---

## Fix 1: `skill_manage` schema confusion (commit f477bd4)

Models invoking jcode produce malformed calls like `skill_manage(action="load")` (missing `name`) and error with `'name' is required for load action`. Root cause: the public-facing tool is `Skill` with schema `{skill}`, internal tool is `skill_manage` with schema `{action, name}`. The translation layer in `src/tool/mod.rs` was half-applied at v0.12.0 (mapping draft + `transform_input` were committed but the `json` import was missing — the file did not compile).

This PR:
1. Adds the missing `json` import to `src/tool/mod.rs`.
2. Keeps the `Skill | skill -> skill_manage` resolve and `{skill: X} -> {action: load, name: X}` transform.
3. Adds `#[serde(alias = "skill")]` to `SkillInput.name` so `skill_manage` called directly with `{action: load, skill: brain}` also works.
4. Improves the error message when `name` is genuinely missing.

## Fix 2: Gemini rejects MCP tool schemas (commit on same branch)

Gemini's `generateContent` endpoint uses an OpenAPI 3.0 schema subset and rejects requests with HTTP 400 when tool parameters contain `$defs`, `$ref`, or `$schema` — which is exactly what most MCP servers emit (notion, supabase, etc.) because they generate schemas from typed code (Pydantic / Zod) that produces `$defs+$ref`.

Repro: configure notion or supabase MCP, then `jcode --provider gemini run "hi"` — fails with hundreds of errors like:
```
Unknown name "$defs" at 'request.tools[0].function_declarations[17].parameters'
Unknown name "$ref" at 'request.tools[0].function_declarations[18]...'
Unknown name "$schema" at 'request.tools[0].function_declarations[40]...'
```

This PR extends `gemini_compatible_schema` in `src/provider/gemini.rs` to:
1. Extract `$defs` (or `definitions`) from the root.
2. Recursively walk the schema, resolving `$ref` to the corresponding `$def` and inlining the target.
3. Strip JSON-Schema metadata (`$defs`, `$schema`, `$id`, `$comment`, `$anchor`, `definitions`, `title`) at every level.
4. Cap recursion depth at 24 to handle circular schemas safely.

Preserves the existing `const → enum` rewrite.

---

## Tested

- `cargo check -p jcode --bin jcode` — passes
- `cargo build --release -p jcode --bin jcode` — passes (4m24s first build, 1m08s incremental)
- Smoke 1: Skill tool loads `jcode` skill end-to-end with Claude Sonnet OAuth in TUI.
- Smoke 2: `jcode --provider gemini --model gemini-2.5-flash run "Reply only OK"` from setterapp dir (notion + supabase-dev + supabase-prod MCPs configured) — works after fix, was failing with HTTP 400 before.

## Diff stat

```
 src/tool/mod.rs       | 28 ++++++++++++++++++++++++++++-
 src/tool/skill.rs     | 13 +++++++++++--
 src/provider/gemini.rs | 64 +++++++++++++++++++++++++++++++++++++--
 3 files changed, 100 insertions(+), 5 deletions(-)
```

No public API changes.