### PR TITLE
fix: remove unused TlsConnector in notify-email IMAP polling

### DIFF
--- a/crates/jcode-notify-email/Cargo.toml
+++ b/crates/jcode-notify-email/Cargo.toml
@@ -13,6 +13,5 @@ chrono = "0.4"
 imap = { version = "3.0.0-alpha.15", default-features = false, features = ["native-tls"] }
 lettre = { version = "0.11", default-features = false, features = ["tokio1-rustls-tls", "smtp-transport", "builder"] }
 mail-parser = "0.9"
-native-tls = "0.2"
 pulldown-cmark = "0.12"
 urlencoding = "2"

--- a/crates/jcode-notify-email/src/lib.rs
+++ b/crates/jcode-notify-email/src/lib.rs
@@ -63,7 +63,8 @@ pub async fn send_email(request: SendEmailRequest<'_>) -> Result<()> {
 }
 
 pub fn poll_imap_once(host: &str, port: u16, user: &str, pass: &str) -> Result<Vec<ReplyAction>> {
-    let _tls = native_tls::TlsConnector::builder().build()?;
+    // imap 3.0's ClientBuilder auto-detects TLS vs STARTTLS based on port
+    // (993 = implicit TLS, 143 = STARTTLS upgrade).
     let client = imap::ClientBuilder::new(host, port).connect()?;
     let mut session = client
         .login(user, pass)


### PR DESCRIPTION
## Summary

Remove unused code in the `jcode-notify-email` crate.

### What changed

`poll_imap_once` builds a `native_tls::TlsConnector` and assigns it to `_tls`, but the variable is never read. The `imap` 3.0 `ClientBuilder::connect()` already auto-detects TLS vs STARTTLS based on port number (993 = implicit TLS, 143 = STARTTLS upgrade), so the manual connector construction is dead code.

- Remove the unused `_tls` variable and add a brief comment explaining the auto-detection
- Remove the `native-tls` direct dependency from `Cargo.toml` (it is still pulled in transitively via the `imap` crate's `native-tls` feature flag)

### Why this matters
Unused `TlsConnector::builder().build()?` runs native TLS initialization on every poll cycle for no reason. The `?` also means a TLS init failure would abort the entire poll, even though the connector is never used for the connection. After this fix, a native-tls init failure can no longer incorrectly block IMAP polling.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/1jehuang/codesmith/jcode/pr/184"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->