### PR TITLE
Fix OpenAI usage percent normalization for low values

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3260,7 +3260,7 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "jcode"
-version = "0.11.4"
+version = "0.12.0"
 dependencies = [
  "agentgrep",
  "anyhow",

--- a/src/usage/openai_helpers.rs
+++ b/src/usage/openai_helpers.rs
@@ -12,11 +12,14 @@ pub(super) fn normalize_ratio(raw: f32) -> f32 {
     if !raw.is_finite() {
         return 0.0;
     }
-    if raw > 1.0 {
-        (raw / 100.0).clamp(0.0, 1.0)
-    } else {
-        raw.clamp(0.0, 1.0)
-    }
+    // The ChatGPT `wham/usage` endpoint (and equivalent OpenAI account usage
+    // endpoints) always reports `used_percent` as a value in `[0, 100]`. The
+    // previous implementation tried to auto-detect ratio-vs-percent based on
+    // `raw > 1.0`, which incorrectly mapped the legitimate response
+    // `used_percent: 1` (1% used) to a ratio of `1.0` (100% used). Treating
+    // the value as a percent unconditionally avoids that misclassification
+    // and matches the documented API contract.
+    (raw / 100.0).clamp(0.0, 1.0)
 }
 
 fn normalize_percent(raw: f32) -> f32 {

--- a/src/usage/tests.rs
+++ b/src/usage/tests.rs
@@ -554,3 +554,62 @@ fn test_account_usage_probe_detects_all_accounts_exhausted() {
     assert!(probe.best_available_alternative().is_none());
     assert!(probe.switch_guidance().is_none());
 }
+
+#[test]
+fn test_parse_openai_usage_payload_reports_low_percentages_correctly() {
+    // Regression test: the live `wham/usage` payload returns `used_percent`
+    // values in `[0, 100]`. A weekly bucket reporting `1` (1% used) must not
+    // be misclassified as a fully exhausted ratio of `1.0` (100% used).
+    // Mirrors a real production response from
+    // `https://chatgpt.com/backend-api/wham/usage`.
+    let json = serde_json::json!({
+        "plan_type": "prolite",
+        "rate_limit": {
+            "allowed": true,
+            "limit_reached": false,
+            "primary_window": {
+                "used_percent": 5,
+                "reset_at": 1_778_283_299_i64
+            },
+            "secondary_window": {
+                "used_percent": 1,
+                "reset_at": 1_778_870_099_i64
+            }
+        },
+        "additional_rate_limits": [{
+            "limit_name": "GPT-5.3-Codex-Spark",
+            "rate_limit": {
+                "allowed": true,
+                "primary_window": { "used_percent": 5, "reset_at": 1_778_283_310_i64 },
+                "secondary_window": { "used_percent": 1, "reset_at": 1_778_870_110_i64 }
+            }
+        }]
+    });
+
+    let parsed = openai_helpers::parse_openai_usage_payload(&json);
+
+    assert!(!parsed.hard_limit_reached);
+    let by_name: std::collections::HashMap<_, _> = parsed
+        .limits
+        .iter()
+        .map(|l| (l.name.as_str(), l.usage_percent))
+        .collect();
+    assert_eq!(by_name.get("5-hour window"), Some(&5.0));
+    assert_eq!(by_name.get("7-day window"), Some(&1.0));
+    assert_eq!(by_name.get("GPT-5.3-Codex-Spark (5h)"), Some(&5.0));
+    assert_eq!(by_name.get("GPT-5.3-Codex-Spark (7d)"), Some(&1.0));
+}
+
+#[test]
+fn test_normalize_ratio_treats_low_integer_values_as_percent() {
+    // Direct unit test for the normalization helper to lock in the contract.
+    assert!((openai_helpers::normalize_ratio(0.0) - 0.0).abs() < 1e-6);
+    assert!((openai_helpers::normalize_ratio(1.0) - 0.01).abs() < 1e-6);
+    assert!((openai_helpers::normalize_ratio(5.0) - 0.05).abs() < 1e-6);
+    assert!((openai_helpers::normalize_ratio(50.0) - 0.5).abs() < 1e-6);
+    assert!((openai_helpers::normalize_ratio(100.0) - 1.0).abs() < 1e-6);
+    // Out of range / weird inputs are clamped, not exploded.
+    assert!((openai_helpers::normalize_ratio(150.0) - 1.0).abs() < 1e-6);
+    assert!((openai_helpers::normalize_ratio(-5.0) - 0.0).abs() < 1e-6);
+    assert!((openai_helpers::normalize_ratio(f32::NAN) - 0.0).abs() < 1e-6);
+}

--- a/src/usage_openai.rs
+++ b/src/usage_openai.rs
@@ -12,11 +12,14 @@ pub(super) fn normalize_ratio(raw: f32) -> f32 {
     if !raw.is_finite() {
         return 0.0;
     }
-    if raw > 1.0 {
-        (raw / 100.0).clamp(0.0, 1.0)
-    } else {
-        raw.clamp(0.0, 1.0)
-    }
+    // The ChatGPT `wham/usage` endpoint (and equivalent OpenAI account usage
+    // endpoints) always reports `used_percent` as a value in `[0, 100]`. The
+    // previous implementation tried to auto-detect ratio-vs-percent based on
+    // `raw > 1.0`, which incorrectly mapped the legitimate response
+    // `used_percent: 1` (1% used) to a ratio of `1.0` (100% used). Treating
+    // the value as a percent unconditionally avoids that misclassification
+    // and matches the documented API contract.
+    (raw / 100.0).clamp(0.0, 1.0)
 }
 
 fn normalize_percent(raw: f32) -> f32 {


### PR DESCRIPTION
## Summary

`jcode usage` (and the inline `/usage` overlay) shows ChatGPT subscriptions
as fully rate-limited (`100% used`, exhausted bar) even when the live
`wham/usage` endpoint reports only a few percent consumed. The Codex
desktop app, which reads the same endpoint with the same OAuth token,
correctly shows the actual remaining quota.

## Root cause

Both `src/usage/openai_helpers.rs` and `src/usage_openai.rs` define a
`normalize_ratio` helper:

```rust
pub(super) fn normalize_ratio(raw: f32) -> f32 {
    if !raw.is_finite() { return 0.0; }
    if raw > 1.0 {
        (raw / 100.0).clamp(0.0, 1.0)
    } else {
        raw.clamp(0.0, 1.0)
    }
}
```

It tries to auto-detect whether the input is a ratio (`0..=1`) or a
percent (`0..=100`) using `raw > 1.0`. The OpenAI `wham/usage` endpoint
unambiguously returns `used_percent` in `[0, 100]`. A real production
payload with a barely-touched weekly bucket looks like:

```json
{
  "rate_limit": {
    "primary_window":  { "used_percent": 5, ... },
    "secondary_window":{ "used_percent": 1, ... }
  }
}
```

`used_percent: 1` (1% used) hits the `else` branch, clamps to `1.0`,
and is rendered as **100% used / fully exhausted** — even though the
user has 99% of their weekly Codex quota remaining.

The existing tests only exercise values like `25.0`, `50.0`, `75.0`,
`100.0`, so the bug never surfaced in CI.

## Fix

The wham/usage and OpenAI account-usage endpoints always report
percentages in `[0, 100]`. Drop the heuristic and just divide:

```rust
pub(super) fn normalize_ratio(raw: f32) -> f32 {
    if !raw.is_finite() { return 0.0; }
    (raw / 100.0).clamp(0.0, 1.0)
}
```

Applied to both `src/usage/openai_helpers.rs` and the legacy
`src/usage_openai.rs`.

## Tests

Added two tests in `src/usage/tests.rs`:

1. `test_normalize_ratio_treats_low_integer_values_as_percent` — direct
   unit coverage of the helper across `0`, `1`, `5`, `50`, `100`, plus
   `>100`, negative, and `NaN` inputs.
2. `test_parse_openai_usage_payload_reports_low_percentages_correctly` —
   regression test built from a real `wham/usage` payload with
   `used_percent: 1` in the secondary window. Asserts the parser
   returns `1.0`, not `100.0`.

All 33 `usage::tests::*` pass on `cargo test --release --lib`.

## Verification (live API)

Before patch:

```
OpenAI (ChatGPT) (k***9@gmail.com)
----------------------------------
5-hour window: █░░░░░░░░░░░░░░ 5% (resets in 3h 0m)
7-day window:  ███████████████ 100% (resets in 6d 22h)
GPT-5.3-Codex-Spark (5h): █░░░░░░░░░░░░░░ 5%
GPT-5.3-Codex-Spark (7d): ███████████████ 100%
```

After patch (same account, same `wham/usage` response, ~10 minutes later):

```
OpenAI (ChatGPT) (k***9@gmail.com)
----------------------------------
5-hour window: █░░░░░░░░░░░░░░ 5% (resets in 2h 26m)
7-day window:  ░░░░░░░░░░░░░░░ 1% (resets in 6d 21h)
GPT-5.3-Codex-Spark (5h): █░░░░░░░░░░░░░░ 5%
GPT-5.3-Codex-Spark (7d): ░░░░░░░░░░░░░░░ 1%
```

This now matches what the Codex desktop app shows for the same account.

## Impact

- `jcode usage`, the `/usage` overlay, and the info-widget compact usage
  bar all consume `normalize_ratio` via `parse_wham_window`, so all three
  now report correctly.
- Cross-provider failover heuristics that key off `usage_ratio` /
  `seven_day_ratio` previously assumed users were exhausted at 1% real
  usage; they now see the true value and stop spuriously failing over.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/1jehuang/codesmith/jcode/pr/178"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->