### PR TITLE
Add native PR feedback watch tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ ios_simulator_screenshot.png
 /.wrangler/
 /tmp/
 /.jcode/generated-images/
+/.omc/
+/.playwright-mcp/

--- a/.jcode/pr-feedback-watch/ShawnSantiago-move-in-out-inpect-app-pr-25.json
+++ b/.jcode/pr-feedback-watch/ShawnSantiago-move-in-out-inpect-app-pr-25.json
@@ -1,0 +1,104 @@
+{
+  "canceled_at": "2026-05-04T20:24:24Z",
+  "consecutive_transient_failures": 0,
+  "cycle_number": 2,
+  "last_cycle": {
+    "actionable_count": 2,
+    "completed_at": "2026-05-04T20:14:48Z",
+    "status": "actionable_locally_fixed_waiting_for_write_approval",
+    "surfaces_checked": [
+      "review_threads",
+      "review_comments",
+      "issue_comments",
+      "reviews",
+      "timeline"
+    ],
+    "unresolved_thread_count": 2,
+    "verification": [
+      "cd /tmp/move-in-out-inpect-app-pr25/mobile && npm test -- --run src/screens/CreateInspectionScreen.test.tsx src/state/propertyUnitCatalog.test.ts (17 passed)",
+      "cd /tmp/move-in-out-inpect-app-pr25 && git diff --check (passed)"
+    ]
+  },
+  "last_seen_review_markers": {
+    "issue_comments": {
+      "4374108794": "2026-05-04T20:05:27Z"
+    },
+    "review_comments": {
+      "3183715059": "2026-05-04T18:43:54Z",
+      "3183726717": "2026-05-04T18:45:48Z",
+      "3183757116": "2026-05-04T18:50:46Z",
+      "3183757119": "2026-05-04T18:50:46Z",
+      "3183757122": "2026-05-04T18:50:46Z",
+      "3184046850": "2026-05-04T19:42:19Z",
+      "3184195125": "2026-05-04T20:09:18Z",
+      "3184195131": "2026-05-04T20:09:18Z"
+    },
+    "review_threads": {
+      "PRRT_kwDOSQE1Ec5_cHz3": "2026-05-04T18:43:54Z",
+      "PRRT_kwDOSQE1Ec5_cJ1i": "2026-05-04T18:45:48Z",
+      "PRRT_kwDOSQE1Ec5_cPIc": "2026-05-04T18:50:46Z",
+      "PRRT_kwDOSQE1Ec5_cPIf": "2026-05-04T18:50:46Z",
+      "PRRT_kwDOSQE1Ec5_cPIi": "2026-05-04T18:50:46Z",
+      "PRRT_kwDOSQE1Ec5_dDUt": "2026-05-04T19:42:19Z",
+      "PRRT_kwDOSQE1Ec5_deOG": "2026-05-04T20:09:18Z",
+      "PRRT_kwDOSQE1Ec5_deOM": "2026-05-04T20:09:18Z"
+    },
+    "reviews": {
+      "4222580922": "2026-05-04T18:43:54Z",
+      "4222594924": "2026-05-04T18:45:48Z",
+      "4222630161": "2026-05-04T18:50:45Z",
+      "4222956957": "2026-05-04T19:42:19Z",
+      "4223129257": "2026-05-04T20:09:18Z"
+    },
+    "timeline": {
+      "25148583790": "2026-05-04T20:05:29Z",
+      "4222580922": "",
+      "4222594924": "",
+      "4222630161": "",
+      "4222956957": "",
+      "4223129257": "",
+      "4374108794": "2026-05-04T20:05:27Z",
+      "https://github.com/ShawnSantiago/move-in-out-inpect-app/commit/5f01bee95969e6c1c5f2325d03e5c2cdfe3da89b": "",
+      "https://github.com/ShawnSantiago/move-in-out-inpect-app/commit/c162816c818cd8082e96447a229ab6ed8497aae6": "",
+      "https://github.com/ShawnSantiago/move-in-out-inpect-app/commit/da8f51b0f51456413551f5285e2c8c2ace8911cd": "",
+      "https://github.com/ShawnSantiago/move-in-out-inpect-app/commit/ee45a3c3f456768be9f505fa0e03599729bc41c6": ""
+    }
+  },
+  "lock": null,
+  "next_resume": null,
+  "pending_actionable": [
+    {
+      "local_fix_path": "/tmp/move-in-out-inpect-app-pr25",
+      "path": "mobile/src/screens/CreateInspectionScreen.tsx",
+      "status": "locally_fixed_verified_not_pushed",
+      "summary": "**<sub><sub>![P1 Badge](https://img.shields.io/badge/P1-orange?style=flat)</sub></sub>  Clear saved selection before continuing an in-progress edit**",
+      "thread_id": "PRRT_kwDOSQE1Ec5_deOG",
+      "url": "https://github.com/ShawnSantiago/move-in-out-inpect-app/pull/25#discussion_r3184195125"
+    },
+    {
+      "local_fix_path": "/tmp/move-in-out-inpect-app-pr25",
+      "path": "mobile/src/state/propertyUnitCatalog.ts",
+      "status": "locally_fixed_verified_not_pushed",
+      "summary": "**<sub><sub>![P2 Badge](https://img.shields.io/badge/P2-yellow?style=flat)</sub></sub>  Reject unit-label collisions when editing saved units**",
+      "thread_id": "PRRT_kwDOSQE1Ec5_deOM",
+      "url": "https://github.com/ShawnSantiago/move-in-out-inpect-app/pull/25#discussion_r3184195131"
+    }
+  ],
+  "pr": {
+    "number": 25,
+    "repo": "ShawnSantiago/move-in-out-inpect-app",
+    "url": "https://github.com/ShawnSantiago/move-in-out-inpect-app/pull/25"
+  },
+  "quiet_cycles": 0,
+  "schema_version": 1,
+  "stop_reason": "canceled_by_user_after_manual_validation_protocol",
+  "surface_last_successful_fetch": {
+    "issue_comments": "2026-05-04T20:14:48Z",
+    "review_comments": "2026-05-04T20:14:48Z",
+    "review_threads": "2026-05-04T20:14:48Z",
+    "reviews": "2026-05-04T20:14:48Z",
+    "timeline": "2026-05-04T20:14:48Z"
+  },
+  "terminal": true,
+  "write_authorized": false
+}

--- a/.jcode/skills/release-cto/SKILL.md
+++ b/.jcode/skills/release-cto/SKILL.md
@@ -1,0 +1,325 @@
+---
+name: release-cto
+description: Act as CTO/coordinator for this repo, staffing a multi-agent development department to plan, implement, review, integrate, and summarize the next release without merging dev to main.
+triggers:
+  - cto
+  - coordinator
+  - next release
+  - development department
+  - multi-agent release
+  - engineering manager
+  - release train
+argument-hint: "<release goal or theme>"
+---
+
+# Release CTO Skill
+
+## Purpose
+
+Run a disciplined, multi-agent release workflow for this repository. The active agent acts as CTO and creates a temporary development department for the next release: define the feature set, split it into engineering areas, spawn engineering-manager agents for each area, have managers create implementation plans, delegate scoped tasks to senior developer agents, require isolated branches/worktrees, require tests and gates, require manager review before integration, integrate approved work into `dev`, monitor CI, and produce a final release summary.
+
+**Hard rule:** Do not merge `dev` to `main`/`master` or push a production release without explicit user approval.
+
+## When to Activate
+
+Use this skill when the user asks for any of:
+
+- "Act as CTO", "be the coordinator", "run the next release", or "create a development department".
+- A broad release composed of multiple features or engineering areas.
+- Multi-agent planning/implementation/review/integration with managers and developers.
+- A release process that must preserve branches, worktrees, tests, reviews, and CI evidence.
+
+Do not use this skill for a one-file bug fix, one-off explanation, or read-only analysis unless the user explicitly requests CTO-style coordination.
+
+## Operating Principles
+
+- **CTO owns scope, sequencing, risk, integration, and user communication.**
+- **Engineering managers own area plans and review developer work before integration.**
+- **Senior developers own scoped implementation tasks in isolated branch/worktree contexts.**
+- **No direct commits to `main`/`master`.** Use `dev` as the integration branch.
+- **Every implementation task requires tests and relevant gates.** If a gate cannot run, the developer must explain why and provide the best substitute evidence.
+- **Review before integration is mandatory.** Manager approval is required before the CTO integrates a developer branch into `dev`.
+- **Keep progress visible.** Use `todo`, `goal`, `memory`, `swarm`, background tasks, and concise progress updates.
+- **Prefer reversible changes.** Ask before destructive operations, production deploys, releases, or merges from `dev` into `main`/`master`.
+
+## Required Tools and State
+
+Use these tools proactively:
+
+- `goal`: create and track a release goal with milestones for discovery, planning, implementation, review, integration, CI, and final summary.
+- `todo`: maintain visible CTO-level task state.
+- `memory`: remember durable repo/release decisions, branch names, conventions, and constraints.
+- `swarm`: spawn/coordinate engineering managers and senior developers when native multi-agent coordination is available.
+- `bash`: inspect git status, create branches/worktrees, run tests/build/lint, and monitor local gates.
+- `schedule`: if external CI takes time, schedule a follow-up check instead of abandoning monitoring.
+- `agentgrep`, `read`, `ls`, `glob`: ground scope in repository facts before assigning work.
+
+If a tool is unavailable, continue with the closest safe equivalent and document the limitation.
+
+## Branch and Worktree Policy
+
+1. Determine integration branch:
+   - Prefer existing `dev`.
+   - If absent and safe, create `dev` from current default branch.
+   - Never merge `dev` to `main`/`master` without explicit user approval.
+2. Each developer task gets a unique branch:
+   - Format: `release/<release-slug>/<area-slug>-<task-slug>` or similar.
+3. Each developer works in an isolated worktree:
+   - Format: `.worktrees/<branch-slug>` or repo-local convention.
+   - Verify with `git worktree list`.
+4. Developer branches merge into `dev` only after manager review approval and passing gates.
+5. The CTO integrates approved work into `dev` with clear merge commits or an agreed strategy.
+6. Never delete worktrees/branches unless safe and clearly no longer needed; ask if uncertain.
+
+## Workflow
+
+### Phase 0 - CTO Intake and Repository Grounding
+
+1. Read the user request carefully and extract:
+   - release theme/objective
+   - must-have features
+   - explicit exclusions
+   - risk constraints
+   - deadline or quality bar if provided
+2. Inspect repository structure and current state:
+   - `git status --short --branch`
+   - `git branch --list`
+   - project docs such as `README`, `AGENTS.md`, `package.json`, lockfiles, CI configs, test scripts, app directories
+3. Create a release context note under `.omx/context/` or equivalent if useful:
+   - task statement
+   - known repo facts
+   - likely engineering areas
+   - risks/open questions
+   - branch/worktree conventions
+4. Create a `goal` for the release and seed CTO `todo` items.
+5. Remember durable constraints with `memory`, especially: "Do not merge dev to main without explicit approval."
+
+### Phase 1 - Define Feature Set and Engineering Areas
+
+1. Propose a concrete feature set for the next release based on repo context and user intent.
+2. Split the release into coherent engineering areas, for example:
+   - Backend/API
+   - Frontend/UI
+   - Data/model/migrations
+   - AI/agent orchestration
+   - DevEx/CI/release tooling
+   - QA/security/performance
+3. For each area define:
+   - scope
+   - non-goals
+   - impacted files/modules
+   - test expectations
+   - acceptance criteria
+   - dependencies on other areas
+4. If scope is materially ambiguous, make the best safe assumption, state it, and continue unless it would cause irreversible or high-risk changes.
+
+### Phase 2 - Spawn Engineering Managers
+
+Use `swarm spawn` or equivalent to create one engineering-manager agent per area.
+
+Manager prompt template:
+
+```text
+You are the Engineering Manager for <area> in this repo's next release.
+
+Context:
+- Release goal: <goal>
+- Area scope: <scope>
+- Non-goals: <non-goals>
+- Integration branch: dev
+- Hard rule: do not merge dev to main/master.
+
+Your tasks:
+1. Inspect relevant repo files.
+2. Create an implementation plan for your area with scoped senior-developer tasks.
+3. For each task define branch/worktree name, acceptance criteria, required tests/gates, and review checklist.
+4. Identify dependencies and risks.
+5. Report the plan to the CTO. Do not implement directly unless explicitly assigned.
+```
+
+Require each manager to return a plan before developer work starts.
+
+### Phase 3 - Manager Plan Review and Release Plan Assembly
+
+1. CTO reviews manager plans for overlap, gaps, conflicts, test coverage, and integration order.
+2. Resolve cross-area dependencies.
+3. Build a release task graph:
+   - independent tasks can run in parallel
+   - dependent tasks wait for prerequisites
+4. Update `goal` milestones and `todo` with accepted tasks.
+5. If needed, ask managers to revise plans before spawning developers.
+
+### Phase 4 - Delegate to Senior Developer Agents
+
+For each approved scoped task, spawn a senior developer agent. Prefer one task per developer.
+
+Developer prompt template:
+
+```text
+You are a Senior Developer assigned to <task> for the next release.
+
+You must work in isolation:
+- Base branch: dev
+- Task branch: <branch>
+- Worktree path: <worktree>
+
+Instructions:
+1. Create or verify your isolated branch/worktree before editing.
+2. Inspect relevant files and confirm the implementation approach.
+3. Implement only your scoped task.
+4. Add or update tests for the behavior you change.
+5. Run relevant gates, such as unit tests, integration tests, typecheck, lint, build, or targeted scripts.
+6. Commit your changes on your task branch with a clear message.
+7. Report back with:
+   - summary of changes
+   - files changed
+   - tests/gates run with pass/fail output
+   - known risks or follow-ups
+   - branch and commit SHA
+
+Do not merge into dev. Do not touch main/master. Do not perform destructive operations.
+```
+
+### Phase 5 - Engineering Manager Review
+
+After each developer reports completion:
+
+1. Assign the relevant manager to review the developer branch.
+2. Manager must inspect diff, tests, and acceptance criteria.
+3. Manager review outcomes:
+   - `APPROVED`: ready for CTO integration into `dev`.
+   - `CHANGES_REQUESTED`: developer must revise in same branch/worktree.
+   - `BLOCKED`: CTO resolves dependency/scope issue.
+4. CTO must not integrate unapproved branches.
+
+Manager review prompt template:
+
+```text
+Review developer branch <branch> for <task>.
+
+Check:
+- scope adherence
+- correctness and maintainability
+- tests and gate evidence
+- regressions or conflicts
+- security/performance concerns where relevant
+
+Return one of APPROVED, CHANGES_REQUESTED, or BLOCKED with concrete findings.
+Do not merge into dev yourself unless explicitly assigned by CTO.
+```
+
+### Phase 6 - CTO Integration into `dev`
+
+For each approved branch:
+
+1. Ensure local tree is clean or only contains known CTO changes.
+2. Checkout/update `dev`.
+3. Merge or cherry-pick the approved branch using the chosen release strategy.
+4. Resolve conflicts carefully, ideally involving the manager/developer if conflict semantics are non-trivial.
+5. Run relevant integration gates after each merge or after a safe batch.
+6. Commit integration conflict resolutions if needed.
+7. Update `goal`, `todo`, and memory with integration status.
+
+Recommended local commands, adapted to repo conventions:
+
+```bash
+git status --short --branch
+git checkout dev
+git pull --ff-only || true
+git merge --no-ff <approved-branch>
+# run relevant gates
+```
+
+Do not push or merge to `main`/`master` unless explicitly approved.
+
+### Phase 7 - CI Monitoring and Release Hardening
+
+1. Run local release gates from repo scripts, for example:
+   - tests
+   - typecheck
+   - lint
+   - build
+   - migrations checks
+   - e2e or integration tests where configured
+2. If GitHub/GitLab CI exists and remote push/PR is appropriate:
+   - push `dev` or create/update release PR only if safe and consistent with repo workflow.
+   - monitor CI using available tools.
+3. If CI is asynchronous, use `schedule` to re-check.
+4. On CI failure:
+   - classify failure by area
+   - assign fix to responsible manager/developer or create a new senior developer task
+   - repeat review and integration.
+
+### Phase 8 - Final Release Summary
+
+Produce a concise final summary including:
+
+- release goal and feature set
+- engineering areas staffed
+- branches/worktrees used
+- commits integrated into `dev`
+- tests/gates run and results
+- CI status
+- known risks/follow-ups
+- artifacts/docs updated
+- explicit note: `dev` has not been merged to `main`/`master`
+- exact next steps requiring user approval, especially merge/release/deploy actions
+
+## CTO Progress Updates
+
+Keep user-facing updates concise and evidence-based:
+
+- "Created release goal and split scope into N areas."
+- "Managers are planning Backend, Frontend, and QA lanes."
+- "Developer branches A/B/C are in progress in isolated worktrees."
+- "Backend branch approved by manager and integrated into dev; targeted tests passed."
+- "CI is still running; scheduled follow-up check."
+
+Avoid dumping raw logs unless necessary. Include failing command names and key error lines when relevant.
+
+## Review Checklist
+
+Before any branch enters `dev`:
+
+- [ ] Developer worked on isolated branch/worktree.
+- [ ] Scope matches assigned task.
+- [ ] Tests were added or updated where behavior changed.
+- [ ] Relevant gates ran and passed, or limitations are documented.
+- [ ] Manager reviewed the diff and returned `APPROVED`.
+- [ ] Integration risks and dependencies are known.
+
+Before final summary:
+
+- [ ] All approved work integrated into `dev`.
+- [ ] Local gates passed or failures are clearly documented.
+- [ ] CI status checked or scheduled for follow-up.
+- [ ] Release notes/final summary produced.
+- [ ] No merge from `dev` to `main`/`master` occurred without explicit approval.
+
+## Stop and Ask Conditions
+
+Stop and ask the user before:
+
+- merging `dev` into `main`/`master`
+- pushing to a protected/shared branch if repo policy is unknown and push could surprise the user
+- deploying, publishing, tagging a production release, or completing payments
+- deleting branches/worktrees with unmerged work
+- applying destructive migrations or data operations
+- accepting a scope tradeoff that drops a user-stated must-have
+
+## Example Invocation
+
+```text
+/release-cto Prepare the next release focused on improving analytics, assistant reliability, and CI hardening.
+```
+
+Expected behavior:
+
+1. CTO inspects repo and creates release goal.
+2. CTO defines feature set and areas.
+3. CTO spawns engineering managers for analytics, assistant, and CI/QA.
+4. Managers produce plans and scoped developer tasks.
+5. Senior developers implement on isolated branches/worktrees with tests.
+6. Managers review branches.
+7. CTO integrates approved branches into `dev` and monitors gates.
+8. CTO summarizes release readiness and waits for explicit approval before any `dev` to `main` merge.

--- a/.omx/artifacts/claude-jcode-omx-workflows-plan-review-20260504T174844Z.md
+++ b/.omx/artifacts/claude-jcode-omx-workflows-plan-review-20260504T174844Z.md
@@ -1,0 +1,63 @@
+# Claude Review: Jcode OMX-style workflow plan
+
+## Original user task
+Can you have claude review the plan
+
+## Final prompt sent to Claude CLI
+```text
+You are reviewing an implementation plan for adding OMX-style workflow modes to Jcode, an open-source Rust agent harness. Please perform a rigorous architecture review.
+
+Context:
+- Jcode already has native skills, subagents, swarm/session orchestration, background tasks, and TUI widgets.
+- OMX has prompt-side workflows: ultrawork (parallel execution protocol), ralph (persistent completion loop), ralplan (Planner -> Architect -> Critic consensus planning), plus omx team as tmux worker runtime.
+- The proposed Jcode design intentionally uses native Jcode swarm/session runtime instead of tmux.
+
+Plan to review:
+
+Goal: Add OMX-style workflow modes to Jcode:
+- /ulw / /ultrawork: native parallel execution protocol
+- /ralph: persistent completion loop with verification gates
+- /ralplan: Planner → Architect → Critic consensus planning
+- Optional CLI entrypoints later, but first implement prompt/skill-native behavior
+
+Key principle: use Jcode’s native swarm/session/background runtime, not tmux.
+
+Phase 1: Workflow mode state
+Add durable workflow state under .jcode/state/workflows/{ralph,ralplan,ultrawork}.json. State includes mode, active, phase, iteration, max_iterations, task, session_id, timestamps, verification, agents.
+Acceptance: start/update/complete/cancel workflow state, survives restart/compaction, UI/swarm widgets can read active mode.
+Likely files: src/skill.rs, src/tool/skill.rs, src/server/swarm*.rs, new src/workflow_mode.rs.
+
+Phase 2: Keyword and skill activation
+Support /ralph, /ralplan, /ulw, /ultrawork, ralph, ulw, don't stop, must complete, consensus plan. Activation detects workflow, seeds state, loads skill instructions, injects mode reminder into active turn. Prompt-side /ralph does not spawn new session automatically. /ulw spawns only when independent lanes are identified. /ralplan plans, not edits.
+
+Phase 3: Ultrawork native implementation
+Ground task, define acceptance criteria, split independent lanes, use native Jcode swarm/subagent only where parallelism helps, keep shared-file edits local, run lightweight verification.
+
+Phase 4: Ralplan consensus planning
+Planner draft -> Architect review -> Critic review -> revise until approval/max iterations. Architect and Critic sequential. Output .jcode/plans/<slug>.md/json with scope, non-goals, implementation steps, risks, acceptance criteria, test plan, recommended execution mode, suggested lanes.
+
+Phase 5: Ralph persistent completion loop
+Seed state, track TODOs, execute until done, spawn helpers when useful, run required verification, run reviewer/architect check, prevent premature completion if gates fail. Ralph can finish only when all TODOs complete, verification commands pass, changed files reviewed, no active spawned agents remain, final evidence recorded.
+
+Phase 6: Stop/completion gates
+Native stop checks in Jcode's turn loop. If Ralph active and incomplete, continue/remind. Ultrawork has weaker gate: require lightweight evidence. Ralplan requires plan artifact and critic verdict.
+
+Phase 7: UI/status integration
+Show active workflow in TUI/statusline and link spawned agents to workflow.
+
+Phase 8: Optional CLI entrypoints
+jcode ralph/ralplan/ultrawork start new sessions with state pre-seeded.
+
+Recommended order: state module, skill docs, activation plumbing, ultrawork, ralplan, ralph, UI, CLI.
+MVP: state model, /ulw, /ralplan, /ralph, prompt-side activation, status display, no hard stop hooks. Second PR: Ralph gates, spawned-agent tracking, plan artifacts, reviewer verification loop.
+
+Review request:
+1. Identify architectural risks, hidden complexity, and likely integration points missing from the plan.
+2. Recommend changes to phase order and MVP boundaries.
+3. Propose specific acceptance tests, unit/integration/e2e.
+4. Point out where the plan may conflict with Jcode-native behavior or user expectations.
+5. Return a severity-ranked review: blockers, high priority, medium priority, nice-to-have.
+```
+
+## Claude output (raw)
+

--- a/.omx/artifacts/claude-jcode-omx-workflows-plan-review-20260504T174907Z.md
+++ b/.omx/artifacts/claude-jcode-omx-workflows-plan-review-20260504T174907Z.md
@@ -1,0 +1,37 @@
+# Claude Review: Jcode OMX-style workflow plan
+
+## Original user task
+Can you have claude review the plan
+
+## Final prompt sent to Claude CLI
+```text
+You are reviewing an implementation plan for adding OMX-style workflow modes to Jcode, an open-source Rust agent harness. Please perform a rigorous architecture review.
+
+Context:
+- Jcode already has native skills, subagents, swarm/session orchestration, background tasks, and TUI widgets.
+- OMX has prompt-side workflows: ultrawork (parallel execution protocol), ralph (persistent completion loop), ralplan (Planner -> Architect -> Critic consensus planning), plus omx team as tmux worker runtime.
+- The proposed Jcode design intentionally uses native Jcode swarm/session runtime instead of tmux.
+
+Plan to review:
+Goal: Add OMX-style workflow modes to Jcode: /ulw / /ultrawork, /ralph, /ralplan. Use Jcode native swarm/session/background runtime, not tmux.
+
+Phase 1: Workflow mode state under .jcode/state/workflows/{ralph,ralplan,ultrawork}.json with mode, active, phase, iteration, task, session_id, verification, agents.
+Phase 2: Keyword and skill activation for /ralph, /ralplan, /ulw, ralph, ulw, don't stop, must complete, consensus plan. Activation seeds state, loads skill instructions, injects reminder. Prompt-side /ralph does not spawn new session automatically.
+Phase 3: Ultrawork grounds task, defines acceptance criteria, splits independent lanes, uses native swarm/subagent only where helpful, keeps shared-file edits local, lightweight verification.
+Phase 4: Ralplan: Planner draft -> Architect review -> Critic review -> revise until approval/max iterations. Architect and Critic sequential. Output .jcode/plans/<slug>.md/json with scope, non-goals, steps, risks, acceptance criteria, test plan, recommended execution mode, suggested lanes.
+Phase 5: Ralph: persistent completion loop, TODO tracking, execution, helper agents, verification, reviewer/architect check, prevent premature completion. Finish only when TODOs complete, verification passes, changed files reviewed, no active spawned agents, final evidence recorded.
+Phase 6: Stop/completion gates in Jcode turn loop.
+Phase 7: UI/status integration.
+Phase 8: Optional CLI entrypoints.
+MVP: state model, /ulw, /ralplan, /ralph, prompt-side activation, status display, no hard stop hooks. Second PR: Ralph gates, spawned-agent tracking, plan artifacts, reviewer verification loop.
+
+Review request:
+1. Identify architectural risks, hidden complexity, and missing integration points.
+2. Recommend phase order and MVP boundary changes.
+3. Propose unit/integration/e2e acceptance tests.
+4. Point out conflicts with Jcode-native behavior or user expectations.
+5. Return severity-ranked review: blockers, high priority, medium priority, nice-to-have.
+```
+
+## Claude output (raw)
+

--- a/.omx/artifacts/claude-jcode-omx-workflows-plan-review-20260504T175439Z.md
+++ b/.omx/artifacts/claude-jcode-omx-workflows-plan-review-20260504T175439Z.md
@@ -1,0 +1,243 @@
+# Claude Review: Jcode OMX-style workflow plan
+
+## Original user task
+Can you have claude review the plan
+
+## Final prompt sent to Claude CLI
+```text
+You are reviewing an implementation plan for adding OMX-style workflow modes to Jcode, an open-source Rust agent harness. Please perform a rigorous architecture review.
+
+Context:
+- Jcode already has native skills, subagents, swarm/session orchestration, background tasks, and TUI widgets.
+- OMX has prompt-side workflows: ultrawork (parallel execution protocol), ralph (persistent completion loop), ralplan (Planner -> Architect -> Critic consensus planning), plus omx team as tmux worker runtime.
+- The proposed Jcode design intentionally uses native Jcode swarm/session runtime instead of tmux.
+
+Plan to review:
+Goal: Add OMX-style workflow modes to Jcode: /ulw / /ultrawork, /ralph, /ralplan. Use Jcode native swarm/session/background runtime, not tmux.
+
+Phase 1: Workflow mode state under .jcode/state/workflows/{ralph,ralplan,ultrawork}.json with mode, active, phase, iteration, task, session_id, verification, agents.
+Phase 2: Keyword and skill activation for /ralph, /ralplan, /ulw, ralph, ulw, don't stop, must complete, consensus plan. Activation seeds state, loads skill instructions, injects reminder. Prompt-side /ralph does not spawn new session automatically.
+Phase 3: Ultrawork grounds task, defines acceptance criteria, splits independent lanes, uses native swarm/subagent only where helpful, keeps shared-file edits local, lightweight verification.
+Phase 4: Ralplan: Planner draft -> Architect review -> Critic review -> revise until approval/max iterations. Architect and Critic sequential. Output .jcode/plans/<slug>.md/json with scope, non-goals, steps, risks, acceptance criteria, test plan, recommended execution mode, suggested lanes.
+Phase 5: Ralph: persistent completion loop, TODO tracking, execution, helper agents, verification, reviewer/architect check, prevent premature completion. Finish only when TODOs complete, verification passes, changed files reviewed, no active spawned agents, final evidence recorded.
+Phase 6: Stop/completion gates in Jcode turn loop.
+Phase 7: UI/status integration.
+Phase 8: Optional CLI entrypoints.
+MVP: state model, /ulw, /ralplan, /ralph, prompt-side activation, status display, no hard stop hooks. Second PR: Ralph gates, spawned-agent tracking, plan artifacts, reviewer verification loop.
+
+Review request:
+1. Identify architectural risks, hidden complexity, and missing integration points.
+2. Recommend phase order and MVP boundary changes.
+3. Propose unit/integration/e2e acceptance tests.
+4. Point out conflicts with Jcode-native behavior or user expectations.
+5. Return severity-ranked review: blockers, high priority, medium priority, nice-to-have.
+```
+
+## Claude output (raw)
+
+The prior review artifacts at `.omx/artifacts/` are empty stubs (37 and 63 lines, just the prompt header), so this is a clean review. Here is my critique grounded in the actual jcode workspace.
+
+---
+
+# Architecture Review: OMX-style Workflow Modes for Jcode
+
+## Summary
+The plan ports OMX's prompt-side workflows but treats jcode as if it were Claude Code — a generic harness with a filesystem and a CLI. It is not. Jcode is a 35-crate Rust workspace with strongly typed primitives that already cover most of what the plan re-implements ad hoc:
+
+- **`jcode-plan::PlanItem`** already has `id`, `status`, `blocked_by`, `assigned_to`, `file_scope`, `subsystem`, plus `summarize_plan_graph` (ready/blocked/active/cycle), `next_runnable_item_ids`, and `newly_ready_item_ids`. This *is* a Ralph executor's task graph.
+- **`jcode-task-types::Goal`** has `milestones`, `success_criteria`, `status` (Active/Blocked/Completed), `blockers`, `current_milestone_id`, `progress_percent`. This *is* a Ralph completion model.
+- **`jcode-agent-runtime`** exposes `SoftInterruptQueue`, `InterruptSignal`, `GracefulShutdownSignal`, `BackgroundToolSignal`. These *are* the stop/completion gates for Phase 6.
+- **`jcode-background-types::BackgroundTaskStatus`** with `{Running, Completed, Superseded, Failed}` *is* the spawned-agent tracking signal for "no active agents" gate.
+
+The plan never names these. That is the central risk: it invents a parallel state system in `.jcode/state/workflows/*.json` that drifts from the typed runtime instead of plugging into it.
+
+---
+
+## Severity-ranked findings
+
+### 🔴 Blockers (must resolve before MVP)
+
+**B1. Plan does not specify which crate(s) own this code.**
+35 crates, no `jcode-workflow` or `jcode-skill` crate visible, and `jcode-core` has no skill-related symbols (grep confirms). Without this, Phase 1 reviewers cannot say yes/no to anything. **Action:** decide between (a) new `jcode-workflow` crate that depends on `jcode-plan` + `jcode-task-types` + `jcode-agent-runtime`, or (b) a `workflow` module inside `jcode-agent-runtime`. State this explicitly.
+
+**B2. Reinventing the plan graph.**
+Phase 4 outputs `.jcode/plans/<slug>.md/json` with "scope, non-goals, steps, risks, acceptance criteria, test plan, recommended execution mode, suggested lanes." Phase 5 has Ralph track TODOs separately. But `jcode-plan::PlanItem` + `summarize_plan_graph` already model exactly this, with cycle detection and ready/blocked queues already tested. **Action:** ralplan output should serialize as `Vec<PlanItem>` (with extra `acceptance_criteria` / `risks` fields added if needed), and Ralph's TODO tracker should be the same struct — not a parallel "todos" list.
+
+**B3. Stop/completion gates without naming the existing primitives.**
+Phase 6 says "stop/completion gates in Jcode turn loop." But the turn loop already integrates `InterruptSignal`, `SoftInterruptQueue`, `GracefulShutdownSignal`. Ralph's "do not stop until verification passes" must be implemented as a *suppression rule* on these signals (e.g., consume `GracefulShutdownSignal` only if `Ralph::is_complete()` returns true), not a new gate. Otherwise Ctrl-C behavior diverges from user expectation and silently breaks. **Action:** spec the exact signal interaction in Phase 6 *before* shipping the prompt-side activation in MVP, because activation without a defined stop semantics ships a footgun.
+
+**B4. "No active spawned agents" gate is undefined.**
+Ralph's completion criterion includes "no active spawned agents." Jcode tracks `BackgroundTaskStatus` per task and has session/swarm runtime — but the plan doesn't say *which* enumeration counts. Subagent? Background task? Swarm session child? Each has different lifecycle. **Action:** define "active" as a query against a specific source of truth (likely `BackgroundTaskStatus::Running` filtered by session_id), and write that query first.
+
+---
+
+### 🟠 High priority
+
+**H1. State files in `.jcode/state/workflows/*.json` will desync from the session.**
+Three separate JSON files for ralph/ralplan/ultrawork, each with `session_id`, `phase`, `iteration`, `agents`. There is no transactional model with the session store, no schema versioning, no migration story, and crash recovery semantics aren't specified. If a session crashes mid-iteration, what happens on next launch? **Action:** either (a) put workflow state inside the session store (as a `WorkflowState` field on session record) or (b) use atomic-write + schema_version + a documented "stale state" detection rule.
+
+**H2. Mode mutual exclusion / composition is undefined.**
+Can `/ralph` and `/ulw` be active at once? Can `/ralph` invoke ralplan internally for re-planning? OMX allows this composition; the plan has three independent state files implying yes, but with no precedence rules. **Action:** define a single `WorkflowMode` enum with explicit composition rules, or document "at most one active at a time."
+
+**H3. Skill activation pathway is hand-waved.**
+"Activation seeds state, loads skill instructions, injects reminder." Where does the injection happen — system prompt prefix, tool-result reminder, separate channel? Jcode's skills (`.jcode/skills/<name>/SKILL.md`) currently load via what mechanism? Phase 2 needs to point at the existing skill loader and say "we add a `WorkflowSkill` variant" or similar. Without that, the MVP can't be reviewed.
+
+**H4. Ralplan's Architect→Critic loop has no termination guarantee.**
+"Revise until approval/max iterations." If Critic never approves, do we ship the last draft or fail? What does the user see during the loop — silent agents or streamed deltas? In a TUI this matters. **Action:** define max_iterations default (suggest 3), explicit "approved with caveats" exit, and per-iteration TUI status update.
+
+**H5. Keyword activation list is dangerous.**
+"don't stop", "must complete", "consensus plan" as activation triggers will fire on innocent prose ("I don't stop the build before tests" → ralph mode). **Action:** require either a leading slash command OR a high-confidence keyword (e.g., bare "ralph" alone, or quoted phrase). At minimum, log when keyword activation fires so users can see why their mode flipped.
+
+**H6. Verification pipeline isn't specified.**
+"Verification passes" is the gate for Ralph completion, but the plan doesn't say what verifies. `cargo test`? Project-detected? User-supplied? `jcode-config-types` may have a verify hook — this needs to be wired explicitly. Without it, Ralph either over-runs or never completes.
+
+---
+
+### 🟡 Medium priority
+
+**M1. MVP boundary is wrong.** Shipping `/ralph` in MVP without "hard stop hooks" means MVP Ralph can be Ctrl-C'd out trivially, which makes it effectively a no-op vs. just running the underlying work without a mode. Ship `/ralplan` + `/ulw` in MVP (both are bounded operations that complete naturally) and defer all of `/ralph` to PR 2 with the gates. The current MVP/PR2 split puts the dangerous part first and the safety rail second.
+
+**M2. Suggested phase reorder:**
+1. Workflow crate skeleton + `WorkflowState` integrated into session store (replaces Phase 1).
+2. Skill activation API extension + keyword guard rules (Phase 2, but with H5 fix).
+3. `/ralplan` end-to-end emitting `Vec<PlanItem>` into `jcode-plan` (Phase 4, ahead of others; produces test fixtures everyone else needs).
+4. `/ulw` consuming a plan (Phase 3).
+5. UI/status (Phase 7, before Ralph so Ralph is observable).
+6. Ralph: gates first, loop second (Phases 5+6 inverted).
+7. CLI entrypoints (Phase 8, last).
+
+**M3. "Lightweight verification" in ultrawork is ambiguous.** Define it: "after each lane, run `cargo check -p <crate>` if file_scope is bounded to one crate, else skip." Otherwise different reviewers will assume different things.
+
+**M4. TUI integration risk.** Phase 7 is "optional" in the plan but a workflow that runs many iterations without visible state is a UX disaster. Promote to non-optional and define the widget contract before Phase 5.
+
+**M5. No persona / model routing story.** OMX uses different personas/models per role (Planner/Architect/Critic). Jcode has multiple providers — the plan should say whether ralplan roles route to different models or all use the active one. This affects cost and quality.
+
+**M6. Ralplan output dual format (`.md/json`) doubles maintenance.** Pick one as canonical (json, since it round-trips through `PlanItem`) and render markdown on demand.
+
+---
+
+### 🟢 Nice-to-have
+
+- **N1.** Add a `--dry-run` flag to all three modes that prints the activation effect without mutating state — useful for tests and for the keyword-collision concern (H5).
+- **N2.** Telemetry: emit a `workflow.activated`, `workflow.iteration`, `workflow.completed` event series so the existing `0005_workflow_turn_telemetry.sql` migration can be reused.
+- **N3.** A `/workflow status` slash command for users to see which modes are active and inspect state, instead of grepping JSON.
+- **N4.** Document the failure mode where a Ralph session is force-killed and the JSON state says "active" forever — provide a `jcode workflow reset` escape hatch.
+
+---
+
+## Acceptance tests
+
+### Unit
+- `WorkflowState` round-trips through serde for each variant; unknown fields preserved.
+- Keyword activator: positive set fires on `/ralph`, `ralph`, `must complete`; negative set does not fire on "I won't stop here", "the must-complete list".
+- Ralplan termination: convergence within `max_iterations`, fall-through behavior, "approved with caveats" path.
+- Ralph completion gate: returns false if any of {todos open, verification not run, verification failed, active background tasks > 0, unreviewed changed files}.
+- Stop signal interaction: `GracefulShutdownSignal` raised during Ralph → Ralph emits "completion blocked: <reason>" then yields if user re-signals within N seconds (escape hatch).
+
+### Integration
+- `/ralplan "add caching to API"` produces `Vec<PlanItem>` that passes `summarize_plan_graph` with no cycles and at least one ready item.
+- `/ulw <plan>` executes lanes respecting `blocked_by`, never runs two items with overlapping `file_scope` concurrently.
+- Activation seeds state file atomically (kill mid-write → next launch detects partial write and recovers).
+- Mode composition: starting `/ralph` while `/ulw` active either rejects or composes per the rule decided in H2.
+- Ralph + real cargo failure: Ralph re-iterates and eventually gives up at iteration cap with clear final status.
+
+### E2E
+- TUI snapshot test: status widget shows mode, phase, iteration, current_milestone, ready/blocked counts, age.
+- A scripted run of `/ralplan → /ulw → ralph` on a synthetic repo completes in bounded time and the resulting commits match the plan's acceptance criteria.
+- Crash-resume: kill the process during ralplan iteration 2, restart, verify state recovers or is flagged stale.
+
+---
+
+## Conflicts with jcode-native behavior
+
+1. **Stop semantics.** Users on `Ctrl-C` expect to interrupt. Ralph's "don't stop" silently overrides this. Must be visible in TUI and overridable with double-Ctrl-C.
+2. **Plan ownership.** `jcode-plan` already is the swarm plan. Adding `.jcode/plans/<slug>.json` as a parallel concept will confuse anyone touching swarm code.
+3. **Goal ownership.** `jcode-task-types::Goal` is the persistent goal. Ralph's "task" should be a `Goal` reference, not a free-text string in a JSON file — otherwise the "completion" notion drifts from the rest of the harness.
+4. **Skill loading.** `.jcode/skills/<name>/SKILL.md` is the existing convention. Workflows should be skills, not a parallel "workflow" concept, unless there's a specific reason (state machine? gates?) — and that reason should be in the plan.
+
+---
+
+## Bottom line
+The plan's intent (use native runtime, avoid tmux) is right. The execution conflates "OMX-style prompts" with "OMX-style state model" and bypasses jcode's typed primitives. **Before MVP merges**, the team should rewrite Phase 1 + Phase 4 to consume `jcode-plan` and `jcode-task-types` directly, name the owning crate, and pin down the stop-signal interaction. Then ship `/ralplan` and `/ulw` first, defer `/ralph` to a follow-up PR where the gates are the centerpiece.
+
+## Concise summary
+The prior review artifacts at `.omx/artifacts/` are empty stubs (37 and 63 lines, just the prompt header), so this is a clean review. Here is my critique grounded in the actual jcode workspace.
+
+---
+
+# Architecture Review: OMX-style Workflow Modes for Jcode
+
+## Summary
+The plan ports OMX's prompt-side workflows but treats jcode as if it were Claude Code — a generic harness with a filesystem and a CLI. It is not. Jcode is a 35-crate Rust workspace with strongly typed primitives that already cover most of what the plan re-implements ad hoc:
+
+- **`jcode-plan::PlanItem`** already has `id`, `status`, `blocked_by`, `assigned_to`, `file_scope`, `subsystem`, plus `summarize_plan_graph` (ready/blocked/active/cycle), `next_runnable_item_ids`, and `newly_ready_item_ids`. This *is* a Ralph executor's task graph.
+- **`jcode-task-types::Goal`** has `milestones`, `success_criteria`, `status` (Active/Blocked/Completed), `blockers`, `current_milestone_id`, `progress_percent`. This *is* a Ralph completion model.
+- **`jcode-agent-runtime`** exposes `SoftInterruptQueue`, `InterruptSignal`, `GracefulShutdownSignal`, `BackgroundToolSignal`. These *are* the stop/completion gates for Phase 6.
+- **`jcode-background-types::BackgroundTaskStatus`** with `{Running, Completed, Superseded, Failed}` *is* the spawned-agent tracking signal for "no active agents" gate.
+
+The plan never names these. That is the central risk: it invents a parallel state system in `.jcode/state/workflows/*.json` that drifts from the typed runtime instead of plugging into it.
+
+---
+
+## Severity-ranked findings
+
+### 🔴 Blockers (must resolve before MVP)
+
+**B1. Plan does not specify which crate(s) own this code.**
+35 crates, no `jcode-workflow` or `jcode-skill` crate visible, and `jcode-core` has no skill-related symbols (grep confirms). Without this, Phase 1 reviewers cannot say yes/no to anything. **Action:** decide between (a) new `jcode-workflow` crate that depends on `jcode-plan` + `jcode-task-types` + `jcode-agent-runtime`, or (b) a `workflow` module inside `jcode-agent-runtime`. State this explicitly.
+
+**B2. Reinventing the plan graph.**
+Phase 4 outputs `.jcode/plans/<slug>.md/json` with "scope, non-goals, steps, risks, acceptance criteria, test plan, recommended execution mode, suggested lanes." Phase 5 has Ralph track TODOs separately. But `jcode-plan::PlanItem` + `summarize_plan_graph` already model exactly this, with cycle detection and ready/blocked queues already tested. **Action:** ralplan output should serialize as `Vec<PlanItem>` (with extra `acceptance_criteria` / `risks` fields added if needed), and Ralph's TODO tracker should be the same struct — not a parallel "todos" list.
+
+**B3. Stop/completion gates without naming the existing primitives.**
+Phase 6 says "stop/completion gates in Jcode turn loop." But the turn loop already integrates `InterruptSignal`, `SoftInterruptQueue`, `GracefulShutdownSignal`. Ralph's "do not stop until verification passes" must be implemented as a *suppression rule* on these signals (e.g., consume `GracefulShutdownSignal` only if `Ralph::is_complete()` returns true), not a new gate. Otherwise Ctrl-C behavior diverges from user expectation and silently breaks. **Action:** spec the exact signal interaction in Phase 6 *before* shipping the prompt-side activation in MVP, because activation without a defined stop semantics ships a footgun.
+
+**B4. "No active spawned agents" gate is undefined.**
+Ralph's completion criterion includes "no active spawned agents." Jcode tracks `BackgroundTaskStatus` per task and has session/swarm runtime — but the plan doesn't say *which* enumeration counts. Subagent? Background task? Swarm session child? Each has different lifecycle. **Action:** define "active" as a query against a specific source of truth (likely `BackgroundTaskStatus::Running` filtered by session_id), and write that query first.
+
+---
+
+### 🟠 High priority
+
+**H1. State files in `.jcode/state/workflows/*.json` will desync from the session.**
+Three separate JSON files for ralph/ralplan/ultrawork, each with `session_id`, `phase`, `iteration`, `agents`. There is no transactional model with the session store, no schema versioning, no migration story, and crash recovery semantics aren't specified. If a session crashes mid-iteration, what happens on next launch? **Action:** either (a) put workflow state inside the session store (as a `WorkflowState` field on session record) or (b) use atomic-write + schema_version + a documented "stale state" detection rule.
+
+**H2. Mode mutual exclusion / composition is undefined.**
+Can `/ralph` and `/ulw` be active at once? Can `/ralph` invoke ralplan internally for re-planning? OMX allows this composition; the plan has three independent state files implying yes, but with no precedence rules. **Action:** define a single `WorkflowMode` enum with explicit composition rules, or document "at most one active at a time."
+
+**H3. Skill activation pathway is hand-waved.**
+"Activation seeds state, loads skill instructions, injects reminder." Where does the injection happen — system prompt prefix, tool-result reminder, separate channel? Jcode's skills (`.jcode/skills/<name>/SKILL.md`) currently load via what mechanism? Phase 2 needs to point at the existing skill loader and say "we add a `WorkflowSkill` variant" or similar. Without that, the MVP can't be reviewed.
+
+**H4. Ralplan's Architect→Critic loop has no termination guarantee.**
+"Revise until approval/max iterations." If Critic never approves, do we ship the last draft or fail? What does the user see during the loop — silent agents or streamed deltas? In a TUI this matters. **Action:** define max_iterations default (suggest 3), explicit "approved with caveats" exit, and per-iteration TUI status update.
+
+**H5. Keyword activation list is dangerous.**
+"don't stop", "must complete", "consensus plan" as activation triggers will fire on innocent prose ("I don't stop the build before tests" → ralph mode). **Action:** require either a leading slash command OR a high-confidence keyword (e.g., bare "ralph" alone, or quoted phrase). At minimum, log when keyword activation fires so users can see why their mode flipped.
+
+**H6. Verification pipeline isn't specified.**
+"Verification passes" is the gate for Ralph completion, but the plan doesn't say what verifies. `cargo test`? Project-detected? User-supplied? `jcode-config-types` may have a verify hook — this needs to be wired explicitly. Without it, Ralph either over-runs or never completes.
+
+---
+
+### 🟡 Medium priority
+
+**M1. MVP boundary is wrong.** Shipping `/ralph` in MVP without "hard stop hooks" means MVP Ralph can be Ctrl-C'd out trivially, which makes it effectively a no-op vs. just running the underlying work without a mode. Ship `/ralplan` + `/ulw` in MVP (both are bounded operations that complete naturally) and defer all of `/ralph` to PR 2 with the gates. The current MVP/PR2 split puts the dangerous part first and the safety rail second.
+
+**M2. Suggested phase reorder:**
+1. Workflow crate skeleton + `WorkflowState` integrated into session store (replaces Phase 1).
+2. Skill activation API extension + keyword guard rules (Phase 2, but with H5 fix).
+3. `/ralplan` end-to-end emitting `Vec<PlanItem>` into `jcode-plan` (Phase 4, ahead of others; produces test fixtures everyone else needs).
+4. `/ulw` consuming a plan (Phase 3).
+5. UI/status (Phase 7, before Ralph so Ralph is observable).
+6. Ralph: gates first, loop second (Phases 5+6 inverted).
+7. CLI entrypoints (Phase 8, last).
+
+**M3. "Lightweight verification" in ultrawork is ambiguous.** Define it: "after each lane, run `cargo check -p <crate>` if file_scope is bounded to one crate, else skip." Otherwise different reviewers will assume different things.
+
+**M4. TUI integration risk.** Phase 7 is "optional" in the plan but a workflow that runs many iterations without visible state is a UX disaster. Promote to non-optional and define the widget contract before Phase 5.
+
+**M5. No persona / model routing story.** OMX uses different personas/models per role (Planner/Architect/Critic). Jcode has multiple providers — the plan should say whether ralplan roles route to different models or all use the active one. This affects cost and quality.
+
+**M6. Ralplan output dual format (`.md/json`) doubles maintenance.** Pick one as canonical (json, since it round-trips through `PlanItem`) and render markdown on demand.
+
+---

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3858,6 +3858,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "jcode-workflow"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "jcode-background-types",
+ "jcode-plan",
+ "jcode-task-types",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "jni"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3306,6 +3306,7 @@ dependencies = [
  "jcode-overnight-core",
  "jcode-pdf",
  "jcode-plan",
+ "jcode-pr-watch-core",
  "jcode-protocol",
  "jcode-provider-core",
  "jcode-provider-gemini",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3861,12 +3861,15 @@ dependencies = [
 name = "jcode-workflow"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
+ "async-trait",
  "chrono",
  "jcode-background-types",
  "jcode-plan",
  "jcode-task-types",
  "serde",
  "serde_json",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3585,6 +3585,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "jcode-pr-watch-core"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "jcode-protocol"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ members = [
     "crates/jcode-tool-core",
     "crates/jcode-tool-types",
     "crates/jcode-tui-account-picker",
+    "crates/jcode-workflow",
     "crates/jcode-tui-render",
     "crates/jcode-tui-session-picker",
     "crates/jcode-tui-style",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ members = [
     "crates/jcode-message-types",
     "crates/jcode-overnight-core",
     "crates/jcode-plan",
+    "crates/jcode-pr-watch-core",
     "crates/jcode-swarm-core",
     "crates/jcode-protocol",
     "crates/jcode-selfdev-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -197,6 +197,7 @@ jcode-memory-types = { path = "crates/jcode-memory-types" }
 jcode-message-types = { path = "crates/jcode-message-types" }
 jcode-overnight-core = { path = "crates/jcode-overnight-core" }
 jcode-plan = { path = "crates/jcode-plan" }
+jcode-pr-watch-core = { path = "crates/jcode-pr-watch-core" }
 jcode-swarm-core = { path = "crates/jcode-swarm-core" }
 jcode-protocol = { path = "crates/jcode-protocol" }
 jcode-selfdev-types = { path = "crates/jcode-selfdev-types" }

--- a/crates/jcode-overnight-core/src/lib.rs
+++ b/crates/jcode-overnight-core/src/lib.rs
@@ -431,10 +431,36 @@ pub fn task_card_validated(card: &OvernightTaskCard) -> bool {
         .as_deref()
         .unwrap_or_default()
         .to_ascii_lowercase();
-    result.contains("pass")
-        || result.contains("success")
-        || result.contains("validated")
-        || result == "ok"
+    let tokens: Vec<&str> = result
+        .split(|ch: char| !ch.is_ascii_alphanumeric())
+        .filter(|token| !token.is_empty())
+        .collect();
+
+    if tokens.iter().any(|token| {
+        matches!(
+            *token,
+            "fail" | "failed" | "failing" | "failure" | "error" | "errored" | "invalid"
+        )
+    }) || result.contains("did not pass")
+        || result.contains("not passed")
+        || result.contains("not validated")
+    {
+        return false;
+    }
+
+    tokens.iter().any(|token| {
+        matches!(
+            *token,
+            "pass"
+                | "passed"
+                | "passing"
+                | "success"
+                | "succeeded"
+                | "successful"
+                | "validated"
+                | "ok"
+        )
+    })
 }
 
 pub fn event_class(kind: &str) -> &'static str {
@@ -1269,6 +1295,14 @@ mod helper_tests {
         assert_eq!(task_status_bucket("in-progress"), "active");
         assert_eq!(task_status_bucket("needs user"), "blocked");
         assert_eq!(task_status_bucket("not started"), "skipped");
+    }
+
+    #[test]
+    fn task_card_validation_rejects_negative_pass_phrases() {
+        let mut card = task_card("1", "Failed validation", "completed");
+        card.validation.result = Some("failed: tests did not pass".to_string());
+
+        assert!(!task_card_validated(&card));
     }
 
     #[test]

--- a/crates/jcode-plan/src/lib.rs
+++ b/crates/jcode-plan/src/lib.rs
@@ -149,7 +149,7 @@ impl Default for VersionedPlan {
     }
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PlanGraphSummary {
     pub ready_ids: Vec<String>,
     pub blocked_ids: Vec<String>,

--- a/crates/jcode-pr-watch-core/Cargo.toml
+++ b/crates/jcode-pr-watch-core/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "jcode-pr-watch-core"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/crates/jcode-pr-watch-core/src/lib.rs
+++ b/crates/jcode-pr-watch-core/src/lib.rs
@@ -627,6 +627,355 @@ fn insert_marker(map: &mut BTreeMap<String, Marker>, id: &str, updated_at: Optio
     );
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SurfaceError {
+    pub surface: String,
+    pub message: String,
+    pub transient: bool,
+}
+
+impl SurfaceError {
+    pub fn transient(surface: impl Into<String>, message: impl Into<String>) -> Self {
+        Self {
+            surface: surface.into(),
+            message: message.into(),
+            transient: true,
+        }
+    }
+
+    pub fn permanent(surface: impl Into<String>, message: impl Into<String>) -> Self {
+        Self {
+            surface: surface.into(),
+            message: message.into(),
+            transient: false,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ReviewThread {
+    pub id: String,
+    pub is_resolved: bool,
+    pub is_outdated: bool,
+    pub path: Option<String>,
+    pub line: Option<u64>,
+    pub url: Option<String>,
+    pub updated_at: Option<String>,
+    pub author: Option<String>,
+    pub body: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ReviewComment {
+    pub id: String,
+    pub path: Option<String>,
+    pub line: Option<u64>,
+    pub url: Option<String>,
+    pub updated_at: Option<String>,
+    pub author: Option<String>,
+    pub body: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct IssueComment {
+    pub id: String,
+    pub url: Option<String>,
+    pub updated_at: Option<String>,
+    pub author: Option<String>,
+    pub body: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Review {
+    pub id: String,
+    pub state: Option<String>,
+    pub submitted_at: Option<String>,
+    pub author: Option<String>,
+    pub body: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TimelineEvent {
+    pub id: String,
+    pub kind: Option<String>,
+    pub created_at: Option<String>,
+    pub author: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PrMetadata {
+    pub identity: PrIdentity,
+    pub is_draft: Option<bool>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PrSnapshotResult {
+    pub metadata: Result<PrMetadata, SurfaceError>,
+    pub checks: Result<Vec<CheckRunState>, SurfaceError>,
+    pub review_threads: Result<Vec<ReviewThread>, SurfaceError>,
+    pub review_comments: Result<Vec<ReviewComment>, SurfaceError>,
+    pub issue_comments: Result<Vec<IssueComment>, SurfaceError>,
+    pub reviews: Result<Vec<Review>, SurfaceError>,
+    pub timeline: Result<Vec<TimelineEvent>, SurfaceError>,
+}
+
+impl PrSnapshotResult {
+    pub fn has_partial_failure(&self) -> bool {
+        self.metadata.is_err()
+            || self.checks.is_err()
+            || self.review_threads.is_err()
+            || self.review_comments.is_err()
+            || self.issue_comments.is_err()
+            || self.reviews.is_err()
+            || self.timeline.is_err()
+    }
+
+    pub fn failed_surfaces(&self) -> Vec<String> {
+        let mut failed = Vec::new();
+        if let Err(err) = &self.metadata {
+            failed.push(err.surface.clone());
+        }
+        if let Err(err) = &self.checks {
+            failed.push(err.surface.clone());
+        }
+        if let Err(err) = &self.review_threads {
+            failed.push(err.surface.clone());
+        }
+        if let Err(err) = &self.review_comments {
+            failed.push(err.surface.clone());
+        }
+        if let Err(err) = &self.issue_comments {
+            failed.push(err.surface.clone());
+        }
+        if let Err(err) = &self.reviews {
+            failed.push(err.surface.clone());
+        }
+        if let Err(err) = &self.timeline {
+            failed.push(err.surface.clone());
+        }
+        failed
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GhParseError {
+    InvalidJson(String),
+    ExpectedObject(&'static str),
+    ExpectedArray(&'static str),
+    MissingField(&'static str),
+}
+
+impl std::fmt::Display for GhParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidJson(message) => write!(f, "invalid gh JSON: {message}"),
+            Self::ExpectedObject(surface) => write!(f, "expected object for {surface}"),
+            Self::ExpectedArray(surface) => write!(f, "expected array for {surface}"),
+            Self::MissingField(field) => write!(f, "missing field {field}"),
+        }
+    }
+}
+
+impl std::error::Error for GhParseError {}
+
+pub fn parse_gh_pr_view(repo: &str, number: u64, stdout: &str) -> Result<PrMetadata, GhParseError> {
+    let value: Value =
+        serde_json::from_str(stdout).map_err(|err| GhParseError::InvalidJson(err.to_string()))?;
+    let object = value
+        .as_object()
+        .ok_or(GhParseError::ExpectedObject("pr_view"))?;
+    let identity = PrIdentity {
+        repo: repo.to_string(),
+        number,
+        url: string_field(object, "url"),
+        state: string_field(object, "state"),
+        base_ref: string_field(object, "baseRefName").or_else(|| string_field(object, "base_ref")),
+        head_ref: string_field(object, "headRefName").or_else(|| string_field(object, "head_ref")),
+        head_sha: string_field(object, "headRefOid").or_else(|| string_field(object, "head_sha")),
+        merge_state: string_field(object, "mergeStateStatus")
+            .or_else(|| string_field(object, "mergeable")),
+        review_decision: string_field(object, "reviewDecision"),
+    };
+    Ok(PrMetadata {
+        identity,
+        is_draft: object.get("isDraft").and_then(Value::as_bool),
+    })
+}
+
+pub fn parse_gh_checks(stdout: &str) -> Result<Vec<CheckRunState>, GhParseError> {
+    let value: Value = parse_json_values(stdout)?;
+    let array = value
+        .as_array()
+        .ok_or(GhParseError::ExpectedArray("checks"))?;
+    Ok(array
+        .iter()
+        .enumerate()
+        .map(|(idx, item)| {
+            let obj = item.as_object();
+            CheckRunState {
+                id: obj
+                    .and_then(|o| string_field(o, "id"))
+                    .or_else(|| obj.and_then(|o| string_field(o, "databaseId")))
+                    .or_else(|| Some(idx.to_string())),
+                name: obj
+                    .and_then(|o| string_field(o, "name"))
+                    .or_else(|| obj.and_then(|o| string_field(o, "context")))
+                    .unwrap_or_else(|| format!("check-{idx}")),
+                status: obj.and_then(|o| string_field(o, "status")),
+                conclusion: obj
+                    .and_then(|o| string_field(o, "conclusion"))
+                    .or_else(|| obj.and_then(|o| string_field(o, "state"))),
+                url: obj
+                    .and_then(|o| string_field(o, "detailsUrl"))
+                    .or_else(|| obj.and_then(|o| string_field(o, "targetUrl"))),
+            }
+        })
+        .collect())
+}
+
+pub fn parse_gh_review_comments(stdout: &str) -> Result<Vec<ReviewComment>, GhParseError> {
+    let value = parse_json_values(stdout)?;
+    let array = value
+        .as_array()
+        .ok_or(GhParseError::ExpectedArray("review_comments"))?;
+    Ok(array
+        .iter()
+        .filter_map(|item| {
+            let obj = item.as_object()?;
+            let id = string_field(obj, "node_id").or_else(|| string_field(obj, "id"))?;
+            Some(ReviewComment {
+                id,
+                path: string_field(obj, "path"),
+                line: obj
+                    .get("line")
+                    .and_then(Value::as_u64)
+                    .or_else(|| obj.get("original_line").and_then(Value::as_u64)),
+                url: string_field(obj, "html_url").or_else(|| string_field(obj, "url")),
+                updated_at: string_field(obj, "updated_at"),
+                author: login_from_user(obj.get("user")),
+                body: string_field(obj, "body"),
+            })
+        })
+        .collect())
+}
+
+pub fn parse_gh_issue_comments(stdout: &str) -> Result<Vec<IssueComment>, GhParseError> {
+    let value = parse_json_values(stdout)?;
+    let array = value
+        .as_array()
+        .ok_or(GhParseError::ExpectedArray("issue_comments"))?;
+    Ok(array
+        .iter()
+        .filter_map(|item| {
+            let obj = item.as_object()?;
+            let id = string_field(obj, "node_id").or_else(|| string_field(obj, "id"))?;
+            Some(IssueComment {
+                id,
+                url: string_field(obj, "html_url").or_else(|| string_field(obj, "url")),
+                updated_at: string_field(obj, "updated_at"),
+                author: login_from_user(obj.get("user")),
+                body: string_field(obj, "body"),
+            })
+        })
+        .collect())
+}
+
+pub fn parse_gh_reviews(stdout: &str) -> Result<Vec<Review>, GhParseError> {
+    let value = parse_json_values(stdout)?;
+    let array = value
+        .as_array()
+        .ok_or(GhParseError::ExpectedArray("reviews"))?;
+    Ok(array
+        .iter()
+        .filter_map(|item| {
+            let obj = item.as_object()?;
+            let id = string_field(obj, "node_id").or_else(|| string_field(obj, "id"))?;
+            Some(Review {
+                id,
+                state: string_field(obj, "state"),
+                submitted_at: string_field(obj, "submitted_at")
+                    .or_else(|| string_field(obj, "submittedAt")),
+                author: login_from_user(obj.get("user"))
+                    .or_else(|| login_from_user(obj.get("author"))),
+                body: string_field(obj, "body"),
+            })
+        })
+        .collect())
+}
+
+pub fn parse_gh_review_threads(stdout: &str) -> Result<Vec<ReviewThread>, GhParseError> {
+    let value: Value =
+        serde_json::from_str(stdout).map_err(|err| GhParseError::InvalidJson(err.to_string()))?;
+    let nodes = value
+        .pointer("/data/repository/pullRequest/reviewThreads/nodes")
+        .or_else(|| value.pointer("/reviewThreads/nodes"))
+        .and_then(Value::as_array)
+        .ok_or(GhParseError::ExpectedArray("review_threads"))?;
+    Ok(nodes
+        .iter()
+        .filter_map(|thread| {
+            let obj = thread.as_object()?;
+            let id = string_field(obj, "id")?;
+            let first_comment = thread
+                .pointer("/comments/nodes/0")
+                .and_then(Value::as_object);
+            Some(ReviewThread {
+                id,
+                is_resolved: obj
+                    .get("isResolved")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false),
+                is_outdated: obj
+                    .get("isOutdated")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false),
+                path: first_comment.and_then(|c| string_field(c, "path")),
+                line: first_comment.and_then(|c| c.get("line").and_then(Value::as_u64)),
+                url: first_comment.and_then(|c| string_field(c, "url")),
+                updated_at: first_comment.and_then(|c| {
+                    string_field(c, "updatedAt").or_else(|| string_field(c, "createdAt"))
+                }),
+                author: first_comment.and_then(|c| login_from_user(c.get("author"))),
+                body: first_comment.and_then(|c| string_field(c, "body")),
+            })
+        })
+        .collect())
+}
+
+fn parse_json_values(stdout: &str) -> Result<Value, GhParseError> {
+    let text = stdout.trim();
+    if text.is_empty() {
+        return Ok(Value::Array(Vec::new()));
+    }
+    let decoder = serde_json::Deserializer::from_str(text);
+    let values: Result<Vec<Value>, _> = decoder.into_iter::<Value>().collect();
+    let values = values.map_err(|err| GhParseError::InvalidJson(err.to_string()))?;
+    if values.len() == 1 {
+        return Ok(values.into_iter().next().unwrap());
+    }
+    if values.iter().all(Value::is_array) {
+        let mut merged = Vec::new();
+        for value in values {
+            merged.extend(value.as_array().cloned().unwrap_or_default());
+        }
+        return Ok(Value::Array(merged));
+    }
+    Ok(Value::Array(values))
+}
+
+fn string_field(object: &serde_json::Map<String, Value>, key: &str) -> Option<String> {
+    object.get(key).and_then(|value| match value {
+        Value::String(text) if !text.is_empty() => Some(text.clone()),
+        Value::Number(number) => Some(number.to_string()),
+        _ => None,
+    })
+}
+
+fn login_from_user(value: Option<&Value>) -> Option<String> {
+    let object = value?.as_object()?;
+    string_field(object, "login").or_else(|| string_field(object, "name"))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -788,5 +1137,136 @@ mod tests {
         });
         assert_eq!(state.polling.quiet_cycles, 0);
         assert_eq!(state.last_cycle.status, CycleStatus::ChecksFailed);
+    }
+
+    #[test]
+    fn snapshot_result_preserves_per_surface_failures() {
+        let snapshot = PrSnapshotResult {
+            metadata: Ok(PrMetadata {
+                identity: PrIdentity {
+                    repo: "owner/repo".into(),
+                    number: 1,
+                    url: None,
+                    state: Some("OPEN".into()),
+                    base_ref: None,
+                    head_ref: None,
+                    head_sha: None,
+                    merge_state: None,
+                    review_decision: None,
+                },
+                is_draft: Some(false),
+            }),
+            checks: Err(SurfaceError::transient("checks", "timeout")),
+            review_threads: Ok(Vec::new()),
+            review_comments: Ok(Vec::new()),
+            issue_comments: Ok(Vec::new()),
+            reviews: Ok(Vec::new()),
+            timeline: Err(SurfaceError::permanent("timeline", "unsupported")),
+        };
+        assert!(snapshot.has_partial_failure());
+        assert_eq!(
+            snapshot.failed_surfaces(),
+            vec!["checks".to_string(), "timeline".to_string()]
+        );
+    }
+
+    #[test]
+    fn parses_gh_pr_view_metadata_fixture() {
+        let metadata = parse_gh_pr_view(
+            "owner/repo",
+            42,
+            r#"{
+              "url":"https://github.com/owner/repo/pull/42",
+              "state":"OPEN",
+              "baseRefName":"main",
+              "headRefName":"feature/pr-watch",
+              "headRefOid":"abc123",
+              "mergeStateStatus":"CLEAN",
+              "reviewDecision":"REVIEW_REQUIRED",
+              "isDraft":false
+            }"#,
+        )
+        .unwrap();
+        assert_eq!(metadata.identity.repo, "owner/repo");
+        assert_eq!(metadata.identity.number, 42);
+        assert_eq!(metadata.identity.head_sha.as_deref(), Some("abc123"));
+        assert_eq!(metadata.identity.merge_state.as_deref(), Some("CLEAN"));
+        assert_eq!(metadata.is_draft, Some(false));
+    }
+
+    #[test]
+    fn parses_paginated_gh_arrays_for_comments_and_checks() {
+        let checks = parse_gh_checks(
+            r#"[{"name":"ci","status":"COMPLETED","conclusion":"SUCCESS","detailsUrl":"https://ci"}]
+               [{"name":"lint","status":"IN_PROGRESS","conclusion":null}]"#,
+        )
+        .unwrap();
+        assert_eq!(checks.len(), 2);
+        assert_eq!(checks[0].name, "ci");
+        assert_eq!(checks[0].conclusion.as_deref(), Some("SUCCESS"));
+        assert_eq!(checks[1].status.as_deref(), Some("IN_PROGRESS"));
+
+        let comments = parse_gh_review_comments(
+            r#"[{"id":123,"path":"src/lib.rs","line":9,"html_url":"https://comment","updated_at":"2026-05-13T17:00:00Z","user":{"login":"reviewer"},"body":"Please fix"}]"#,
+        )
+        .unwrap();
+        assert_eq!(comments.len(), 1);
+        assert_eq!(comments[0].id, "123");
+        assert_eq!(comments[0].path.as_deref(), Some("src/lib.rs"));
+        assert_eq!(comments[0].author.as_deref(), Some("reviewer"));
+    }
+
+    #[test]
+    fn parses_gh_issue_comments_and_reviews() {
+        let issue_comments = parse_gh_issue_comments(
+            r#"[{"node_id":"IC_1","html_url":"https://issue-comment","updated_at":"2026-05-13T17:00:00Z","user":{"login":"alice"},"body":"Top level"}]"#,
+        )
+        .unwrap();
+        assert_eq!(issue_comments[0].id, "IC_1");
+        assert_eq!(issue_comments[0].author.as_deref(), Some("alice"));
+
+        let reviews = parse_gh_reviews(
+            r#"[{"id":55,"state":"CHANGES_REQUESTED","submitted_at":"2026-05-13T17:01:00Z","user":{"login":"bob"},"body":"Needs work"}]"#,
+        )
+        .unwrap();
+        assert_eq!(reviews[0].id, "55");
+        assert_eq!(reviews[0].state.as_deref(), Some("CHANGES_REQUESTED"));
+        assert_eq!(reviews[0].author.as_deref(), Some("bob"));
+    }
+
+    #[test]
+    fn parses_graphql_review_threads_fixture() {
+        let threads = parse_gh_review_threads(
+            r#"{
+              "data": {"repository": {"pullRequest": {"reviewThreads": {"nodes": [
+                {
+                  "id":"PRRT_1",
+                  "isResolved":false,
+                  "isOutdated":false,
+                  "comments":{"nodes":[{
+                    "path":"src/main.rs",
+                    "line":12,
+                    "url":"https://thread-comment",
+                    "updatedAt":"2026-05-13T17:02:00Z",
+                    "author":{"login":"reviewer"},
+                    "body":"Thread body"
+                  }]}
+                }
+              ]}}}}
+            }"#,
+        )
+        .unwrap();
+        assert_eq!(threads.len(), 1);
+        assert_eq!(threads[0].id, "PRRT_1");
+        assert!(!threads[0].is_resolved);
+        assert_eq!(threads[0].path.as_deref(), Some("src/main.rs"));
+        assert_eq!(threads[0].line, Some(12));
+        assert_eq!(threads[0].author.as_deref(), Some("reviewer"));
+    }
+
+    #[test]
+    fn parser_rejects_wrong_surface_shape() {
+        let err = parse_gh_checks(r#"{"not":"array"}"#).unwrap_err();
+        assert_eq!(err, GhParseError::ExpectedArray("checks"));
     }
 }

--- a/crates/jcode-pr-watch-core/src/lib.rs
+++ b/crates/jcode-pr-watch-core/src/lib.rs
@@ -1,0 +1,792 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::{BTreeMap, BTreeSet};
+
+pub const SCHEMA_VERSION: u32 = 2;
+pub const DEFAULT_MAX_EVENTS: usize = 50;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PrTarget {
+    pub repo: String,
+    pub number: u64,
+}
+
+impl PrTarget {
+    pub fn watch_id(&self) -> String {
+        format!("{}-pr-{}", self.repo.replace('/', "-"), self.number)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PrIdentity {
+    pub repo: String,
+    pub number: u64,
+    pub url: Option<String>,
+    pub state: Option<String>,
+    pub base_ref: Option<String>,
+    pub head_ref: Option<String>,
+    pub head_sha: Option<String>,
+    pub merge_state: Option<String>,
+    pub review_decision: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "snake_case")]
+pub enum WriteScope {
+    Push,
+    Comment,
+    ResolveThreads,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WritePolicy {
+    pub local_fix: bool,
+    pub commit: bool,
+    pub push: bool,
+    pub comment: bool,
+    pub resolve_threads: bool,
+}
+
+impl Default for WritePolicy {
+    fn default() -> Self {
+        Self {
+            local_fix: true,
+            commit: false,
+            push: false,
+            comment: false,
+            resolve_threads: false,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AuthorizationGrant {
+    pub grant_id: String,
+    pub granted_at: String,
+    pub expires_at: String,
+    pub granted_by_session_id: String,
+    pub scopes: BTreeSet<WriteScope>,
+    pub single_use: bool,
+    pub reason: Option<String>,
+}
+
+impl AuthorizationGrant {
+    pub fn grants(&self, scope: WriteScope, now: &str, current_session_id: &str) -> bool {
+        self.scopes.contains(&scope)
+            && now <= self.expires_at.as_str()
+            && self.granted_by_session_id == current_session_id
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct AuthorizationState {
+    pub active_grants: Vec<AuthorizationGrant>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Marker {
+    pub id: String,
+    pub updated_at: Option<String>,
+    pub author: Option<String>,
+    pub body_hash: Option<String>,
+    pub url: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ReviewThreadMarker {
+    pub id: String,
+    pub updated_at: Option<String>,
+    pub resolved: bool,
+    pub outdated: bool,
+    pub body_hash: Option<String>,
+    pub url: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct LastSeen {
+    pub review_threads: BTreeMap<String, ReviewThreadMarker>,
+    pub review_comments: BTreeMap<String, Marker>,
+    pub issue_comments: BTreeMap<String, Marker>,
+    pub reviews: BTreeMap<String, Marker>,
+    pub timeline: BTreeMap<String, Marker>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct CheckRunState {
+    pub id: Option<String>,
+    pub name: String,
+    pub status: Option<String>,
+    pub conclusion: Option<String>,
+    pub url: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct LastChecksForSha {
+    pub head_sha: Option<String>,
+    pub runs: Vec<CheckRunState>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct Baseline {
+    pub head_sha: Option<String>,
+    pub established_at: Option<String>,
+    pub unresolved_thread_ids: Vec<String>,
+    pub review_comment_count: usize,
+    pub issue_comment_count: usize,
+    pub review_count: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PollingState {
+    pub cycle_number: u64,
+    pub quiet_cycles: u64,
+    pub required_quiet_cycles: u64,
+    pub poll_interval_seconds: u64,
+    pub final_poll_due_at: Option<String>,
+    pub next_poll_at: Option<String>,
+    pub consecutive_transient_failures: u64,
+}
+
+impl Default for PollingState {
+    fn default() -> Self {
+        Self {
+            cycle_number: 0,
+            quiet_cycles: 0,
+            required_quiet_cycles: 3,
+            poll_interval_seconds: 300,
+            final_poll_due_at: None,
+            next_poll_at: None,
+            consecutive_transient_failures: 0,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum CycleStatus {
+    BaselineEstablished,
+    Collecting,
+    QuietPending,
+    QuietSatisfied,
+    FinalPollPending,
+    ActionRequired,
+    ChecksPending,
+    ChecksFailed,
+    TransientFailure,
+    OperationalError,
+    Stopped,
+    TerminalReadyForHuman,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CycleSummary {
+    pub completed_at: Option<String>,
+    pub status: CycleStatus,
+    pub surfaces_checked: Vec<String>,
+    pub surface_counts: BTreeMap<String, usize>,
+    pub actionable_count: usize,
+    pub pending_check_count: usize,
+    pub failed_check_count: usize,
+}
+
+impl Default for CycleSummary {
+    fn default() -> Self {
+        Self {
+            completed_at: None,
+            status: CycleStatus::Collecting,
+            surfaces_checked: Vec::new(),
+            surface_counts: BTreeMap::new(),
+            actionable_count: 0,
+            pending_check_count: 0,
+            failed_check_count: 0,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WatchEvent {
+    pub at: String,
+    pub kind: String,
+    #[serde(default)]
+    pub data: Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ActionableItem {
+    pub id: String,
+    pub surface: String,
+    pub summary: String,
+    pub url: Option<String>,
+    pub path: Option<String>,
+    pub status: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ValidationEvidence {
+    pub at: String,
+    pub command: String,
+    pub status: String,
+    pub summary: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PrWatchState {
+    pub schema_version: u32,
+    pub watch_id: String,
+    pub created_at: Option<String>,
+    pub updated_at: Option<String>,
+    pub terminal: bool,
+    pub stop_reason: Option<String>,
+    pub pr: PrIdentity,
+    pub policy: WritePolicy,
+    pub authorization: AuthorizationState,
+    pub polling: PollingState,
+    pub baseline: Baseline,
+    pub last_seen: LastSeen,
+    pub last_checks_for_sha: LastChecksForSha,
+    pub last_successful_fetch: BTreeMap<String, String>,
+    pub last_cycle: CycleSummary,
+    pub pending_actionable: Vec<ActionableItem>,
+    pub last_validation: Vec<ValidationEvidence>,
+    pub events: Vec<WatchEvent>,
+}
+
+impl PrWatchState {
+    pub fn new(target: PrTarget) -> Self {
+        let watch_id = target.watch_id();
+        Self {
+            schema_version: SCHEMA_VERSION,
+            watch_id,
+            created_at: None,
+            updated_at: None,
+            terminal: false,
+            stop_reason: None,
+            pr: PrIdentity {
+                repo: target.repo,
+                number: target.number,
+                url: None,
+                state: None,
+                base_ref: None,
+                head_ref: None,
+                head_sha: None,
+                merge_state: None,
+                review_decision: None,
+            },
+            policy: WritePolicy::default(),
+            authorization: AuthorizationState::default(),
+            polling: PollingState::default(),
+            baseline: Baseline::default(),
+            last_seen: LastSeen::default(),
+            last_checks_for_sha: LastChecksForSha::default(),
+            last_successful_fetch: BTreeMap::new(),
+            last_cycle: CycleSummary::default(),
+            pending_actionable: Vec::new(),
+            last_validation: Vec::new(),
+            events: Vec::new(),
+        }
+    }
+
+    pub fn push_event(&mut self, event: WatchEvent) {
+        self.events.push(event);
+        if self.events.len() > DEFAULT_MAX_EVENTS {
+            let excess = self.events.len() - DEFAULT_MAX_EVENTS;
+            self.events.drain(0..excess);
+        }
+    }
+
+    pub fn apply_cycle_outcome(&mut self, outcome: CycleOutcome) {
+        self.polling.cycle_number = self.polling.cycle_number.saturating_add(1);
+        self.polling.consecutive_transient_failures = 0;
+        self.pending_actionable = outcome.pending_actionable;
+        self.last_cycle.actionable_count = self.pending_actionable.len();
+        self.last_cycle.pending_check_count = outcome.pending_check_count;
+        self.last_cycle.failed_check_count = outcome.failed_check_count;
+
+        if !self.pending_actionable.is_empty() {
+            self.polling.quiet_cycles = 0;
+            self.last_cycle.status = CycleStatus::ActionRequired;
+        } else if outcome.failed_check_count > 0 {
+            self.polling.quiet_cycles = 0;
+            self.last_cycle.status = CycleStatus::ChecksFailed;
+        } else if outcome.pending_check_count > 0 {
+            self.polling.quiet_cycles = 0;
+            self.last_cycle.status = CycleStatus::ChecksPending;
+        } else if outcome.partial_failure {
+            self.last_cycle.status = CycleStatus::TransientFailure;
+            self.polling.consecutive_transient_failures = self
+                .polling
+                .consecutive_transient_failures
+                .saturating_add(1);
+        } else {
+            self.polling.quiet_cycles = self.polling.quiet_cycles.saturating_add(1);
+            self.last_cycle.status =
+                if self.polling.quiet_cycles >= self.polling.required_quiet_cycles {
+                    CycleStatus::QuietSatisfied
+                } else {
+                    CycleStatus::QuietPending
+                };
+        }
+    }
+
+    pub fn readiness(&self) -> Readiness {
+        if self.pr.state.as_deref() != Some("OPEN") && self.pr.state.is_some() {
+            return Readiness::BlockedByClosedPr;
+        }
+        if !self.pending_actionable.is_empty() {
+            return Readiness::NotReadyActionRequired;
+        }
+        if self.last_cycle.failed_check_count > 0 {
+            return Readiness::NotReadyChecksFailed;
+        }
+        if self.last_cycle.pending_check_count > 0 {
+            return Readiness::NotReadyChecksPending;
+        }
+        if self.polling.quiet_cycles >= self.polling.required_quiet_cycles {
+            return Readiness::ReadyForHumanMerge;
+        }
+        Readiness::ReadyForHumanReview
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct CycleOutcome {
+    pub pending_actionable: Vec<ActionableItem>,
+    pub pending_check_count: usize,
+    pub failed_check_count: usize,
+    pub partial_failure: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum Readiness {
+    NotReadyActionRequired,
+    NotReadyChecksPending,
+    NotReadyChecksFailed,
+    NotReadyValidationStale,
+    ReadyForHumanReview,
+    ReadyForHumanPush,
+    ReadyForHumanMerge,
+    BlockedByPolicy,
+    BlockedByClosedPr,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NormalizeError {
+    InvalidJson(String),
+    MissingPrIdentity,
+}
+
+impl std::fmt::Display for NormalizeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidJson(message) => write!(f, "invalid JSON: {message}"),
+            Self::MissingPrIdentity => write!(f, "missing PR repo or number"),
+        }
+    }
+}
+
+impl std::error::Error for NormalizeError {}
+
+pub fn normalize_watch_state_json(input: &str) -> Result<PrWatchState, NormalizeError> {
+    let value: Value =
+        serde_json::from_str(input).map_err(|err| NormalizeError::InvalidJson(err.to_string()))?;
+    if value.get("schema_version").and_then(Value::as_u64) == Some(2) {
+        return serde_json::from_value(value)
+            .map_err(|err| NormalizeError::InvalidJson(err.to_string()));
+    }
+    normalize_v1_value(&value)
+}
+
+fn normalize_v1_value(value: &Value) -> Result<PrWatchState, NormalizeError> {
+    let pr = value
+        .get("pr")
+        .and_then(Value::as_object)
+        .ok_or(NormalizeError::MissingPrIdentity)?;
+    let repo = pr
+        .get("repo")
+        .and_then(Value::as_str)
+        .ok_or(NormalizeError::MissingPrIdentity)?
+        .to_string();
+    let number = pr
+        .get("number")
+        .and_then(Value::as_u64)
+        .ok_or(NormalizeError::MissingPrIdentity)?;
+    let mut state = PrWatchState::new(PrTarget {
+        repo: repo.clone(),
+        number,
+    });
+    state.created_at = value
+        .get("created_at")
+        .and_then(Value::as_str)
+        .map(str::to_string);
+    state.updated_at = value
+        .get("updated_at")
+        .or_else(|| value.pointer("/last_cycle/completed_at"))
+        .and_then(Value::as_str)
+        .map(str::to_string);
+    state.terminal = value
+        .get("terminal")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    state.stop_reason = value
+        .get("stop_reason")
+        .and_then(Value::as_str)
+        .map(str::to_string);
+    state.pr.url = pr.get("url").and_then(Value::as_str).map(str::to_string);
+    state.pr.state = pr.get("state").and_then(Value::as_str).map(str::to_string);
+    state.pr.base_ref = pr
+        .get("baseRefName")
+        .or_else(|| pr.get("base_ref"))
+        .and_then(Value::as_str)
+        .map(str::to_string);
+    state.pr.head_ref = pr
+        .get("headRefName")
+        .or_else(|| pr.get("head_ref"))
+        .and_then(Value::as_str)
+        .map(str::to_string);
+    state.pr.head_sha = pr
+        .get("head_sha")
+        .or_else(|| pr.get("headRefOid"))
+        .and_then(Value::as_str)
+        .map(str::to_string);
+    state.pr.merge_state = pr
+        .get("mergeStateStatus")
+        .or_else(|| pr.get("merge_state"))
+        .and_then(Value::as_str)
+        .map(str::to_string);
+
+    state.polling.cycle_number = value
+        .get("cycle_number")
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    state.polling.quiet_cycles = value
+        .get("quiet_cycles")
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    state.polling.consecutive_transient_failures = value
+        .get("consecutive_transient_failures")
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+
+    if let Some(last_cycle) = value.get("last_cycle").and_then(Value::as_object) {
+        state.last_cycle.completed_at = last_cycle
+            .get("completed_at")
+            .and_then(Value::as_str)
+            .map(str::to_string);
+        state.last_cycle.actionable_count = last_cycle
+            .get("actionable_count")
+            .and_then(Value::as_u64)
+            .unwrap_or(0) as usize;
+        state.last_cycle.surfaces_checked = last_cycle
+            .get("surfaces_checked")
+            .and_then(Value::as_array)
+            .map(|items| {
+                items
+                    .iter()
+                    .filter_map(Value::as_str)
+                    .map(str::to_string)
+                    .collect()
+            })
+            .unwrap_or_default();
+        state.last_cycle.surface_counts = last_cycle
+            .get("surface_counts")
+            .and_then(Value::as_object)
+            .map(|map| {
+                map.iter()
+                    .filter_map(|(k, v)| v.as_u64().map(|n| (k.clone(), n as usize)))
+                    .collect()
+            })
+            .unwrap_or_default();
+        state.last_cycle.status = match last_cycle.get("status").and_then(Value::as_str) {
+            Some("quiet_validation") => CycleStatus::QuietPending,
+            Some("actionable_locally_fixed_waiting_for_write_approval") => {
+                CycleStatus::ActionRequired
+            }
+            Some("quiet_satisfied") => CycleStatus::QuietSatisfied,
+            Some("action_required") => CycleStatus::ActionRequired,
+            Some("checks_failed") => CycleStatus::ChecksFailed,
+            Some("checks_pending") => CycleStatus::ChecksPending,
+            Some("transient_failure") => CycleStatus::TransientFailure,
+            _ => CycleStatus::Collecting,
+        };
+    }
+
+    if let Some(fetch) = value
+        .get("surface_last_successful_fetch")
+        .and_then(Value::as_object)
+    {
+        state.last_successful_fetch = fetch
+            .iter()
+            .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
+            .collect();
+    }
+
+    if let Some(markers) = value
+        .get("last_seen_review_markers")
+        .and_then(Value::as_object)
+    {
+        for (surface, bucket) in markers {
+            if let Some(bucket) = bucket.as_object() {
+                for (id, updated_value) in bucket {
+                    let updated_at = updated_value
+                        .as_str()
+                        .filter(|s| !s.is_empty())
+                        .map(str::to_string);
+                    match surface.as_str() {
+                        "review_threads" => {
+                            state.last_seen.review_threads.insert(
+                                id.clone(),
+                                ReviewThreadMarker {
+                                    id: id.clone(),
+                                    updated_at,
+                                    resolved: false,
+                                    outdated: false,
+                                    body_hash: None,
+                                    url: None,
+                                },
+                            );
+                        }
+                        "review_comments" => {
+                            insert_marker(&mut state.last_seen.review_comments, id, updated_at)
+                        }
+                        "issue_comments" => {
+                            insert_marker(&mut state.last_seen.issue_comments, id, updated_at)
+                        }
+                        "reviews" => insert_marker(&mut state.last_seen.reviews, id, updated_at),
+                        "timeline" => insert_marker(&mut state.last_seen.timeline, id, updated_at),
+                        _ => {}
+                    }
+                }
+            }
+        }
+    }
+
+    if let Some(items) = value.get("pending_actionable").and_then(Value::as_array) {
+        state.pending_actionable = items
+            .iter()
+            .enumerate()
+            .map(|(index, item)| ActionableItem {
+                id: item
+                    .get("thread_id")
+                    .or_else(|| item.get("id"))
+                    .and_then(Value::as_str)
+                    .map(str::to_string)
+                    .unwrap_or_else(|| format!("legacy-{index}")),
+                surface: "review_threads".to_string(),
+                summary: item
+                    .get("summary")
+                    .and_then(Value::as_str)
+                    .unwrap_or("legacy actionable item")
+                    .to_string(),
+                url: item.get("url").and_then(Value::as_str).map(str::to_string),
+                path: item.get("path").and_then(Value::as_str).map(str::to_string),
+                status: item
+                    .get("status")
+                    .and_then(Value::as_str)
+                    .map(str::to_string),
+            })
+            .collect();
+    }
+
+    if let Some(events) = value.get("events").and_then(Value::as_array) {
+        for event in events.iter().rev().take(DEFAULT_MAX_EVENTS).rev() {
+            if let Some(at) = event
+                .get("at")
+                .or_else(|| event.get("completed_at"))
+                .and_then(Value::as_str)
+            {
+                state.events.push(WatchEvent {
+                    at: at.to_string(),
+                    kind: event
+                        .get("status")
+                        .and_then(Value::as_str)
+                        .unwrap_or("legacy_event")
+                        .to_string(),
+                    data: event.clone(),
+                });
+            }
+        }
+    }
+
+    if state.last_cycle.actionable_count == 0 {
+        state.last_cycle.actionable_count = state.pending_actionable.len();
+    }
+    Ok(state)
+}
+
+fn insert_marker(map: &mut BTreeMap<String, Marker>, id: &str, updated_at: Option<String>) {
+    map.insert(
+        id.to_string(),
+        Marker {
+            id: id.to_string(),
+            updated_at,
+            author: None,
+            body_hash: None,
+            url: None,
+        },
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_v1() -> &'static str {
+        r#"{
+          "consecutive_transient_failures": 0,
+          "cycle_number": 2,
+          "last_cycle": {
+            "actionable_count": 0,
+            "completed_at": "2026-05-11T10:30:50Z",
+            "status": "quiet_validation",
+            "surface_counts": {"timeline": 3},
+            "surfaces_checked": ["review_threads", "timeline"]
+          },
+          "last_seen_review_markers": {
+            "review_comments": {"3183715059": "2026-05-04T18:43:54Z"},
+            "review_threads": {"PRRT_kwDOSQE1Ec5_cHz3": "2026-05-04T18:43:54Z"},
+            "timeline": {"cross-referenced:2026-05-11T06:00:53Z": "2026-05-11T06:00:53Z"}
+          },
+          "pr": {"baseRefName": "master", "headRefName": "fix/example", "number": 188, "repo": "1jehuang/jcode", "state": "OPEN", "url": "https://github.com/1jehuang/jcode/pull/188"},
+          "quiet_cycles": 2,
+          "schema_version": 1,
+          "terminal": true,
+          "write_authorized": false
+        }"#
+    }
+
+    #[test]
+    fn new_state_does_not_include_merge_policy() {
+        let state = PrWatchState::new(PrTarget {
+            repo: "owner/repo".into(),
+            number: 7,
+        });
+        let json = serde_json::to_value(&state.policy).unwrap();
+        assert!(json.get("merge").is_none());
+        assert_eq!(state.watch_id, "owner-repo-pr-7");
+    }
+
+    #[test]
+    fn authorization_grant_is_session_and_expiry_bound() {
+        let grant = AuthorizationGrant {
+            grant_id: "g1".into(),
+            granted_at: "2026-05-13T17:00:00Z".into(),
+            expires_at: "2026-05-13T18:00:00Z".into(),
+            granted_by_session_id: "session_a".into(),
+            scopes: BTreeSet::from([WriteScope::Push]),
+            single_use: true,
+            reason: None,
+        };
+        assert!(grant.grants(WriteScope::Push, "2026-05-13T17:30:00Z", "session_a"));
+        assert!(!grant.grants(WriteScope::Push, "2026-05-13T18:30:00Z", "session_a"));
+        assert!(!grant.grants(WriteScope::Push, "2026-05-13T17:30:00Z", "session_b"));
+        assert!(!grant.grants(WriteScope::Comment, "2026-05-13T17:30:00Z", "session_a"));
+    }
+
+    #[test]
+    fn push_event_keeps_newest_fifty() {
+        let mut state = PrWatchState::new(PrTarget {
+            repo: "owner/repo".into(),
+            number: 1,
+        });
+        for i in 0..60 {
+            state.push_event(WatchEvent {
+                at: format!("{i:02}"),
+                kind: "test".into(),
+                data: Value::Null,
+            });
+        }
+        assert_eq!(state.events.len(), DEFAULT_MAX_EVENTS);
+        assert_eq!(state.events.first().unwrap().at, "10");
+        assert_eq!(state.events.last().unwrap().at, "59");
+    }
+
+    #[test]
+    fn v1_state_normalizes_markers_and_pr_identity() {
+        let state = normalize_watch_state_json(sample_v1()).unwrap();
+        assert_eq!(state.schema_version, 2);
+        assert_eq!(state.watch_id, "1jehuang-jcode-pr-188");
+        assert_eq!(state.pr.repo, "1jehuang/jcode");
+        assert_eq!(state.pr.number, 188);
+        assert_eq!(state.pr.base_ref.as_deref(), Some("master"));
+        assert_eq!(state.polling.quiet_cycles, 2);
+        assert!(
+            state
+                .last_seen
+                .review_threads
+                .contains_key("PRRT_kwDOSQE1Ec5_cHz3")
+        );
+        assert!(state.last_seen.review_comments.contains_key("3183715059"));
+        assert!(
+            state
+                .last_seen
+                .timeline
+                .contains_key("cross-referenced:2026-05-11T06:00:53Z")
+        );
+        assert_eq!(state.last_cycle.status, CycleStatus::QuietPending);
+    }
+
+    #[test]
+    fn partial_failure_does_not_increment_quiet_cycles_or_ready() {
+        let mut state = PrWatchState::new(PrTarget {
+            repo: "owner/repo".into(),
+            number: 1,
+        });
+        state.pr.state = Some("OPEN".into());
+        state.polling.quiet_cycles = 2;
+        state.apply_cycle_outcome(CycleOutcome {
+            partial_failure: true,
+            ..CycleOutcome::default()
+        });
+        assert_eq!(state.polling.quiet_cycles, 2);
+        assert_eq!(state.last_cycle.status, CycleStatus::TransientFailure);
+        assert_ne!(state.readiness(), Readiness::ReadyForHumanMerge);
+    }
+
+    #[test]
+    fn clean_cycles_reach_ready_for_human_merge() {
+        let mut state = PrWatchState::new(PrTarget {
+            repo: "owner/repo".into(),
+            number: 1,
+        });
+        state.pr.state = Some("OPEN".into());
+        state.polling.required_quiet_cycles = 2;
+        state.apply_cycle_outcome(CycleOutcome::default());
+        assert_eq!(state.last_cycle.status, CycleStatus::QuietPending);
+        state.apply_cycle_outcome(CycleOutcome::default());
+        assert_eq!(state.last_cycle.status, CycleStatus::QuietSatisfied);
+        assert_eq!(state.readiness(), Readiness::ReadyForHumanMerge);
+    }
+
+    #[test]
+    fn actionable_or_failed_checks_reset_quiet_cycles() {
+        let mut state = PrWatchState::new(PrTarget {
+            repo: "owner/repo".into(),
+            number: 1,
+        });
+        state.polling.quiet_cycles = 2;
+        state.apply_cycle_outcome(CycleOutcome {
+            pending_actionable: vec![ActionableItem {
+                id: "t1".into(),
+                surface: "review_threads".into(),
+                summary: "fix it".into(),
+                url: None,
+                path: None,
+                status: None,
+            }],
+            ..CycleOutcome::default()
+        });
+        assert_eq!(state.polling.quiet_cycles, 0);
+        assert_eq!(state.last_cycle.status, CycleStatus::ActionRequired);
+        assert_eq!(state.readiness(), Readiness::NotReadyActionRequired);
+
+        state.pending_actionable.clear();
+        state.polling.quiet_cycles = 2;
+        state.apply_cycle_outcome(CycleOutcome {
+            failed_check_count: 1,
+            ..CycleOutcome::default()
+        });
+        assert_eq!(state.polling.quiet_cycles, 0);
+        assert_eq!(state.last_cycle.status, CycleStatus::ChecksFailed);
+    }
+}

--- a/crates/jcode-workflow/Cargo.toml
+++ b/crates/jcode-workflow/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "jcode-workflow"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[dependencies]
+chrono = { version = "0.4", features = ["serde"] }
+jcode-background-types = { path = "../jcode-background-types" }
+jcode-plan = { path = "../jcode-plan" }
+jcode-task-types = { path = "../jcode-task-types" }
+serde = { version = "1", features = ["derive"] }
+
+[dev-dependencies]
+serde_json = "1"

--- a/crates/jcode-workflow/Cargo.toml
+++ b/crates/jcode-workflow/Cargo.toml
@@ -5,6 +5,8 @@ edition = "2024"
 publish = false
 
 [dependencies]
+anyhow = "1"
+async-trait = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
 jcode-background-types = { path = "../jcode-background-types" }
 jcode-plan = { path = "../jcode-plan" }
@@ -13,3 +15,4 @@ serde = { version = "1", features = ["derive"] }
 
 [dev-dependencies]
 serde_json = "1"
+tokio = { version = "1", features = ["macros", "rt"] }

--- a/crates/jcode-workflow/src/lib.rs
+++ b/crates/jcode-workflow/src/lib.rs
@@ -1,6 +1,14 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
+pub mod ralplan;
+
+pub use ralplan::{
+    RalplanConsensusExecutor, RalplanDraft, RalplanDraftContext, RalplanPlanValidationError,
+    RalplanReview, RalplanReviewContext, RalplanReviewVerdict, RalplanRunOptions, RalplanRunResult,
+    RalplanTerminalStatus, run_ralplan_consensus, validate_ralplan_plan,
+};
+
 pub const WORKFLOW_STATE_SCHEMA_VERSION: u32 = 1;
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]

--- a/crates/jcode-workflow/src/lib.rs
+++ b/crates/jcode-workflow/src/lib.rs
@@ -1,0 +1,422 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+pub const WORKFLOW_STATE_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkflowMode {
+    Ralplan,
+    Ultrawork,
+    Ralph,
+}
+
+impl WorkflowMode {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Ralplan => "ralplan",
+            Self::Ultrawork => "ultrawork",
+            Self::Ralph => "ralph",
+        }
+    }
+
+    pub fn is_enabled_in_mvp(self) -> bool {
+        matches!(self, Self::Ralplan | Self::Ultrawork)
+    }
+
+    fn default_max_iterations(self) -> u32 {
+        match self {
+            Self::Ralplan => 3,
+            Self::Ultrawork => 1,
+            Self::Ralph => 50,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkflowPhase {
+    Planning,
+    Drafting,
+    ArchitectReview,
+    CriticReview,
+    Executing,
+    Verifying,
+    Blocked,
+    Completed,
+    Cancelled,
+    Failed,
+}
+
+impl WorkflowPhase {
+    pub fn is_terminal(self) -> bool {
+        matches!(self, Self::Completed | Self::Cancelled | Self::Failed)
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkflowActivationSource {
+    SlashCommand,
+    ExplicitKeyword,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WorkflowActivation {
+    pub mode: WorkflowMode,
+    pub source: WorkflowActivationSource,
+    pub raw_trigger: String,
+    pub task_text: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WorkflowState {
+    pub schema_version: u32,
+    pub mode: WorkflowMode,
+    pub active: bool,
+    pub phase: WorkflowPhase,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub goal_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub plan_id: Option<String>,
+    pub iteration: u32,
+    pub max_iterations: u32,
+    pub started_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub completed_at: Option<DateTime<Utc>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_error: Option<String>,
+}
+
+impl WorkflowState {
+    pub fn new(mode: WorkflowMode, phase: WorkflowPhase, now: DateTime<Utc>) -> Self {
+        Self {
+            schema_version: WORKFLOW_STATE_SCHEMA_VERSION,
+            mode,
+            active: true,
+            phase,
+            session_id: None,
+            goal_id: None,
+            plan_id: None,
+            iteration: 1,
+            max_iterations: mode.default_max_iterations(),
+            started_at: now,
+            updated_at: now,
+            completed_at: None,
+            last_error: None,
+        }
+    }
+
+    pub fn for_activation(activation: &WorkflowActivation, now: DateTime<Utc>) -> Self {
+        Self::new(
+            activation.mode,
+            initial_phase_for_mode(activation.mode),
+            now,
+        )
+    }
+
+    pub fn is_terminal(&self) -> bool {
+        self.phase.is_terminal() || !self.active
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WorkflowTransition {
+    pub from_mode: Option<WorkflowMode>,
+    pub from_phase: Option<WorkflowPhase>,
+    pub to_mode: WorkflowMode,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkflowTransitionDecision {
+    Allowed,
+    Rejected { reason: String },
+}
+
+impl WorkflowTransitionDecision {
+    pub fn is_allowed(&self) -> bool {
+        matches!(self, Self::Allowed)
+    }
+}
+
+pub fn parse_workflow_activation(input: &str) -> Option<WorkflowActivation> {
+    let trimmed = input.trim_start();
+    if !trimmed.starts_with('/') {
+        return None;
+    }
+
+    let mut parts = trimmed.splitn(2, char::is_whitespace);
+    let raw_trigger = parts.next()?;
+    let task_text = parts.next().unwrap_or_default().trim().to_string();
+    let normalized = raw_trigger.to_ascii_lowercase();
+
+    let mode = match normalized.as_str() {
+        "/ralplan" => WorkflowMode::Ralplan,
+        "/ulw" | "/ultrawork" => WorkflowMode::Ultrawork,
+        _ => return None,
+    };
+
+    if !mode.is_enabled_in_mvp() {
+        return None;
+    }
+
+    Some(WorkflowActivation {
+        mode,
+        source: WorkflowActivationSource::SlashCommand,
+        raw_trigger: normalized,
+        task_text,
+    })
+}
+
+pub fn validate_workflow_transition(
+    current: Option<&WorkflowState>,
+    requested: WorkflowMode,
+) -> WorkflowTransitionDecision {
+    if !requested.is_enabled_in_mvp() {
+        return WorkflowTransitionDecision::Rejected {
+            reason: format!(
+                "workflow mode '{}' is not enabled in the MVP",
+                requested.as_str()
+            ),
+        };
+    }
+
+    let Some(current) = current else {
+        return WorkflowTransitionDecision::Allowed;
+    };
+
+    if current.is_terminal() {
+        return WorkflowTransitionDecision::Allowed;
+    }
+
+    if current.mode == requested {
+        return WorkflowTransitionDecision::Rejected {
+            reason: format!("workflow mode '{}' is already active", requested.as_str()),
+        };
+    }
+
+    match (current.mode, current.phase, requested) {
+        (WorkflowMode::Ralplan, WorkflowPhase::Completed, WorkflowMode::Ultrawork) => {
+            WorkflowTransitionDecision::Allowed
+        }
+        (WorkflowMode::Ralplan, _, WorkflowMode::Ultrawork) => {
+            WorkflowTransitionDecision::Rejected {
+                reason: "cannot start ultrawork while ralplan is still active".to_string(),
+            }
+        }
+        (WorkflowMode::Ultrawork, _, WorkflowMode::Ralplan) => {
+            WorkflowTransitionDecision::Rejected {
+                reason: "cannot start ralplan while ultrawork is active".to_string(),
+            }
+        }
+        (_, _, _) => WorkflowTransitionDecision::Rejected {
+            reason: format!(
+                "cannot start '{}' while '{}' is active",
+                requested.as_str(),
+                current.mode.as_str()
+            ),
+        },
+    }
+}
+
+pub fn workflow_plan_summary(items: &[jcode_plan::PlanItem]) -> jcode_plan::PlanGraphSummary {
+    jcode_plan::summarize_plan_graph(items)
+}
+
+pub fn goal_is_workflow_relevant(goal: &jcode_task_types::Goal) -> bool {
+    goal.status.is_resumable() || goal.status == jcode_task_types::GoalStatus::Completed
+}
+
+pub fn background_task_is_active(status: &jcode_background_types::BackgroundTaskStatus) -> bool {
+    matches!(
+        status,
+        jcode_background_types::BackgroundTaskStatus::Running
+    )
+}
+
+fn initial_phase_for_mode(mode: WorkflowMode) -> WorkflowPhase {
+    match mode {
+        WorkflowMode::Ralplan => WorkflowPhase::Planning,
+        WorkflowMode::Ultrawork => WorkflowPhase::Planning,
+        WorkflowMode::Ralph => WorkflowPhase::Planning,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn fixed_time() -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2026, 5, 4, 18, 0, 0).unwrap()
+    }
+
+    fn state(mode: WorkflowMode, phase: WorkflowPhase) -> WorkflowState {
+        WorkflowState::new(mode, phase, fixed_time())
+    }
+
+    #[test]
+    fn workflow_mode_serializes_snake_case() {
+        assert_eq!(
+            serde_json::to_string(&WorkflowMode::Ralplan).unwrap(),
+            "\"ralplan\""
+        );
+        assert_eq!(
+            serde_json::to_string(&WorkflowMode::Ultrawork).unwrap(),
+            "\"ultrawork\""
+        );
+    }
+
+    #[test]
+    fn workflow_phase_terminal_detection() {
+        assert!(WorkflowPhase::Completed.is_terminal());
+        assert!(WorkflowPhase::Cancelled.is_terminal());
+        assert!(WorkflowPhase::Failed.is_terminal());
+        assert!(!WorkflowPhase::Planning.is_terminal());
+        assert!(!WorkflowPhase::Executing.is_terminal());
+    }
+
+    #[test]
+    fn workflow_state_round_trips() {
+        let state =
+            WorkflowState::new(WorkflowMode::Ralplan, WorkflowPhase::Planning, fixed_time());
+        let encoded = serde_json::to_string(&state).unwrap();
+        let decoded: WorkflowState = serde_json::from_str(&encoded).unwrap();
+        assert_eq!(decoded, state);
+    }
+
+    #[test]
+    fn parse_ralplan_slash_activation() {
+        let activation = parse_workflow_activation("/ralplan create a plan").unwrap();
+        assert_eq!(activation.mode, WorkflowMode::Ralplan);
+        assert_eq!(activation.source, WorkflowActivationSource::SlashCommand);
+        assert_eq!(activation.raw_trigger, "/ralplan");
+        assert_eq!(activation.task_text, "create a plan");
+    }
+
+    #[test]
+    fn parse_ulw_slash_activation() {
+        let activation = parse_workflow_activation("/ulw do work").unwrap();
+        assert_eq!(activation.mode, WorkflowMode::Ultrawork);
+        assert_eq!(activation.raw_trigger, "/ulw");
+        assert_eq!(activation.task_text, "do work");
+    }
+
+    #[test]
+    fn parse_ultrawork_slash_activation() {
+        let activation = parse_workflow_activation("/ultrawork do work").unwrap();
+        assert_eq!(activation.mode, WorkflowMode::Ultrawork);
+        assert_eq!(activation.raw_trigger, "/ultrawork");
+    }
+
+    #[test]
+    fn parse_activation_allows_leading_whitespace() {
+        let activation = parse_workflow_activation("   /ulw do work").unwrap();
+        assert_eq!(activation.mode, WorkflowMode::Ultrawork);
+        assert_eq!(activation.task_text, "do work");
+    }
+
+    #[test]
+    fn does_not_parse_bare_ulw() {
+        assert_eq!(parse_workflow_activation("ulw do work"), None);
+    }
+
+    #[test]
+    fn does_not_parse_ralph() {
+        assert_eq!(parse_workflow_activation("/ralph do work"), None);
+    }
+
+    #[test]
+    fn does_not_parse_incidental_phrases() {
+        for input in [
+            "I don't stop the build before tests",
+            "this is a must complete list",
+            "please make a consensus plan eventually",
+        ] {
+            assert_eq!(parse_workflow_activation(input), None, "input: {input}");
+        }
+    }
+
+    #[test]
+    fn does_not_parse_mid_sentence_slash() {
+        assert_eq!(parse_workflow_activation("please run /ulw on this"), None);
+    }
+
+    #[test]
+    fn transition_allows_no_active_to_ralplan() {
+        assert!(validate_workflow_transition(None, WorkflowMode::Ralplan).is_allowed());
+    }
+
+    #[test]
+    fn transition_allows_no_active_to_ultrawork() {
+        assert!(validate_workflow_transition(None, WorkflowMode::Ultrawork).is_allowed());
+    }
+
+    #[test]
+    fn transition_rejects_ralph() {
+        assert!(!validate_workflow_transition(None, WorkflowMode::Ralph).is_allowed());
+    }
+
+    #[test]
+    fn transition_rejects_active_ralplan_to_ultrawork() {
+        let current = state(WorkflowMode::Ralplan, WorkflowPhase::ArchitectReview);
+        assert!(
+            !validate_workflow_transition(Some(&current), WorkflowMode::Ultrawork).is_allowed()
+        );
+    }
+
+    #[test]
+    fn transition_allows_completed_ralplan_to_ultrawork() {
+        let mut current = state(WorkflowMode::Ralplan, WorkflowPhase::Completed);
+        current.active = false;
+        current.completed_at = Some(fixed_time());
+        assert!(validate_workflow_transition(Some(&current), WorkflowMode::Ultrawork).is_allowed());
+    }
+
+    #[test]
+    fn transition_rejects_active_ultrawork_to_ralplan() {
+        let current = state(WorkflowMode::Ultrawork, WorkflowPhase::Executing);
+        assert!(!validate_workflow_transition(Some(&current), WorkflowMode::Ralplan).is_allowed());
+    }
+
+    #[test]
+    fn transition_allows_terminal_state_to_new_workflow() {
+        let current = state(WorkflowMode::Ultrawork, WorkflowPhase::Failed);
+        assert!(validate_workflow_transition(Some(&current), WorkflowMode::Ralplan).is_allowed());
+    }
+
+    #[test]
+    fn bridge_helpers_use_existing_typed_primitives() {
+        assert!(background_task_is_active(
+            &jcode_background_types::BackgroundTaskStatus::Running
+        ));
+        assert!(!background_task_is_active(
+            &jcode_background_types::BackgroundTaskStatus::Completed
+        ));
+
+        let plan = vec![jcode_plan::PlanItem {
+            content: "do thing".to_string(),
+            status: "queued".to_string(),
+            priority: "high".to_string(),
+            id: "item-1".to_string(),
+            subsystem: None,
+            file_scope: Vec::new(),
+            blocked_by: Vec::new(),
+            assigned_to: None,
+        }];
+        assert_eq!(
+            workflow_plan_summary(&plan).ready_ids,
+            vec!["item-1".to_string()]
+        );
+
+        let goal = jcode_task_types::Goal::new(
+            "Ship workflow modes",
+            jcode_task_types::GoalScope::Project,
+        );
+        assert!(goal_is_workflow_relevant(&goal));
+    }
+}

--- a/crates/jcode-workflow/src/ralplan.rs
+++ b/crates/jcode-workflow/src/ralplan.rs
@@ -1,0 +1,645 @@
+use async_trait::async_trait;
+use jcode_plan::{PlanGraphSummary, PlanItem, summarize_plan_graph};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum RalplanReviewVerdict {
+    Approve,
+    Iterate,
+    Reject,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RalplanDraft {
+    pub plan_items: Vec<PlanItem>,
+    pub summary: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub notes: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RalplanReview {
+    pub verdict: RalplanReviewVerdict,
+    pub summary: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub required_changes: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RalplanRunOptions {
+    pub task: String,
+    pub max_iterations: u32,
+}
+
+impl RalplanRunOptions {
+    pub fn new(task: impl Into<String>) -> Self {
+        Self {
+            task: task.into(),
+            max_iterations: 3,
+        }
+    }
+
+    fn normalized(self) -> Result<Self, String> {
+        let task = self.task.trim().to_string();
+        if task.is_empty() {
+            return Err("ralplan task must not be empty".to_string());
+        }
+        Ok(Self {
+            task,
+            max_iterations: self.max_iterations.max(1),
+        })
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum RalplanTerminalStatus {
+    Approved,
+    Rejected,
+    MaxIterationsReached,
+    InvalidPlan,
+    ExecutorFailed,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RalplanRunResult {
+    pub status: RalplanTerminalStatus,
+    pub iterations: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub final_draft: Option<RalplanDraft>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub architect_reviews: Vec<RalplanReview>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub critic_reviews: Vec<RalplanReview>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub validation_summary: Option<PlanGraphSummary>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+pub struct RalplanDraftContext<'a> {
+    pub task: &'a str,
+    pub iteration: u32,
+    pub previous_draft: Option<&'a RalplanDraft>,
+    pub architect_reviews: &'a [RalplanReview],
+    pub critic_reviews: &'a [RalplanReview],
+}
+
+pub struct RalplanReviewContext<'a> {
+    pub task: &'a str,
+    pub iteration: u32,
+    pub draft: &'a RalplanDraft,
+    pub prior_architect_reviews: &'a [RalplanReview],
+    pub prior_critic_reviews: &'a [RalplanReview],
+}
+
+#[async_trait]
+pub trait RalplanConsensusExecutor {
+    async fn draft(&mut self, ctx: RalplanDraftContext<'_>) -> anyhow::Result<RalplanDraft>;
+
+    async fn architect_review(
+        &mut self,
+        ctx: RalplanReviewContext<'_>,
+    ) -> anyhow::Result<RalplanReview>;
+
+    async fn critic_review(
+        &mut self,
+        ctx: RalplanReviewContext<'_>,
+    ) -> anyhow::Result<RalplanReview>;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RalplanPlanValidationError {
+    EmptyPlan,
+    DuplicateIds(Vec<String>),
+    Cycles(Vec<String>),
+    UnresolvedDependencies(Vec<String>),
+    NoRunnableItems,
+}
+
+impl std::fmt::Display for RalplanPlanValidationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::EmptyPlan => write!(f, "plan must contain at least one item"),
+            Self::DuplicateIds(ids) => {
+                write!(f, "plan contains duplicate item ids: {}", ids.join(", "))
+            }
+            Self::Cycles(ids) => write!(
+                f,
+                "plan contains dependency cycles involving: {}",
+                ids.join(", ")
+            ),
+            Self::UnresolvedDependencies(ids) => {
+                write!(
+                    f,
+                    "plan contains unresolved dependencies: {}",
+                    ids.join(", ")
+                )
+            }
+            Self::NoRunnableItems => write!(f, "plan must contain at least one runnable item"),
+        }
+    }
+}
+
+impl std::error::Error for RalplanPlanValidationError {}
+
+pub fn validate_ralplan_plan(
+    items: &[PlanItem],
+) -> Result<PlanGraphSummary, RalplanPlanValidationError> {
+    if items.is_empty() {
+        return Err(RalplanPlanValidationError::EmptyPlan);
+    }
+
+    let duplicate_ids = duplicate_plan_item_ids(items);
+    if !duplicate_ids.is_empty() {
+        return Err(RalplanPlanValidationError::DuplicateIds(duplicate_ids));
+    }
+
+    let summary = summarize_plan_graph(items);
+    if !summary.cycle_ids.is_empty() {
+        return Err(RalplanPlanValidationError::Cycles(summary.cycle_ids));
+    }
+    if !summary.unresolved_dependency_ids.is_empty() {
+        return Err(RalplanPlanValidationError::UnresolvedDependencies(
+            summary.unresolved_dependency_ids,
+        ));
+    }
+    if summary.ready_ids.is_empty() {
+        return Err(RalplanPlanValidationError::NoRunnableItems);
+    }
+
+    Ok(summary)
+}
+
+pub async fn run_ralplan_consensus<E>(
+    executor: &mut E,
+    options: RalplanRunOptions,
+) -> RalplanRunResult
+where
+    E: RalplanConsensusExecutor + Send,
+{
+    let options = match options.normalized() {
+        Ok(options) => options,
+        Err(error) => return failure_result(RalplanTerminalStatus::InvalidPlan, 0, error),
+    };
+
+    let mut final_draft: Option<RalplanDraft> = None;
+    let mut architect_reviews = Vec::new();
+    let mut critic_reviews = Vec::new();
+    let mut validation_summary = None;
+
+    for iteration in 1..=options.max_iterations {
+        let draft = match executor
+            .draft(RalplanDraftContext {
+                task: &options.task,
+                iteration,
+                previous_draft: final_draft.as_ref(),
+                architect_reviews: &architect_reviews,
+                critic_reviews: &critic_reviews,
+            })
+            .await
+        {
+            Ok(draft) => draft,
+            Err(error) => {
+                return RalplanRunResult {
+                    status: RalplanTerminalStatus::ExecutorFailed,
+                    iterations: iteration,
+                    final_draft,
+                    architect_reviews,
+                    critic_reviews,
+                    validation_summary,
+                    error: Some(error.to_string()),
+                };
+            }
+        };
+
+        let summary = match validate_ralplan_plan(&draft.plan_items) {
+            Ok(summary) => summary,
+            Err(error) => {
+                return RalplanRunResult {
+                    status: RalplanTerminalStatus::InvalidPlan,
+                    iterations: iteration,
+                    final_draft: Some(draft),
+                    architect_reviews,
+                    critic_reviews,
+                    validation_summary: None,
+                    error: Some(error.to_string()),
+                };
+            }
+        };
+        validation_summary = Some(summary);
+
+        let architect_review = match executor
+            .architect_review(RalplanReviewContext {
+                task: &options.task,
+                iteration,
+                draft: &draft,
+                prior_architect_reviews: &architect_reviews,
+                prior_critic_reviews: &critic_reviews,
+            })
+            .await
+        {
+            Ok(review) => review,
+            Err(error) => {
+                return RalplanRunResult {
+                    status: RalplanTerminalStatus::ExecutorFailed,
+                    iterations: iteration,
+                    final_draft: Some(draft),
+                    architect_reviews,
+                    critic_reviews,
+                    validation_summary,
+                    error: Some(error.to_string()),
+                };
+            }
+        };
+        architect_reviews.push(architect_review);
+
+        let critic_review = match executor
+            .critic_review(RalplanReviewContext {
+                task: &options.task,
+                iteration,
+                draft: &draft,
+                prior_architect_reviews: &architect_reviews,
+                prior_critic_reviews: &critic_reviews,
+            })
+            .await
+        {
+            Ok(review) => review,
+            Err(error) => {
+                return RalplanRunResult {
+                    status: RalplanTerminalStatus::ExecutorFailed,
+                    iterations: iteration,
+                    final_draft: Some(draft),
+                    architect_reviews,
+                    critic_reviews,
+                    validation_summary,
+                    error: Some(error.to_string()),
+                };
+            }
+        };
+        let verdict = critic_review.verdict;
+        critic_reviews.push(critic_review);
+        final_draft = Some(draft);
+
+        match verdict {
+            RalplanReviewVerdict::Approve => {
+                return RalplanRunResult {
+                    status: RalplanTerminalStatus::Approved,
+                    iterations: iteration,
+                    final_draft,
+                    architect_reviews,
+                    critic_reviews,
+                    validation_summary,
+                    error: None,
+                };
+            }
+            RalplanReviewVerdict::Reject => {
+                return RalplanRunResult {
+                    status: RalplanTerminalStatus::Rejected,
+                    iterations: iteration,
+                    final_draft,
+                    architect_reviews,
+                    critic_reviews,
+                    validation_summary,
+                    error: None,
+                };
+            }
+            RalplanReviewVerdict::Iterate => {}
+        }
+    }
+
+    RalplanRunResult {
+        status: RalplanTerminalStatus::MaxIterationsReached,
+        iterations: options.max_iterations,
+        final_draft,
+        architect_reviews,
+        critic_reviews,
+        validation_summary,
+        error: None,
+    }
+}
+
+fn duplicate_plan_item_ids(items: &[PlanItem]) -> Vec<String> {
+    let mut counts = BTreeMap::<&str, usize>::new();
+    for item in items {
+        *counts.entry(item.id.as_str()).or_insert(0) += 1;
+    }
+    counts
+        .into_iter()
+        .filter_map(|(id, count)| (count > 1).then_some(id.to_string()))
+        .collect()
+}
+
+fn failure_result(
+    status: RalplanTerminalStatus,
+    iterations: u32,
+    error: String,
+) -> RalplanRunResult {
+    RalplanRunResult {
+        status,
+        iterations,
+        final_draft: None,
+        architect_reviews: Vec::new(),
+        critic_reviews: Vec::new(),
+        validation_summary: None,
+        error: Some(error),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn item(id: &str, status: &str, blocked_by: &[&str]) -> PlanItem {
+        PlanItem {
+            content: format!("task {id}"),
+            status: status.to_string(),
+            priority: "medium".to_string(),
+            id: id.to_string(),
+            subsystem: None,
+            file_scope: Vec::new(),
+            blocked_by: blocked_by.iter().map(|value| value.to_string()).collect(),
+            assigned_to: None,
+        }
+    }
+
+    fn draft(items: Vec<PlanItem>) -> RalplanDraft {
+        RalplanDraft {
+            plan_items: items,
+            summary: "draft summary".to_string(),
+            notes: Vec::new(),
+        }
+    }
+
+    fn review(verdict: RalplanReviewVerdict) -> RalplanReview {
+        RalplanReview {
+            verdict,
+            summary: format!("{verdict:?}"),
+            required_changes: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn validate_plan_rejects_empty_plan() {
+        assert_eq!(
+            validate_ralplan_plan(&[]).unwrap_err(),
+            RalplanPlanValidationError::EmptyPlan
+        );
+    }
+
+    #[test]
+    fn validate_plan_rejects_duplicate_ids() {
+        assert_eq!(
+            validate_ralplan_plan(&[item("a", "queued", &[]), item("a", "queued", &[])])
+                .unwrap_err(),
+            RalplanPlanValidationError::DuplicateIds(vec!["a".to_string()])
+        );
+    }
+
+    #[test]
+    fn validate_plan_rejects_cycles() {
+        assert_eq!(
+            validate_ralplan_plan(&[item("a", "queued", &["b"]), item("b", "queued", &["a"])])
+                .unwrap_err(),
+            RalplanPlanValidationError::Cycles(vec!["a".to_string(), "b".to_string()])
+        );
+    }
+
+    #[test]
+    fn validate_plan_rejects_unresolved_dependencies() {
+        assert_eq!(
+            validate_ralplan_plan(&[item("a", "queued", &["missing"])]).unwrap_err(),
+            RalplanPlanValidationError::UnresolvedDependencies(vec!["missing".to_string()])
+        );
+    }
+
+    #[test]
+    fn validate_plan_accepts_ready_graph() {
+        let summary =
+            validate_ralplan_plan(&[item("a", "queued", &[]), item("b", "queued", &["a"])])
+                .unwrap();
+        assert_eq!(summary.ready_ids, vec!["a".to_string()]);
+        assert_eq!(summary.blocked_ids, vec!["b".to_string()]);
+    }
+
+    #[test]
+    fn validate_plan_rejects_no_runnable_items() {
+        assert_eq!(
+            validate_ralplan_plan(&[item("a", "completed", &[])]).unwrap_err(),
+            RalplanPlanValidationError::NoRunnableItems
+        );
+    }
+
+    #[derive(Default)]
+    struct FakeExecutor {
+        calls: Vec<String>,
+        critic_verdicts: Vec<RalplanReviewVerdict>,
+        draft_error_at: Option<u32>,
+        architect_error_at: Option<u32>,
+        critic_error_at: Option<u32>,
+        invalid_plan_at: Option<u32>,
+    }
+
+    impl FakeExecutor {
+        fn with_verdicts(critic_verdicts: Vec<RalplanReviewVerdict>) -> Self {
+            Self {
+                critic_verdicts,
+                ..Self::default()
+            }
+        }
+    }
+
+    #[async_trait]
+    impl RalplanConsensusExecutor for FakeExecutor {
+        async fn draft(&mut self, ctx: RalplanDraftContext<'_>) -> anyhow::Result<RalplanDraft> {
+            self.calls.push(format!("draft:{}", ctx.iteration));
+            if self.draft_error_at == Some(ctx.iteration) {
+                anyhow::bail!("draft failed at {}", ctx.iteration);
+            }
+            if self.invalid_plan_at == Some(ctx.iteration) {
+                return Ok(draft(Vec::new()));
+            }
+            Ok(draft(vec![item("a", "queued", &[])]))
+        }
+
+        async fn architect_review(
+            &mut self,
+            ctx: RalplanReviewContext<'_>,
+        ) -> anyhow::Result<RalplanReview> {
+            self.calls.push(format!("architect:{}", ctx.iteration));
+            if self.architect_error_at == Some(ctx.iteration) {
+                anyhow::bail!("architect failed at {}", ctx.iteration);
+            }
+            Ok(review(RalplanReviewVerdict::Approve))
+        }
+
+        async fn critic_review(
+            &mut self,
+            ctx: RalplanReviewContext<'_>,
+        ) -> anyhow::Result<RalplanReview> {
+            self.calls.push(format!("critic:{}", ctx.iteration));
+            if self.critic_error_at == Some(ctx.iteration) {
+                anyhow::bail!("critic failed at {}", ctx.iteration);
+            }
+            let verdict = self
+                .critic_verdicts
+                .get((ctx.iteration - 1) as usize)
+                .copied()
+                .unwrap_or(RalplanReviewVerdict::Iterate);
+            Ok(review(verdict))
+        }
+    }
+
+    #[tokio::test]
+    async fn ralplan_calls_architect_before_critic() {
+        let mut executor = FakeExecutor::with_verdicts(vec![RalplanReviewVerdict::Approve]);
+        let result = run_ralplan_consensus(&mut executor, RalplanRunOptions::new("task")).await;
+        assert_eq!(result.status, RalplanTerminalStatus::Approved);
+        assert_eq!(executor.calls, vec!["draft:1", "architect:1", "critic:1"]);
+    }
+
+    #[tokio::test]
+    async fn ralplan_approves_on_first_iteration() {
+        let mut executor = FakeExecutor::with_verdicts(vec![RalplanReviewVerdict::Approve]);
+        let result = run_ralplan_consensus(&mut executor, RalplanRunOptions::new("task")).await;
+        assert_eq!(result.status, RalplanTerminalStatus::Approved);
+        assert_eq!(result.iterations, 1);
+        assert_eq!(result.architect_reviews.len(), 1);
+        assert_eq!(result.critic_reviews.len(), 1);
+        assert!(result.final_draft.is_some());
+    }
+
+    #[tokio::test]
+    async fn ralplan_iterates_until_approval() {
+        let mut executor = FakeExecutor::with_verdicts(vec![
+            RalplanReviewVerdict::Iterate,
+            RalplanReviewVerdict::Approve,
+        ]);
+        let result = run_ralplan_consensus(&mut executor, RalplanRunOptions::new("task")).await;
+        assert_eq!(result.status, RalplanTerminalStatus::Approved);
+        assert_eq!(result.iterations, 2);
+        assert_eq!(result.architect_reviews.len(), 2);
+        assert_eq!(result.critic_reviews.len(), 2);
+        assert_eq!(
+            executor.calls,
+            vec![
+                "draft:1",
+                "architect:1",
+                "critic:1",
+                "draft:2",
+                "architect:2",
+                "critic:2"
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn ralplan_stops_at_max_iterations() {
+        let mut executor = FakeExecutor::with_verdicts(vec![RalplanReviewVerdict::Iterate; 5]);
+        let mut options = RalplanRunOptions::new("task");
+        options.max_iterations = 3;
+        let result = run_ralplan_consensus(&mut executor, options).await;
+        assert_eq!(result.status, RalplanTerminalStatus::MaxIterationsReached);
+        assert_eq!(result.iterations, 3);
+        assert_eq!(result.architect_reviews.len(), 3);
+        assert_eq!(result.critic_reviews.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn ralplan_rejects_on_critic_reject() {
+        let mut executor = FakeExecutor::with_verdicts(vec![RalplanReviewVerdict::Reject]);
+        let result = run_ralplan_consensus(&mut executor, RalplanRunOptions::new("task")).await;
+        assert_eq!(result.status, RalplanTerminalStatus::Rejected);
+        assert_eq!(result.iterations, 1);
+    }
+
+    #[tokio::test]
+    async fn ralplan_returns_executor_failed_on_draft_error() {
+        let mut executor = FakeExecutor {
+            draft_error_at: Some(1),
+            ..FakeExecutor::default()
+        };
+        let result = run_ralplan_consensus(&mut executor, RalplanRunOptions::new("task")).await;
+        assert_eq!(result.status, RalplanTerminalStatus::ExecutorFailed);
+        assert_eq!(result.iterations, 1);
+        assert!(result.error.unwrap().contains("draft failed"));
+    }
+
+    #[tokio::test]
+    async fn ralplan_returns_executor_failed_on_architect_error() {
+        let mut executor = FakeExecutor {
+            architect_error_at: Some(1),
+            ..FakeExecutor::default()
+        };
+        let result = run_ralplan_consensus(&mut executor, RalplanRunOptions::new("task")).await;
+        assert_eq!(result.status, RalplanTerminalStatus::ExecutorFailed);
+        assert_eq!(result.iterations, 1);
+        assert!(result.error.unwrap().contains("architect failed"));
+        assert!(result.final_draft.is_some());
+        assert!(result.architect_reviews.is_empty());
+    }
+
+    #[tokio::test]
+    async fn ralplan_returns_executor_failed_on_critic_error() {
+        let mut executor = FakeExecutor {
+            critic_error_at: Some(1),
+            ..FakeExecutor::default()
+        };
+        let result = run_ralplan_consensus(&mut executor, RalplanRunOptions::new("task")).await;
+        assert_eq!(result.status, RalplanTerminalStatus::ExecutorFailed);
+        assert_eq!(result.iterations, 1);
+        assert!(result.error.unwrap().contains("critic failed"));
+        assert!(result.final_draft.is_some());
+        assert_eq!(result.architect_reviews.len(), 1);
+        assert!(result.critic_reviews.is_empty());
+    }
+
+    #[tokio::test]
+    async fn ralplan_returns_invalid_plan_for_bad_draft() {
+        let mut executor = FakeExecutor {
+            invalid_plan_at: Some(1),
+            ..FakeExecutor::default()
+        };
+        let result = run_ralplan_consensus(&mut executor, RalplanRunOptions::new("task")).await;
+        assert_eq!(result.status, RalplanTerminalStatus::InvalidPlan);
+        assert_eq!(result.iterations, 1);
+        assert!(result.error.unwrap().contains("plan must contain"));
+        assert!(result.architect_reviews.is_empty());
+        assert!(result.critic_reviews.is_empty());
+    }
+
+    #[tokio::test]
+    async fn ralplan_normalizes_empty_task_to_invalid_plan() {
+        let mut executor = FakeExecutor::default();
+        let result = run_ralplan_consensus(&mut executor, RalplanRunOptions::new("   ")).await;
+        assert_eq!(result.status, RalplanTerminalStatus::InvalidPlan);
+        assert_eq!(result.iterations, 0);
+        assert!(result.error.unwrap().contains("must not be empty"));
+        assert!(executor.calls.is_empty());
+    }
+
+    #[tokio::test]
+    async fn ralplan_max_iterations_minimum_is_one() {
+        let mut executor = FakeExecutor::with_verdicts(vec![RalplanReviewVerdict::Iterate]);
+        let mut options = RalplanRunOptions::new("task");
+        options.max_iterations = 0;
+        let result = run_ralplan_consensus(&mut executor, options).await;
+        assert_eq!(result.status, RalplanTerminalStatus::MaxIterationsReached);
+        assert_eq!(result.iterations, 1);
+    }
+
+    #[test]
+    fn duplicate_ids_are_sorted() {
+        assert_eq!(
+            duplicate_plan_item_ids(&[
+                item("b", "queued", &[]),
+                item("a", "queued", &[]),
+                item("b", "queued", &[]),
+                item("a", "queued", &[]),
+            ]),
+            vec!["a".to_string(), "b".to_string()]
+        );
+    }
+}

--- a/docs/JCODE_WORKFLOW_MODES_PLAN.md
+++ b/docs/JCODE_WORKFLOW_MODES_PLAN.md
@@ -1,0 +1,389 @@
+# Jcode-native Workflow Modes Plan
+
+Status: revised plan, not yet implemented  
+Date: 2026-05-04
+
+## Purpose
+
+Add OMX-inspired workflow modes to Jcode while using Jcode's native typed runtime instead of copying OMX's tmux and ad hoc JSON state model.
+
+Target workflows:
+
+- `/ralplan`: consensus planning, Planner -> Architect -> Critic.
+- `/ulw` / `/ultrawork`: bounded parallel execution over independent work lanes.
+- `/ralph`: persistent completion loop with verification and stop/completion gates.
+
+Non-goal: reimplement `omx team` tmux pane orchestration. Jcode already has native swarm/session/background execution primitives.
+
+## Architectural decision
+
+Jcode workflow modes must be built on existing typed primitives:
+
+- `jcode-plan::PlanItem`
+  - canonical plan/task graph item.
+  - existing graph helpers: `summarize_plan_graph`, `next_runnable_item_ids`, `newly_ready_item_ids`.
+- `jcode-task-types::Goal`
+  - persistent user-facing goal/completion model.
+  - existing milestones, success criteria, blockers, progress.
+- `jcode-background-types::BackgroundTaskStatus`
+  - canonical source for background task liveness.
+- `jcode-agent-runtime::{SoftInterruptQueue, InterruptSignal, GracefulShutdownSignal}`
+  - canonical stop/interrupt integration points.
+
+Do **not** create `.jcode/state/workflows/*.json` as an independent source of truth for plans, todos, or completion. Workflow state may be persisted, but it must reference typed `Goal` and `PlanItem` data rather than duplicating them.
+
+## Ownership
+
+Create a new crate:
+
+```text
+crates/jcode-workflow/
+```
+
+Initial dependencies:
+
+- `jcode-plan`
+- `jcode-task-types`
+- `jcode-background-types`
+- `serde`
+- `chrono`
+
+Later, when implementing Ralph stop gates, add `jcode-agent-runtime` if needed.
+
+Rationale: workflow modes are higher-level orchestration policy. Keeping them out of `jcode-agent-runtime` avoids mixing runtime signal primitives with planning/goal policy, while still allowing the main binary/server to compose the pieces.
+
+## Core types
+
+### WorkflowMode
+
+```rust
+pub enum WorkflowMode {
+    Ralplan,
+    Ultrawork,
+    Ralph,
+}
+```
+
+### WorkflowPhase
+
+```rust
+pub enum WorkflowPhase {
+    Planning,
+    Drafting,
+    ArchitectReview,
+    CriticReview,
+    Executing,
+    Verifying,
+    Blocked,
+    Completed,
+    Cancelled,
+    Failed,
+}
+```
+
+### WorkflowState
+
+```rust
+pub struct WorkflowState {
+    pub schema_version: u32,
+    pub mode: WorkflowMode,
+    pub active: bool,
+    pub phase: WorkflowPhase,
+    pub session_id: Option<String>,
+    pub goal_id: Option<String>,
+    pub plan_id: Option<String>,
+    pub iteration: u32,
+    pub max_iterations: u32,
+    pub started_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    pub completed_at: Option<DateTime<Utc>>,
+    pub last_error: Option<String>,
+}
+```
+
+Important: `WorkflowState` identifies the active workflow and links to canonical `Goal` and `PlanItem` collections. It does not own a separate TODO list.
+
+### WorkflowActivation
+
+```rust
+pub struct WorkflowActivation {
+    pub mode: WorkflowMode,
+    pub source: WorkflowActivationSource,
+    pub raw_trigger: String,
+    pub task_text: String,
+}
+
+pub enum WorkflowActivationSource {
+    SlashCommand,
+    ExplicitKeyword,
+}
+```
+
+## Mode composition rules
+
+MVP rule: at most one primary workflow mode active per session.
+
+Allowed transitions:
+
+- `ralplan -> ultrawork`: allowed after plan approval.
+- `ralplan -> ralph`: allowed after plan approval, once Ralph exists.
+- `ultrawork -> completed/cancelled/failed`: normal terminal path.
+- `ralph` may internally use ultrawork-style planning/execution lanes, but does not activate a separate `Ultrawork` workflow state in MVP.
+
+Rejected transitions:
+
+- Starting `/ralplan` while `/ulw` is active unless the current workflow is completed/cancelled.
+- Starting `/ulw` while `/ralplan` is still reviewing unless explicitly using the approved plan handoff.
+- Starting `/ralph` in MVP, except as a documented placeholder that explains Ralph is not enabled until stop gates exist.
+
+## Activation policy
+
+Prefer explicit slash commands. Avoid broad natural-language triggers in MVP.
+
+MVP accepted triggers:
+
+- `/ralplan ...`
+- `/ulw ...`
+- `/ultrawork ...`
+
+Deferred triggers:
+
+- `/ralph ...`
+- `ralph`
+- `ulw` as a bare non-slash keyword
+- `don't stop`
+- `must complete`
+- `consensus plan`
+
+Reason: broad phrase triggers can activate workflows from incidental prose. If implicit triggers are added later, they must be high-confidence, visible to the user, and covered by negative tests.
+
+## Canonical plan representation
+
+`/ralplan` emits a canonical `Vec<PlanItem>`.
+
+Use `PlanItem` fields as follows:
+
+- `id`: stable item id, for example `plan-1`, `test-1`, `verify-1`.
+- `content`: task description.
+- `status`: `queued`, `ready`, `running`, `completed`, `blocked`, `failed`.
+- `priority`: `high`, `medium`, `low`.
+- `subsystem`: logical subsystem when known.
+- `file_scope`: files or directories the item may edit/read.
+- `blocked_by`: item ids that must complete first.
+- `assigned_to`: swarm/subagent/session id once assigned.
+
+If ralplan needs richer metadata, add typed extensions deliberately instead of using a parallel JSON shape. Candidate future additions:
+
+- `acceptance_criteria: Vec<String>`
+- `risk_notes: Vec<String>`
+- `verification_commands: Vec<String>`
+
+Markdown plans are rendered views. JSON `PlanItem` data is canonical.
+
+## Verification policy
+
+Verification must be explicit before Ralph ships.
+
+MVP verification levels:
+
+- Ralplan: graph validation only.
+  - `summarize_plan_graph` has no cycles.
+  - unresolved dependency ids are empty.
+  - at least one ready/runnable item exists unless the plan is intentionally blocked.
+- Ultrawork: lightweight evidence.
+  - If all file scopes are within one Rust crate, run `cargo check -p <crate>` when feasible.
+  - Otherwise run the smallest known relevant command discovered during planning or report why no command was run.
+  - Never claim full completion guarantee.
+- Ralph: deferred until stop gates and verification command policy are implemented.
+
+## Stop/completion gates for Ralph
+
+Ralph must not ship as an active workflow until gates are implemented.
+
+Completion predicate:
+
+```rust
+RalphComplete ==
+    all PlanItem statuses are terminal/completed as appropriate
+    && required verification has passed
+    && no tracked background task is Running
+    && changed files review is recorded
+    && final evidence is present
+```
+
+Stop behavior:
+
+- On `GracefulShutdownSignal`, check `RalphComplete`.
+- If complete, allow shutdown/completion.
+- If incomplete, enqueue a `SoftInterruptMessage` explaining missing gates and continue.
+- Provide an escape hatch for user intent, for example repeated interrupt or explicit `/cancel`, so Ralph never traps the user.
+
+The exact turn-loop integration should be implemented and tested before `/ralph` activation is enabled.
+
+## UI/status contract
+
+Workflow status is not optional. Any multi-step workflow must be visible.
+
+Minimum status fields:
+
+- mode
+- phase
+- iteration/max_iterations when relevant
+- linked goal id
+- ready/blocked/active/completed counts from `summarize_plan_graph`
+- age / last update
+- blocker summary if failed or blocked
+
+Example status strings:
+
+```text
+ralplan critic-review 2/3 ready:3 blocked:1
+ulw executing ready:0 active:2 completed:4
+ralph verifying 4/50 missing:tests,review
+```
+
+## Revised implementation sequence
+
+### PR 1: Workflow foundations
+
+Scope:
+
+- Add `crates/jcode-workflow`.
+- Add `WorkflowMode`, `WorkflowPhase`, `WorkflowState`, `WorkflowActivation`.
+- Add conservative slash-command activation parser.
+- Add mode transition validation.
+- Add state serialization with `schema_version`.
+
+Acceptance tests:
+
+- State serde round-trip for all modes.
+- Transition validation accepts and rejects expected mode changes.
+- Slash activation detects `/ralplan`, `/ulw`, `/ultrawork`.
+- Negative keyword tests do not activate on incidental prose.
+
+### PR 2: Ralplan planning protocol
+
+Scope:
+
+- Implement ralplan orchestration policy.
+- Planner creates initial `Vec<PlanItem>`.
+- Architect reviews after planner.
+- Critic reviews after architect.
+- Iterate up to default max 3.
+- Persist or attach canonical plan in the existing plan/swarm/session path, not separate workflow TODO JSON.
+
+Acceptance tests:
+
+- Ralplan produces non-empty `Vec<PlanItem>`.
+- `summarize_plan_graph` reports no cycles for valid plan.
+- Architect and Critic order is enforced.
+- Non-approval reaches max iterations and returns failed/needs-user-review status.
+- Markdown rendering, if present, is generated from canonical JSON.
+
+### PR 3: Ultrawork execution protocol
+
+Scope:
+
+- Consume a `Vec<PlanItem>` or synthesize one for simple slash-command tasks.
+- Use `next_runnable_item_ids` to select lanes.
+- Spawn native Jcode agents only for independent tasks.
+- Do not run concurrent tasks with overlapping `file_scope`.
+- Track assignments through `PlanItem.assigned_to`.
+- Close with lightweight verification evidence.
+
+Acceptance tests:
+
+- Independent non-overlapping items are eligible for parallel execution.
+- Overlapping `file_scope` items are serialized or kept local.
+- Blocked items are not assigned before dependencies complete.
+- Failed verification yields clear final blocked/failed status.
+
+### PR 4: UI/status integration
+
+Scope:
+
+- Render active workflow state in TUI/status surfaces.
+- Link workflow state to swarm/background widgets where possible.
+- Add `/workflow status` or equivalent status surface if appropriate.
+
+Acceptance tests:
+
+- Snapshot/status formatting for ralplan, ultrawork, and future Ralph.
+- Completed/cancelled workflows clear or dim their status.
+
+### PR 5: Ralph gates and loop
+
+Scope:
+
+- Implement `RalphCompletionGate` over canonical plan, verification evidence, background tasks, and review evidence.
+- Integrate with `GracefulShutdownSignal` and `SoftInterruptQueue`.
+- Add explicit `/cancel` escape hatch behavior.
+- Enable `/ralph` activation only after gates are in place.
+- Ralph may spawn helper agents, but completion waits for all tracked work to finish.
+
+Acceptance tests:
+
+- Ralph completion predicate returns false for each missing gate.
+- Graceful shutdown during incomplete Ralph enqueues a soft interrupt and continues.
+- Explicit cancel exits Ralph.
+- Running background tasks block completion.
+- Passing verification + completed plan + no active tasks allows completion.
+
+### PR 6: Optional CLI entrypoints
+
+Scope:
+
+```bash
+jcode ralplan "task"
+jcode ultrawork "task"
+jcode ralph "task"
+```
+
+These should start new Jcode sessions with workflow state pre-seeded. Keep this after prompt-side workflows are stable.
+
+## Risks and mitigations
+
+### Risk: workflow state drifts from session state
+
+Mitigation: use typed references to `Goal` and `PlanItem`; avoid parallel TODO state.
+
+### Risk: user loses interrupt control under Ralph
+
+Mitigation: implement double-interrupt or explicit `/cancel` escape hatch; show blocked completion reason in TUI.
+
+### Risk: activation surprises users
+
+Mitigation: MVP slash commands only; broad keywords require explicit future tests and visible activation notices.
+
+### Risk: role/model routing ambiguity
+
+Mitigation: default to active model for MVP. Later add role routing policy for Planner/Architect/Critic if provider/model config supports it.
+
+### Risk: Ralplan loops too long or silently
+
+Mitigation: default max iterations 3; status updates each phase; final non-approval returns best plan plus review reasons.
+
+## MVP boundary
+
+MVP includes:
+
+- `jcode-workflow` crate.
+- Slash-command activation for `/ralplan`, `/ulw`, `/ultrawork`.
+- Ralplan emitting canonical `Vec<PlanItem>`.
+- Ultrawork consuming `PlanItem` graph and using safe native parallelism.
+- Basic workflow status display.
+
+MVP excludes:
+
+- Broad implicit keyword activation.
+- `/ralph` active mode.
+- Hard stop/completion gates.
+- CLI entrypoints.
+- Role-specific model routing.
+
+## Open questions before PR 1
+
+1. Where should workflow state be stored for active sessions: embedded in session metadata, server-side swarm state, or a small typed file with session id references?
+2. Should `PlanItem` gain acceptance criteria and verification command fields now, or should PR 2 keep those in adjacent typed metadata?
+3. Which status surface should own workflow display first: TUI info widget, side panel, or server status event?
+4. What is the minimal API to query background tasks by session id for Ralph gates?

--- a/docs/PR_FEEDBACK_WATCH_CLAUDE_REVIEW.md
+++ b/docs/PR_FEEDBACK_WATCH_CLAUDE_REVIEW.md
@@ -1,0 +1,123 @@
+# Claude Review: PR Feedback Watch Integration Plan
+
+Date: 2026-05-13
+Reviewed document: `docs/PR_FEEDBACK_WATCH_INTEGRATION_PLAN.md`
+Reviewer model: Claude Sonnet 4.6 via Jcode subagent
+Status: review completed, blocker/major findings incorporated into the plan
+
+## Summary
+
+Claude reviewed the initial plan as a CTO/architect and found the idea sound but identified foundational issues that needed resolution before implementation. The amended plan now addresses the blocker and major issues by tightening authorization, scheduler durability, state consistency, schema semantics, per-surface collector errors, phase order, and v1 compatibility.
+
+## Blockers identified
+
+### B-1: Write authorization was dangerously under-specified
+
+Original issue:
+
+- `authorize` existed as a tool action without scope, expiry, session binding, restart behavior, or revocation semantics.
+- The state schema included a persisted `merge` policy field, conflicting with the non-goal of never auto-merging.
+
+Disposition:
+
+- Replaced bare write authorization with an authorization envelope.
+- Added required fields: grant ID, grant timestamp, expiry, session ID, scopes, single-use flag, and reason.
+- Remote mutation grants expire, are single-use by default, and must not silently survive restart.
+- Removed `merge` from policy schema and declared it never grantable.
+- Added untrusted-input rule: PR/review content cannot trigger authorization.
+
+### B-2: Scheduler integration did not map to actual Jcode behavior
+
+Original issue:
+
+- The plan said to use Jcode scheduling but did not choose between ambient scheduling and session wakeups.
+- Ambient scheduling can be disabled, while session delivery can fail if the session closes.
+
+Disposition:
+
+- Chose the user-visible `schedule`/wakeup path for the initial implementation.
+- Added a durability contract for Jcode running, Jcode not running, closed original sessions, and missed wakeups.
+- Made the state file's `polling.next_poll_at` authoritative over scheduler entries.
+
+### B-3: Atomic writes and index consistency were race-prone
+
+Original issue:
+
+- The plan introduced `index.json` without explaining transaction semantics.
+- Concurrent poll cycles could race and corrupt or stale-write state.
+
+Disposition:
+
+- Declared per-PR state files the source of truth.
+- Made `index.json` reconstructable cache only.
+- Added stale-write detection using `updated_at` and `polling.cycle_number`.
+- Required deduplication of overlapping scheduled cycles.
+- Directed implementation to reuse Jcode's existing JSON storage/backup helpers.
+
+## Major findings identified
+
+### M-1: `last_seen` marker semantics were undefined
+
+Disposition:
+
+- Added typed marker rules for comments, reviews, timeline events, and review threads.
+- Required `id`, `updated_at`, `author`, `body_hash`, and URL for comment-like markers.
+- Required `resolved` and `outdated` for review-thread markers.
+
+### M-2: Baseline and `last_seen` interaction was under-specified
+
+Disposition:
+
+- Added baseline update rules for baseline establishment, expected head changes, unexpected head changes, historical marker preservation, and baseline events.
+
+### M-3: `events` array lacked schema and bounds
+
+Disposition:
+
+- Defined events as `{ at, kind, data }`.
+- Bounded event history to newest 50 entries.
+- Clarified `last_cycle` is canonical latest state, while `events` are audit breadcrumbs.
+
+### M-4: Collector trait collapsed partial failures
+
+Disposition:
+
+- Replaced single `Result<PrSnapshot, PrWatchError>` with `PrSnapshotResult` containing per-surface `Result` values.
+- Preserves partial successes and prevents partial fetches from being treated as quiet.
+
+### M-5: Remediation came before UI/status visibility
+
+Disposition:
+
+- Swapped phase order.
+- Minimal terminal/side-panel visibility now ships before autonomous remediation.
+
+### M-6: Migration was too late
+
+Disposition:
+
+- Moved v1 read-compatibility into Phase 1.
+- Phase 7 is now bulk migration/cleanup only.
+
+## Minor and suggestion disposition
+
+- `authorize` remains listed, but only after the authorization-envelope design is implemented.
+- `next_poll_at` is authoritative; `final_poll_due_at` is metadata and must match `next_poll_at` when final poll is scheduled.
+- `not_ready_validation_stale` is scoped to local-fix/remediation modes where validation is recorded or required.
+- Checks moved out of `last_seen` into `last_checks_for_sha`.
+- Tool examples use seconds, not mixed minute/second units.
+- State-store section now warns about `.jcode/pr-feedback-watch/` gitignore behavior.
+- Handoff example no longer hard-codes `--squash`; it presents merge strategy as a human choice.
+- Open questions were reduced to unresolved implementation choices only.
+
+## Remaining open questions after incorporation
+
+1. Start with `gh` CLI or add direct GitHub API immediately? Current decision: `gh` first, direct API later.
+2. Normal tool or background-task subtype? Current decision: normal tool first, designed to become a background-task subtype later.
+3. Mechanical Python port vs. typed Rust redesign depth.
+4. Whether readiness reports should include project memory-bank context.
+5. Whether ignored automation authors should be global config, project config, or both.
+
+## Review verdict
+
+After the amendments, the plan is suitable to use as the basis for Phase 1 design work. The most important condition is that Phase 1 must include v1 read-compatibility, authorization-envelope data types, bounded events, typed markers, baseline rules, and per-surface collector result types before any networked GitHub collector is implemented.

--- a/docs/PR_FEEDBACK_WATCH_INTEGRATION_PLAN.md
+++ b/docs/PR_FEEDBACK_WATCH_INTEGRATION_PLAN.md
@@ -1,0 +1,821 @@
+# PR Feedback Watch Integration Plan
+
+Date: 2026-05-13
+Status: draft reviewed by Claude and amended
+Owner: Jcode self-development
+
+## Claude review disposition
+
+Claude reviewed the initial draft on 2026-05-13. This revision incorporates the blocker and major findings before implementation. Key decisions made from that review:
+
+1. Write authorization is no longer a bare persisted boolean. Mutating permissions require an authorization envelope with scope, grant metadata, expiry, and restart behavior. Merge is not a grantable stored permission.
+2. Scheduled polling must use an explicit durable wakeup strategy, not an implicit ambient loop. Phase 4 will use the user-visible `schedule`/wakeup path first and document missed-wakeup behavior.
+3. The state file is the source of truth. `index.json` is reconstructable cache only, and writes require compare-and-swap style stale-cycle detection.
+4. v1 state read-compatibility moves into Phase 1, because current repositories already contain v1 watch artifacts.
+5. Collector results must preserve per-surface success/failure so partial fetches cannot accidentally become quiet cycles.
+6. Remediation must not become invisible background activity. Minimal status visibility ships before autonomous remediation.
+
+## Executive summary
+
+Jcode should promote the ad hoc PR feedback watch workflows found in `biz-agents`, `concierge-app`, and current `.jcode/pr-feedback-watch` snapshots into a first-class Jcode capability.
+
+The target capability is a native, durable PR watch system that can:
+
+1. Poll GitHub pull requests across all relevant feedback surfaces.
+2. Persist normalized state under `.jcode/pr-feedback-watch/`.
+3. Distinguish quiet, pending, failing, and actionable states.
+4. Schedule recurring checks without fragile long-running shell loops.
+5. Surface status in tools and UI.
+6. Convert actionable feedback into Jcode tasks or subagent assignments.
+7. Respect explicit write and merge authorization boundaries.
+8. Produce human handoff and review-readiness reports.
+
+The strongest existing implementation is `biz-agents/scripts/pr_review_monitor.py`. The strongest operating model is `concierge-app/.jcode/overnight-templates/visible-overnight-pr-watch.md`. Jcode should combine those lessons into a core subsystem rather than continuing project-local scripts.
+
+## Source observations
+
+### Current Jcode `.jcode/pr-feedback-watch` snapshots
+
+Observed files:
+
+- `.jcode/pr-feedback-watch/ShawnSantiago-move-in-out-inpect-app-pr-25.json`
+- `.jcode/pr-feedback-watch/validation-1jehuang-jcode-pr-188.json`
+- `.jcode/pr-feedback-watch/validation-1jehuang-jcode-pr-188-failure-sim.json`
+
+Useful concepts already present:
+
+- `schema_version`
+- PR identity: repo, number, URL, branch metadata
+- `last_seen_review_markers` split by surface
+- `surface_last_successful_fetch`
+- `quiet_cycles`
+- `consecutive_transient_failures`
+- `pending_actionable`
+- `last_cycle` with status and surface counts
+- `write_authorized`
+- terminal stop reasons such as `validation_required_quiet_cycles_reached`
+
+Gaps:
+
+- No first-class Jcode tool owns these files.
+- No stable schema contract across projects.
+- No native scheduler integration.
+- No UI or side-panel summary.
+- No automatic remediation task creation.
+
+### biz-agents monitor
+
+Relevant files:
+
+- `/home/shawn/business-projects/biz-agents/scripts/pr_review_monitor.py`
+- `/home/shawn/business-projects/biz-agents/tests/test_pr_review_monitor.py`
+- `/home/shawn/business-projects/biz-agents/.jcode/pr-feedback-watch/pr-92-watch-state.json`
+- `/home/shawn/business-projects/biz-agents/.jcode/pr-feedback-watch/pr-92-watch.log`
+- `/home/shawn/business-projects/biz-agents/businessagents/dataflows/review_readiness.py`
+
+Strengths:
+
+- Importable/testable monitor module with runtime side effects behind `main()`.
+- Read-only default behavior.
+- GitHub CLI based collection.
+- State normalization for legacy shapes.
+- Baseline and quiet-cycle model.
+- Automation chatter filtering.
+- Optional but gated mutation modes.
+- Exit codes distinguish quiet, action required, operational error, and timeout.
+- Tests cover parsing, state migration, thread queries, automation filtering, and monitor logic.
+- Review readiness command turns monitor state plus project context into a human-safe checklist.
+
+Gaps:
+
+- Python project-local implementation, not native Jcode.
+- State format is optimized for that repo rather than a reusable Jcode schema.
+- Artifact volume can become high.
+- No Jcode UI integration.
+- No native subagent/task integration.
+
+### concierge-app scheduled watch template
+
+Relevant file:
+
+- `/home/shawn/business-projects/concierge-app/.jcode/overnight-templates/visible-overnight-pr-watch.md`
+
+Strengths:
+
+- Explicitly avoids long-running watchdog processes because the harness can kill them.
+- Recommends scheduled 5-minute monitor checks.
+- Defines clean-cycle and final-poll behavior.
+- Distinguishes PR merge milestone from end-of-overnight-run completion.
+- Requires visible status reporting and audit logging.
+- Preserves unrelated user changes.
+- Forbids repository-disallowed `git push` or `gh pr merge` unless policy/approval allows.
+
+Gaps:
+
+- Template only, not enforced by Jcode.
+- State shape differs from other projects.
+- No reusable parser/monitor.
+
+## Goals
+
+### Product goals
+
+1. Make PR feedback monitoring a native Jcode workflow.
+2. Reduce manual bookkeeping in `.jcode/pr-feedback-watch`.
+3. Make long-running review feedback loops reliable across restarts and session loss.
+4. Give users a concise, visible view of PR state and next action.
+5. Let Jcode proactively fix feedback locally when safe.
+6. Preserve strict approval boundaries for pushes, comments, thread resolution, and merges.
+
+### Engineering goals
+
+1. Define one stable state schema.
+2. Implement a reusable core monitor library with deterministic tests.
+3. Add a `pr_watch` tool wrapper.
+4. Integrate with the existing `schedule`, `todo`, `subagent`, `swarm`, background task, and side-panel systems.
+5. Support migration from current `.jcode` watch artifacts.
+6. Keep GitHub API/CLI failures transient and recoverable.
+7. Avoid runaway artifact creation.
+
+## Non-goals
+
+1. Do not auto-merge PRs.
+2. Do not auto-push without explicit scope authorization.
+3. Do not replace human review or repository branch protection.
+4. Do not require every project to adopt GitHub-only hosting forever, but GitHub PRs are the initial target.
+5. Do not add a heavyweight external daemon in the first iteration.
+6. Do not delete existing project-local artifacts during migration.
+
+## Proposed architecture
+
+```mermaid
+flowchart TD
+    User[User or agent request] --> Tool[pr_watch tool]
+    Tool --> Core[PR Watch Core]
+    Core --> Gh[GitHub collector]
+    Core --> Store[.jcode/pr-feedback-watch state store]
+    Core --> Analyzer[Analyzer]
+    Analyzer --> Status[Status/readiness report]
+    Analyzer --> Tasks[Todo/subagent remediation tasks]
+    Core --> Scheduler[Jcode schedule recurring poll]
+    Scheduler --> Tool
+    Status --> UI[Side panel / terminal summary]
+```
+
+### Components
+
+#### 1. PR Watch Core crate/module
+
+Recommended location options:
+
+- Short-term: `src/pr_watch.rs` plus `src/tool/pr_watch.rs`
+- Longer-term: `crates/jcode-pr-watch-core/`
+
+The core should contain pure or mostly pure logic:
+
+- state schema structs
+- state load/save/migration
+- event normalization
+- new/actionable event detection
+- automation chatter detection
+- quiet-cycle calculation
+- readiness classification
+- output summarization
+
+This should be heavily unit-tested without network calls.
+
+#### 2. GitHub collector
+
+Initial implementation can call `gh` CLI because the existing workflows already use it and it inherits user auth.
+
+Surfaces to collect:
+
+- PR metadata: state, head SHA, base/head refs, mergeability, review decision, URL
+- Checks/status rollup
+- Review threads with resolved/outdated flags
+- Review comments
+- Issue/top-level comments
+- Reviews
+- Timeline or events, when available
+
+Future implementation can switch to direct GitHub REST/GraphQL with an auth abstraction.
+
+#### 3. State store
+
+Canonical path:
+
+```text
+.jcode/pr-feedback-watch/<owner>-<repo>-pr-<number>-state.json
+```
+
+A small index file is optional and useful:
+
+```text
+.jcode/pr-feedback-watch/index.json
+```
+
+State-store rules:
+
+1. The per-PR state file is the source of truth. `index.json` is a reconstructable cache only. If the index and a state file disagree, trust the state file.
+2. `pr_watch list` should tolerate a missing or stale index by scanning `*-state.json` files and rebuilding the index.
+3. Writes should reuse Jcode's existing JSON storage/backup recovery helpers rather than inventing a second persistence path.
+4. Poll cycles must use stale-write detection: load state, remember `updated_at` and `polling.cycle_number`, collect/analyze, reload before writing, and abort/retry if another cycle advanced the state.
+5. Overlapping scheduled cycles for the same `watch_id` must be deduplicated.
+6. `pr_watch start` should warn if `.jcode/pr-feedback-watch/` is not ignored by git. The tool should offer or perform a safe `.gitignore` update only when user policy allows repository writes.
+
+#### 4. Scheduler integration
+
+`pr_watch start` should schedule a follow-up poll using Jcode's user-visible `schedule`/wakeup path instead of launching an endless process or relying on the ambient loop. Ambient scheduling can be added later as an optimization, but the initial contract must work for normal user sessions and be visible in session history.
+
+Durability contract:
+
+1. If Jcode is running at `next_poll_at`, the scheduled wake invokes `pr_watch poll_now` for the watch ID.
+2. If Jcode is not running, the missed poll is processed on next startup/session resume when `pr_watch status`, `list`, or a startup watcher scan observes `next_poll_at <= now`.
+3. If the original session is closed, the follow-up should resume through a new minimal poll task or ask the active session to take over. It must not silently disappear.
+4. Scheduler entries are advisory. The canonical state file's `polling.next_poll_at` is authoritative.
+
+Each scheduled invocation should:
+
+1. Load state.
+2. Check cancellation/terminal state.
+3. Poll GitHub.
+4. Analyze changes.
+5. Save state atomically.
+6. Emit a status event.
+7. Create remediation tasks if applicable and authorized.
+8. Schedule the next poll or final poll.
+
+#### 5. Tool interface
+
+Add a `pr_watch` tool with actions:
+
+- `start`
+- `poll_now`
+- `status`
+- `list`
+- `stop`
+- `ack_baseline`
+- `readiness`
+- `handoff`
+- `authorize`, only for time-bound non-merge mutation scopes after the authorization-envelope design is implemented
+
+Example input:
+
+```json
+{
+  "action": "start",
+  "repo": "ShawnSantiago/concierge-app",
+  "pr": 156,
+  "poll_interval_seconds": 300,
+  "required_quiet_cycles": 3,
+  "final_poll_seconds": 600,
+  "dry_run": false,
+  "write_policy": {
+    "local_fix": true,
+    "commit": true,
+    "push": false,
+    "comment": false,
+    "resolve_threads": false
+  }
+}
+```
+
+#### 6. UI integration
+
+A side panel or status widget should show:
+
+- watched PRs
+- current state
+- quiet cycle progress
+- pending actionable count
+- failing/pending checks
+- next poll time
+- last validation evidence
+- current write policy
+
+Example table:
+
+| PR | State | Quiet | Actionable | Checks | Next poll | Policy |
+|---|---|---:|---:|---|---|---|
+| `concierge-app#156` | watching | 2/3 | 0 | passing | 5m | local commit only |
+| `biz-agents#92` | action required | 0/3 | 7 | clean | now | read-only |
+
+## Canonical state schema v2
+
+```json
+{
+  "schema_version": 2,
+  "watch_id": "ShawnSantiago-concierge-app-pr-156",
+  "created_at": "2026-05-13T17:00:00Z",
+  "updated_at": "2026-05-13T17:05:00Z",
+  "terminal": false,
+  "stop_reason": null,
+  "pr": {
+    "repo": "ShawnSantiago/concierge-app",
+    "number": 156,
+    "url": "https://github.com/ShawnSantiago/concierge-app/pull/156",
+    "state": "OPEN",
+    "base_ref": "main",
+    "head_ref": "feature/example",
+    "head_sha": "abc123",
+    "merge_state": "CLEAN",
+    "review_decision": null
+  },
+  "policy": {
+    "local_fix": true,
+    "commit": true,
+    "push": false,
+    "comment": false,
+    "resolve_threads": false
+  },
+  "authorization": {
+    "active_grants": []
+  },
+  "polling": {
+    "cycle_number": 4,
+    "quiet_cycles": 2,
+    "required_quiet_cycles": 3,
+    "poll_interval_seconds": 300,
+    "final_poll_due_at": null,
+    "next_poll_at": "2026-05-13T17:10:00Z",
+    "consecutive_transient_failures": 0
+  },
+  "baseline": {
+    "head_sha": "abc123",
+    "established_at": "2026-05-13T17:00:00Z",
+    "review_comment_count": 31,
+    "issue_comment_count": 1,
+    "review_count": 5,
+    "unresolved_thread_ids": [],
+    "review_comment_count": 31,
+    "issue_comment_count": 1,
+    "review_count": 5
+  },
+  "last_seen": {
+    "review_threads": {
+      "PRRT_example": {
+        "id": "PRRT_example",
+        "updated_at": "2026-05-13T17:00:00Z",
+        "resolved": false,
+        "outdated": false,
+        "body_hash": "sha256:..."
+      }
+    },
+    "review_comments": {},
+    "issue_comments": {},
+    "reviews": {},
+    "timeline": {}
+  },
+  "last_checks_for_sha": {
+    "head_sha": "abc123",
+    "runs": []
+  },
+  "last_successful_fetch": {
+    "review_threads": "2026-05-13T17:05:00Z",
+    "review_comments": "2026-05-13T17:05:00Z",
+    "issue_comments": "2026-05-13T17:05:00Z",
+    "reviews": "2026-05-13T17:05:00Z",
+    "timeline": "2026-05-13T17:05:00Z",
+    "checks": "2026-05-13T17:05:00Z"
+  },
+  "last_cycle": {
+    "completed_at": "2026-05-13T17:05:00Z",
+    "status": "quiet_pending",
+    "surfaces_checked": [
+      "review_threads",
+      "review_comments",
+      "issue_comments",
+      "reviews",
+      "timeline",
+      "checks"
+    ],
+    "surface_counts": {
+      "review_threads": 0,
+      "review_comments": 31,
+      "issue_comments": 1,
+      "reviews": 5,
+      "timeline": 3,
+      "checks": 8
+    },
+    "actionable_count": 0,
+    "pending_check_count": 0,
+    "failed_check_count": 0
+  },
+  "pending_actionable": [],
+  "last_validation": [
+    {
+      "at": "2026-05-13T17:03:00Z",
+      "command": "npm test -- targeted.test.ts",
+      "status": "passed",
+      "summary": "17 passed"
+    }
+  ],
+  "events": [
+    {
+      "at": "2026-05-13T17:05:00Z",
+      "kind": "cycle_completed",
+      "data": {"status": "quiet_pending"}
+    }
+  ]
+}
+```
+
+### Marker, event, and baseline rules
+
+`last_seen` values are typed markers, not bare booleans. Comment-like markers store at least `id`, `updated_at`, `author`, `body_hash`, and source URL. Review-thread markers additionally store `resolved` and `outdated`. Checks are not stored in `last_seen` because check-run IDs are scoped to a commit and reset on pushes; checks use `last_checks_for_sha`.
+
+`events` is a bounded ring buffer with entries shaped as `{ "at": string, "kind": string, "data": object }`. Keep the newest 50 events by default, matching Jcode's existing background event-history scale. `last_cycle` is the canonical latest cycle summary; `events` is for audit breadcrumbs and exceptional transitions.
+
+Baseline update rules:
+
+1. Establishing a baseline records current head SHA, counts, and unresolved thread IDs, then marks current comments/reviews/threads as seen.
+2. Re-baselining after an expected head change updates `baseline.head_sha`, counts, unresolved threads, and `last_checks_for_sha`.
+3. Re-baselining should preserve historical `last_seen` markers where IDs still exist, but update markers for current events so old reviewer feedback is not reprocessed.
+4. Unexpected head changes reset quiet cycles and append a `head_changed_unexpectedly` event.
+5. Every baseline change appends a `baseline_established` or `baseline_updated` event.
+
+`polling.next_poll_at` is authoritative for the next scheduled wake. `final_poll_due_at` is evidence/metadata; when a final poll is due, `next_poll_at` must be set to the same timestamp.
+
+### State classifications
+
+Recommended `last_cycle.status` values:
+
+- `baseline_established`
+- `collecting`
+- `quiet_pending`
+- `quiet_satisfied`
+- `final_poll_pending`
+- `action_required`
+- `checks_pending`
+- `checks_failed`
+- `transient_failure`
+- `operational_error`
+- `stopped`
+- `terminal_ready_for_human`
+
+### Readiness classifications
+
+`pr_watch readiness` should return one of:
+
+- `not_ready_action_required`
+- `not_ready_checks_pending`
+- `not_ready_checks_failed`
+- `not_ready_validation_stale`, only after remediation/local-fix mode has recorded or required validation
+- `ready_for_human_review`
+- `ready_for_human_push`
+- `ready_for_human_merge`
+- `blocked_by_policy`
+- `blocked_by_closed_pr`
+
+## Actionable feedback detection
+
+An event should be actionable if it is new or newly updated since the baseline/last seen markers and any of the following are true:
+
+1. It is an unresolved review thread.
+2. It is a new review comment not classified as automation chatter.
+3. It is a new top-level issue comment not classified as automation chatter.
+4. It is a review requesting changes.
+5. It is a failed required check.
+6. It is a mergeability state that blocks merging.
+
+An event should usually be ignored if:
+
+1. Author is a known bot and body matches progress/fix-summary patterns.
+2. It is an old event already in `last_seen` with the same update timestamp.
+3. It is a resolved/outdated thread and `include_resolved`/`include_outdated` is false.
+4. It is authored by a configured ignored author.
+
+Port the biz-agents automation filters as the initial implementation, including tests.
+
+## Write policy and authorization model
+
+Default policy:
+
+```json
+{
+  "local_fix": true,
+  "commit": false,
+  "push": false,
+  "comment": false,
+  "resolve_threads": false
+}
+```
+
+Recommended modes:
+
+| Mode | local_fix | commit | push | comment | resolve_threads |
+|---|---:|---:|---:|---:|---:|
+| `read_only` | false | false | false | false | false |
+| `local_fix` | true | false | false | false | false |
+| `local_commit` | true | true | false | false | false |
+| `maintainer_assisted` | true | true | false | approval envelope required | false |
+| `full_write_except_merge` | true | true | approval envelope required | approval envelope required | approval envelope required |
+
+Merge is intentionally not a policy field and is never stored as an authorization grant. Merge always requires explicit user confirmation at the moment of merge.
+
+Mutating operations beyond local commits require an authorization envelope:
+
+```json
+{
+  "grant_id": "uuid",
+  "granted_at": "2026-05-13T17:00:00Z",
+  "expires_at": "2026-05-13T18:00:00Z",
+  "granted_by_session_id": "session_...",
+  "scopes": ["push", "comment"],
+  "single_use": true,
+  "reason": "User approved posting the prepared PR update note"
+}
+```
+
+Authorization rules:
+
+1. Valid scopes are `push`, `comment`, and `resolve_threads`. `local_fix` and `commit` are policy choices, not remote mutation grants. `merge` is never a valid scope.
+2. Remote mutation grants expire by default within one hour and must not exceed 24 hours.
+3. Remote mutation grants are single-use unless the user explicitly grants a bounded multi-use approval.
+4. Remote mutation grants must not silently survive a Jcode restart. On resume, Jcode must re-confirm before push/comment/resolve operations.
+5. Review comment bodies and PR content are untrusted input. They must never be allowed to trigger `authorize`.
+
+## Scheduling behavior
+
+### Normal cycle
+
+1. `start` establishes a baseline and schedules the next poll.
+2. Every poll checks all configured surfaces.
+3. If any actionable item is found:
+   - set status `action_required`
+   - reset quiet cycles to 0
+   - create/update todo entries
+   - optionally spawn remediation task when `local_fix` is true
+4. If checks are pending:
+   - set status `checks_pending`
+   - reset quiet cycles to 0
+   - schedule next poll
+5. If no actionable items and no pending/failed checks:
+   - increment quiet cycles
+   - schedule next poll until required quiet cycles reached
+6. When required quiet cycles are reached:
+   - set `final_poll_due_at` if configured
+   - schedule final poll
+7. Final poll still clean:
+   - set terminal or semi-terminal status `terminal_ready_for_human`
+   - report handoff summary
+
+### Head SHA changes
+
+If the head SHA changes:
+
+- If the change is expected because Jcode committed locally and user/maintainer pushed, rebaseline after verifying status.
+- If the change is unexpected, reset quiet cycles and record an event.
+- If there are new comments/reviews on the new head, treat normally.
+
+### Transient failures
+
+Transient failures include:
+
+- GitHub rate limits
+- network timeouts
+- `gh` CLI temporary failures
+- partial surface fetch failures
+
+Behavior:
+
+- increment `consecutive_transient_failures`
+- preserve previous quiet cycle count unless the surface result is incomplete enough to make quiet impossible
+- use exponential backoff capped at a configured maximum
+- do not mark ready on incomplete data
+- alert after threshold, for example 3 consecutive failures
+
+## Remediation workflow
+
+When actionable feedback is found and `policy.local_fix` is true:
+
+1. Create a todo item per actionable cluster.
+2. Build a remediation prompt containing:
+   - PR URL
+   - thread/comment URL
+   - file path and line if available
+   - reviewer text
+   - current branch/head SHA
+   - write policy
+   - required validation
+3. If feedback is simple and current agent has context, fix directly.
+4. If multiple independent threads exist, optionally use `swarm` or `subagent`.
+5. Run targeted validation and repository-level checks when practical.
+6. Save validation evidence into watch state.
+7. If `commit` is allowed, commit only Jcode's changes.
+8. If `push` is not allowed, produce handoff command.
+9. After maintainer push or authorized push, rebaseline.
+
+## Tool output examples
+
+### `pr_watch status`
+
+```text
+PR watch: ShawnSantiago/concierge-app#156
+State: quiet_pending, 2/3 clean cycles
+Checks: passing
+Actionable: 0
+Head: abc123
+Next poll: 2026-05-13T17:10:00Z
+Policy: local fixes and commits allowed, push/comment/resolve/merge disabled
+Last validation: npm run verify:repo passed at 2026-05-13T17:03:00Z
+```
+
+### `pr_watch handoff`
+
+```text
+PR #156 is ready for human merge review.
+
+Evidence:
+- 3/3 clean cycles completed
+- final poll completed at 2026-05-13T17:20:00Z
+- checks passing
+- no unresolved review threads
+- no new actionable comments or reviews
+- last validation: npm run verify:repo passed
+
+No merge was performed. Human next step, choose the repository-approved strategy:
+  gh pr merge 156 --repo ShawnSantiago/concierge-app [--squash|--merge|--rebase]
+```
+
+## Implementation phases
+
+### Phase 0: Commit this plan and collect reviewer feedback
+
+Deliverables:
+
+- This document.
+- Claude review.
+- Updated plan if review finds material gaps.
+
+Validation:
+
+- Document exists in `docs/`.
+- Review comments are summarized or incorporated.
+
+### Phase 1: Extract and port core monitor logic
+
+Deliverables:
+
+- New Rust module/crate with:
+  - schema structs
+  - v1 read-compatibility and state normalization/migration
+  - automation chatter detection
+  - event normalization
+  - actionable detection
+  - quiet-cycle update logic
+- Unit tests ported from biz-agents concepts.
+
+Suggested files:
+
+- `crates/jcode-pr-watch-core/src/lib.rs`
+- `crates/jcode-pr-watch-core/Cargo.toml`
+- `src/tool/pr_watch.rs` for tool wrapper later
+
+Validation:
+
+- `cargo test -p jcode-pr-watch-core`
+- tests for legacy state migration from known `.jcode` examples
+- tests for automation chatter false positives/negatives
+- tests for quiet cycle transitions
+- tests for transient failure behavior
+
+### Phase 2: Add GitHub collector
+
+Deliverables:
+
+- Collector trait:
+
+```rust
+trait PrWatchCollector {
+    fn collect(&self, target: &PrTarget) -> PrSnapshotResult;
+}
+
+struct PrSnapshotResult {
+    metadata: Result<PrMetadata, SurfaceError>,
+    checks: Result<Vec<CheckRun>, SurfaceError>,
+    review_threads: Result<Vec<ReviewThread>, SurfaceError>,
+    review_comments: Result<Vec<ReviewComment>, SurfaceError>,
+    issue_comments: Result<Vec<IssueComment>, SurfaceError>,
+    reviews: Result<Vec<Review>, SurfaceError>,
+    timeline: Result<Vec<TimelineEvent>, SurfaceError>,
+}
+```
+
+- `GhCliCollector` implementation using `gh`.
+- Typed per-surface snapshots for metadata, checks, comments, reviews, threads, and timeline. Partial failures must be preserved instead of collapsed into one error.
+
+Validation:
+
+- Unit tests with fixture JSON.
+- No network in unit tests.
+- Optional integration test gated behind env var, for example `JCODE_GH_INTEGRATION=1`.
+
+### Phase 3: Add `pr_watch` tool
+
+Deliverables:
+
+- Tool definition and handler.
+- Actions: `start`, `poll_now`, `status`, `list`, `stop`, `readiness`, `handoff`.
+- Atomic writes to `.jcode/pr-feedback-watch`.
+- Index file support.
+
+Validation:
+
+- Tool handler tests with mock collector.
+- Manual dry run against a public or existing PR.
+- Verify no mutation occurs by default.
+
+### Phase 4: Scheduler integration
+
+Deliverables:
+
+- `start` schedules recurring poll tasks.
+- `poll_now` can schedule next poll based on state.
+- Final-poll support.
+- Stale watcher detection.
+
+Validation:
+
+- Simulated scheduled cycles using mock time.
+- Restart/resume test by saving state and invoking poll again.
+- Transient failure simulation, similar to current `.jcode` validation artifact.
+
+### Phase 5: Minimal UI/status visibility
+
+Deliverables:
+
+- `pr_watch list/status` available in terminal.
+- Optional side panel page showing active watchers.
+- Clickable or copyable PR/thread URLs.
+- Badges for action required, quiet, pending checks, failed checks, ready.
+
+Validation:
+
+- UI snapshot/debug_socket check if applicable.
+- Manual usability pass with at least two watched PR fixtures.
+
+### Phase 6: Remediation integration
+
+Deliverables:
+
+- Actionable items become todos.
+- Optional subagent/swarm task creation for multi-thread remediation.
+- Validation evidence appended to state.
+- Handoff summary generated when push is not authorized.
+
+Validation:
+
+- Tests for todo creation payloads.
+- Manual dry run on a PR with synthetic actionable fixture.
+- Confirm unrelated dirty files are not committed.
+
+### Phase 7: Bulk migration and cleanup
+
+Deliverables:
+
+- Bulk-convert or index schema v1 files already readable since Phase 1.
+- Import project-local `scheduled-state` and biz-agent-style baseline state if possible.
+- Document migration behavior.
+- Keep original files intact unless user opts into cleanup.
+
+Validation:
+
+- Migration tests with:
+  - current Jcode `validation-1jehuang-jcode-pr-188.json`
+  - current Jcode failure simulation file
+  - biz-agents `pr-92-watch-state.json`
+  - concierge scheduled state if present
+
+## Risks and mitigations
+
+| Risk | Impact | Mitigation |
+|---|---|---|
+| GitHub API shape changes | Monitor breaks | Fixture tests, collector abstraction, graceful partial failures |
+| `gh` unavailable or unauthenticated | Cannot poll | Clear operational error, setup hint, later direct API support |
+| False actionable classification | Wasted work or noisy user alerts | Conservative automation filters, allow ignore authors, show evidence |
+| False quiet classification | Missed review feedback | Require multiple surfaces, no readiness on partial failures, final poll |
+| Accidental mutation | User trust loss | Read-only default, explicit write policy, merge always prompt-gated |
+| Artifact explosion | Repo clutter | Single canonical state plus bounded event log, optional summaries |
+| Scheduled task spam | Poor UX | Index active watchers, dedupe schedules by watch ID |
+| Dirty repo conflicts | Lost user work | Require dirty status inspection before commit, commit only owned changes |
+
+## Open design questions
+
+1. Should the initial collector use only `gh`, or should direct GitHub API be added immediately? Current decision: `gh` first, direct API later.
+2. Should `pr_watch` live as a normal tool or as a background-task subtype with tool controls? Current decision: normal tool first, design so it can become a background-task subtype.
+3. How much of the biz-agents Python script should be mechanically ported versus re-designed around Rust types?
+4. Should readiness reports include project memory-bank context when present, or should that stay project-local?
+5. Should ignored automation authors be global config, per-project config, or both?
+
+## Recommended near-term decision
+
+Implement the smallest native vertical slice:
+
+1. `jcode-pr-watch-core` with schema v2, v1 read-compatibility, and analyzer tests.
+2. `pr_watch poll_now/status` with a per-surface `gh` collector.
+3. Read-only default.
+4. Single canonical state file.
+5. Handoff/readiness report.
+
+Then add scheduled recurrence, remediation tasks, and UI once the analyzer/state model is proven.

--- a/scripts/dev_cargo.sh
+++ b/scripts/dev_cargo.sh
@@ -237,15 +237,16 @@ configure_linux_linker() {
   esac
 
   selected_linker_mode="$mode"
-  export CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER="${CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER:-clang}"
 
   case "$mode" in
     lld)
+      export CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER="${CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER:-clang}"
       append_rustflags "-C link-arg=-fuse-ld=lld"
       selected_linker_desc="clang + lld"
       log "using clang + lld"
       ;;
     mold)
+      export CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER="${CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER:-clang}"
       append_rustflags "-C link-arg=-fuse-ld=mold"
       selected_linker_desc="clang + mold"
       log "using clang + mold"

--- a/scripts/jcode-dev.sh
+++ b/scripts/jcode-dev.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+cd "$repo_root"
+
+log() {
+  printf 'jcode-dev: %s\n' "$*" >&2
+}
+
+remote_exists() {
+  git remote get-url "$1" >/dev/null 2>&1
+}
+
+is_worktree_clean() {
+  git diff --quiet && git diff --cached --quiet
+}
+
+git_divergence() {
+  local lhs="$1" rhs="$2"
+  git rev-list --left-right --count "$lhs...$rhs" 2>/dev/null || printf '0\t0'
+}
+
+maybe_sync_branch() {
+  local branch
+  branch=$(git symbolic-ref --quiet --short HEAD 2>/dev/null || true)
+  if [[ -z "$branch" ]]; then
+    log "detached HEAD; skipping git sync preflight"
+    return 0
+  fi
+
+  remote_exists upstream || {
+    log "no upstream remote; skipping git sync preflight"
+    return 0
+  }
+
+  local upstream_ref="upstream/$branch"
+  if ! git show-ref --verify --quiet "refs/remotes/$upstream_ref"; then
+    log "no $upstream_ref; skipping git sync preflight"
+    return 0
+  fi
+
+  local ahead behind
+  read -r ahead behind < <(git_divergence "$branch" "$upstream_ref")
+  if (( behind == 0 )); then
+    return 0
+  fi
+
+  log "$branch is $ahead ahead and $behind behind $upstream_ref"
+
+  if ! is_worktree_clean; then
+    log "working tree has local changes; not auto-rebasing"
+    log "run: git stash push -m 'wip before jcode-dev sync' && scripts/jcode-dev.sh"
+    return 1
+  fi
+
+  local backup="backup/${branch}-before-jcode-dev-sync-$(date -u +%Y%m%d-%H%M%S)"
+  git branch "$backup" "$branch"
+  log "created backup branch $backup"
+
+  git rebase "$upstream_ref"
+
+  if remote_exists origin && [[ "${JCODE_DEV_SYNC_PUSH:-0}" == "1" ]]; then
+    local origin_ref="origin/$branch"
+    git fetch origin --prune
+    if git show-ref --verify --quiet "refs/remotes/$origin_ref"; then
+      local origin_ahead origin_behind
+      read -r origin_ahead origin_behind < <(git_divergence "$branch" "$origin_ref")
+      if (( origin_ahead > 0 || origin_behind > 0 )); then
+        log "updating origin/$branch with --force-with-lease"
+        git push --force-with-lease origin "$branch"
+      fi
+    fi
+  elif remote_exists origin; then
+    local origin_ref="origin/$branch"
+    if git show-ref --verify --quiet "refs/remotes/$origin_ref"; then
+      local origin_ahead origin_behind
+      read -r origin_ahead origin_behind < <(git_divergence "$branch" "$origin_ref")
+      if (( origin_ahead > 0 || origin_behind > 0 )); then
+        log "origin/$branch differs from local; set JCODE_DEV_SYNC_PUSH=1 to update fork with --force-with-lease"
+      fi
+    fi
+  fi
+}
+
+if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  log "fetching remotes"
+  git fetch --all --prune
+  maybe_sync_branch
+fi
+
+if command -v selfdev >/dev/null 2>&1; then
+  exec selfdev enter "$@"
+fi
+
+if command -v jcode >/dev/null 2>&1; then
+  exec jcode "$@"
+fi
+
+exec "$repo_root/scripts/dev_cargo.sh" run --profile selfdev -p jcode --bin jcode -- "$@"

--- a/scripts/jcode-dev.sh
+++ b/scripts/jcode-dev.sh
@@ -93,8 +93,4 @@ if command -v selfdev >/dev/null 2>&1; then
   exec selfdev enter "$@"
 fi
 
-if command -v jcode >/dev/null 2>&1; then
-  exec jcode "$@"
-fi
-
 exec "$repo_root/scripts/dev_cargo.sh" run --profile selfdev -p jcode --bin jcode -- "$@"

--- a/src/agent/provider.rs
+++ b/src/agent/provider.rs
@@ -166,6 +166,12 @@ impl Agent {
         self.session.working_dir = Some(dir.to_string());
         self.session.refresh_initial_session_context_message();
         self.log_env_snapshot("working_dir");
+        if let Err(error) = self.session.save() {
+            crate::logging::warn(&format!(
+                "Failed to persist session working directory update for {}: {}",
+                self.session.id, error
+            ));
+        }
     }
 
     /// Get the working directory for this session

--- a/src/agent_tests.rs
+++ b/src/agent_tests.rs
@@ -206,6 +206,35 @@ async fn run_turn_streaming_mpsc_emits_keepalive_while_provider_is_quiet() {
 }
 
 #[tokio::test]
+async fn set_working_dir_persists_refreshed_initial_session_context() {
+    let _guard = crate::storage::lock_test_env();
+    let provider: Arc<dyn Provider> = Arc::new(DelayedProvider {
+        open_delay: Duration::from_millis(0),
+        first_event_delay: Duration::from_millis(0),
+    });
+    let registry = Registry::new(provider.clone()).await;
+    let mut agent = Agent::new(provider, registry);
+    let session_id = agent.session_id().to_string();
+
+    let real_workspace = tempfile::Builder::new()
+        .prefix("jcode-real-workspace-")
+        .tempdir()
+        .expect("create temp workspace");
+    let real_workspace = real_workspace.path().display().to_string();
+
+    agent.set_working_dir(&real_workspace);
+
+    let persisted = std::fs::read_to_string(
+        crate::session::session_path(&session_id).expect("resolve session path"),
+    )
+    .expect("read persisted session");
+    assert!(
+        persisted.contains(&format!("Working directory: {real_workspace}")),
+        "persisted initial system reminder should contain refreshed workspace, got: {persisted}"
+    );
+}
+
+#[tokio::test]
 async fn messages_for_provider_replays_persisted_native_compaction_in_auto_mode() {
     let provider: Arc<dyn Provider> = Arc::new(NativeAutoCompactionProvider);
     let registry = Registry::new(provider.clone()).await;

--- a/src/ambient/manager.rs
+++ b/src/ambient/manager.rs
@@ -95,6 +95,14 @@ impl AmbientManager {
         Ok(id)
     }
 
+    /// Requeue a scheduled item that was popped as ready but could not be
+    /// delivered. This keeps transient delivery failures from permanently
+    /// dropping scheduled session wakeups.
+    pub fn requeue_after(&mut self, item: ScheduledItem, delay: chrono::Duration) -> Result<()> {
+        self.queue.requeue_after(item, delay);
+        Ok(())
+    }
+
     pub fn state(&self) -> &AmbientState {
         &self.state
     }

--- a/src/ambient/persistence.rs
+++ b/src/ambient/persistence.rs
@@ -78,6 +78,18 @@ impl ScheduledQueue {
         let _ = self.save();
     }
 
+    /// Put an already-created item back in the queue after a delivery failure.
+    ///
+    /// Ready direct-delivery items are removed before delivery so one broken live
+    /// session or transient server problem does not block the rest of the queue.
+    /// Requeueing failed items avoids silently losing scheduled checks, which is
+    /// especially important for visible overnight/PR-monitor tasks.
+    pub fn requeue_after(&mut self, mut item: ScheduledItem, delay: chrono::Duration) {
+        item.scheduled_for = Utc::now() + delay;
+        self.items.push(item);
+        let _ = self.save();
+    }
+
     /// Pop items whose `scheduled_for` is in the past, sorted by priority
     /// (highest first) then by time (earliest first).
     pub fn pop_ready(&mut self) -> Vec<ScheduledItem> {

--- a/src/ambient/runner.rs
+++ b/src/ambient/runner.rs
@@ -27,6 +27,7 @@ use std::sync::Arc;
 use tokio::sync::{Notify, RwLock};
 
 const MAX_IDLE_POLL_SECS: u64 = 30;
+const DIRECT_DELIVERY_RETRY_SECS: i64 = 300;
 
 /// Shared ambient runner state, accessible from the server, debug socket, and TUI.
 #[derive(Clone)]
@@ -521,9 +522,13 @@ impl AmbientRunnerHandle {
         for item in items {
             if let Err(e) = self.deliver_scheduled_direct_item(provider, &item).await {
                 logging::error(&format!(
-                    "Ambient runner: failed to deliver scheduled direct item {}: {}",
-                    item.id, e
+                    "Ambient runner: failed to deliver scheduled direct item {}; requeueing in {}s: {}",
+                    item.id, DIRECT_DELIVERY_RETRY_SECS, e
                 ));
+                if let Ok(mut mgr) = AmbientManager::new() {
+                    let _ = mgr
+                        .requeue_after(item, chrono::Duration::seconds(DIRECT_DELIVERY_RETRY_SECS));
+                }
             }
         }
     }

--- a/src/ambient_tests.rs
+++ b/src/ambient_tests.rs
@@ -177,6 +177,44 @@ fn test_take_ready_direct_items_only_removes_direct_targets() {
 }
 
 #[test]
+fn test_requeue_after_preserves_failed_direct_item() {
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    let path = tmp.path().to_path_buf();
+
+    let mut queue = ScheduledQueue::load(path);
+    let past = Utc::now() - Duration::minutes(5);
+
+    queue.push(ScheduledItem {
+        id: "session_due".into(),
+        scheduled_for: past,
+        context: "scheduled session task".into(),
+        priority: Priority::Normal,
+        target: ScheduleTarget::Session {
+            session_id: "session_123".into(),
+        },
+        created_by_session: "session_123".into(),
+        created_at: Utc::now(),
+        working_dir: None,
+        task_description: None,
+        relevant_files: Vec::new(),
+        git_branch: None,
+        additional_context: None,
+    });
+
+    let mut ready = queue.take_ready_direct_items();
+    assert_eq!(ready.len(), 1);
+    assert!(queue.is_empty());
+
+    let item = ready.pop().unwrap();
+    queue.requeue_after(item, Duration::minutes(5));
+
+    assert_eq!(queue.len(), 1);
+    let requeued = queue.peek_next().unwrap();
+    assert_eq!(requeued.id, "session_due");
+    assert!(requeued.scheduled_for > Utc::now());
+}
+
+#[test]
 fn test_ambient_state_record_cycle() {
     let mut state = AmbientState::default();
     assert_eq!(state.total_cycles, 0);

--- a/src/overnight.rs
+++ b/src/overnight.rs
@@ -175,7 +175,7 @@ fn create_coordinator_session(parent: &Session, mission: &Option<String>) -> Res
     child.replace_messages(parent.messages.clone());
     child.compaction = parent.compaction.clone();
     child.provider_key = parent.provider_key.clone();
-    child.reasoning_effort = parent.reasoning_effort.clone();
+    child.model = parent.model.clone();
     child.subagent_model = parent.subagent_model.clone();
     child.improve_mode = parent.improve_mode;
     child.autoreview_enabled = Some(false);

--- a/src/server/client_lifecycle.rs
+++ b/src/server/client_lifecycle.rs
@@ -859,9 +859,17 @@ pub(super) async fn handle_client(
     let mut last_available_models_snapshot: Option<String> = None;
     const MAX_LIVE_AVAILABLE_MODELS_UPDATE_BYTES: usize = 64 * 1024;
 
+    let initial_subscribe_working_dir = match &initial_request {
+        Request::Subscribe { working_dir, .. } => working_dir.clone(),
+        _ => None,
+    };
+
     // Create a new session for this client
     let t0 = std::time::Instant::now();
     let mut new_agent = Agent::new(Arc::clone(&provider), registry.clone());
+    if let Some(ref dir) = initial_subscribe_working_dir {
+        new_agent.set_working_dir(dir);
+    }
     let agent_new_ms = t0.elapsed().as_millis();
 
     new_agent.set_memory_enabled(crate::config::config().features.memory);

--- a/src/skill.rs
+++ b/src/skill.rs
@@ -34,6 +34,19 @@ pub struct SkillRegistry {
 }
 
 impl SkillRegistry {
+    fn with_builtins() -> Self {
+        let mut registry = Self::default();
+        registry.load_builtin_omx_workflows();
+        registry
+    }
+
+    fn load_builtin_omx_workflows(&mut self) {
+        for spec in BUILTIN_OMX_SKILLS {
+            let skill = Skill::builtin(spec.name, spec.description, spec.content);
+            self.skills.insert(skill.name.clone(), skill);
+        }
+    }
+
     /// Process-wide shared mutable registry used by both `skill_manage` and
     /// direct slash invocation paths. Keeping a single registry prevents slash
     /// commands from seeing a stale startup-only skill snapshot after reloads.
@@ -209,7 +222,7 @@ impl SkillRegistry {
         // First-run import from Claude Code / Codex CLI
         Self::import_from_external();
 
-        let mut registry = Self::default();
+        let mut registry = Self::with_builtins();
 
         // Load from ~/.jcode/skills/ (jcode's own global skills)
         if let Ok(jcode_dir) = crate::storage::jcode_dir() {
@@ -355,8 +368,9 @@ impl SkillRegistry {
     /// active session working directory.
     pub fn reload_all_for_working_dir(&mut self, working_dir: Option<&Path>) -> Result<usize> {
         self.skills.clear();
+        self.load_builtin_omx_workflows();
 
-        let mut count = 0;
+        let mut count = self.skills.len();
 
         // Load from ~/.jcode/skills/ (jcode's own global skills)
         if let Ok(jcode_dir) = crate::storage::jcode_dir() {
@@ -418,6 +432,17 @@ impl SkillRegistry {
 }
 
 impl Skill {
+    fn builtin(name: &str, description: &str, content: &str) -> Self {
+        Self {
+            name: name.to_string(),
+            description: description.to_string(),
+            allowed_tools: None,
+            content: content.to_string(),
+            path: PathBuf::from(format!("<builtin>/omx/{name}/SKILL.md")),
+            search_text: build_skill_search_text(name, description, content),
+        }
+    }
+
     /// Get the full prompt content for this skill
     pub fn get_prompt(&self) -> String {
         format!(
@@ -462,6 +487,122 @@ impl Skill {
         }
     }
 }
+
+struct BuiltinSkillSpec {
+    name: &'static str,
+    description: &'static str,
+    content: &'static str,
+}
+
+const BUILTIN_OMX_SKILLS: &[BuiltinSkillSpec] = &[
+    BuiltinSkillSpec {
+        name: "autopilot",
+        description: "[OMX native] Autonomous delivery loop: ralplan -> ralph -> code-review",
+        content: r#"<Purpose>
+Autopilot is the strict autonomous delivery loop for non-trivial implementation work.
+Its primary contract is exactly: ralplan -> ralph -> code-review.
+</Purpose>
+
+<Use_When>
+- The user wants hands-off execution from a concrete idea, issue, or requirements artifact to reviewed code.
+- The request needs planning, implementation, verification, and review with automatic follow-up.
+</Use_When>
+
+<Execution_Policy>
+- Ground the request first. Create or reuse a context snapshot in `.jcode/context/` when the task is non-trivial.
+- Execute phases in order: planning consensus, implementation/verification, then code review.
+- If code review is not clean, return to planning with the findings as first-class input, then repeat.
+- Continue automatically through safe reversible phase transitions. Ask only for destructive, credentialed, production, or preference-dependent branches.
+- Persist visible progress with todo updates and, when useful, native state/memory/wiki artifacts.
+</Execution_Policy>
+
+<Final_Checklist>
+- Planning artifacts or acceptance criteria exist.
+- Implementation has fresh verification evidence.
+- Code review is clean or unresolved findings are reported with next steps.
+- The user receives a concise summary of plan, implementation, verification, and review evidence.
+</Final_Checklist>"#,
+    },
+    BuiltinSkillSpec {
+        name: "ralph",
+        description: "[OMX native] Persistent execution loop until verified completion",
+        content: r#"<Purpose>
+Ralph is a persistence loop that keeps working until the task is genuinely complete and verified.
+</Purpose>
+
+<Execution_Policy>
+- Do not reduce scope or declare partial work complete.
+- Define acceptance criteria, implement, verify with fresh evidence, fix failures, and repeat until done or blocked.
+- Run independent work in parallel and long-running commands in the background.
+- Require architect/code-review style verification before a high-confidence completion claim.
+- Use todo state for visible progress and preserve enough artifacts for resume.
+</Execution_Policy>
+
+<Final_Checklist>
+- All original requirements are met.
+- No pending/in-progress todos remain for the task.
+- Relevant tests/build/lint/typecheck or manual QA evidence is fresh.
+- Review/architect concerns are resolved or explicitly blocked.
+</Final_Checklist>"#,
+    },
+    BuiltinSkillSpec {
+        name: "ultrawork",
+        description: "[OMX native] Parallel execution discipline for high-throughput work",
+        content: r#"<Purpose>
+Ultrawork is the parallelism and execution-discipline layer for bounded high-throughput task completion.
+</Purpose>
+
+<Execution_Policy>
+- Ground context and define pass/fail acceptance criteria before editing.
+- Classify dependency shape: independent tasks can run in parallel, coupled tasks stay local or staged.
+- Fire independent tool calls, background commands, or agents simultaneously. Never serialize independent work.
+- Prefer direct local execution for shared-file or immediate-context work.
+- Close with lightweight evidence: affected checks pass, manual QA notes are recorded when needed, and no new errors are introduced.
+</Execution_Policy>"#,
+    },
+    BuiltinSkillSpec {
+        name: "ralplan",
+        description: "[OMX native] Consensus planning gate before execution",
+        content: r#"<Purpose>
+Ralplan produces an execution-ready plan and test specification before implementation begins.
+</Purpose>
+
+<Execution_Policy>
+- Clarify the outcome, constraints, unknowns, risks, and likely code touchpoints.
+- Inspect enough repository context to avoid hallucinated plans.
+- Produce concrete acceptance criteria, task decomposition, validation commands, and rollback/stop conditions.
+- Do not implement unless the user has requested execution or the active workflow explicitly continues into implementation.
+</Execution_Policy>"#,
+    },
+    BuiltinSkillSpec {
+        name: "ultraqa",
+        description: "[OMX native] Rigorous QA and regression validation workflow",
+        content: r#"<Purpose>
+UltraQA validates behavior with risk-proportional automated and manual checks.
+</Purpose>
+
+<Execution_Policy>
+- Identify the change surface, user-visible behavior, invariants, and likely regressions.
+- Prefer targeted tests first, then broader suites when risk warrants.
+- Read outputs and confirm they actually prove the claim.
+- Record commands, artifacts, failures, fixes, and remaining risk.
+</Execution_Policy>"#,
+    },
+    BuiltinSkillSpec {
+        name: "team",
+        description: "[OMX native] Coordinated multi-agent workflow for parallel tasks",
+        content: r#"<Purpose>
+Team coordinates multiple agents on a shared task list when work can be split into durable parallel lanes.
+</Purpose>
+
+<Execution_Policy>
+- Use native swarm/subagent coordination for in-session parallelism.
+- Create clear roles, task boundaries, acceptance criteria, and reporting expectations.
+- Keep shared context synchronized and wait for terminal worker status before final claims.
+- Do not use team mode for tightly coupled single-threaded work.
+</Execution_Policy>"#,
+    },
+];
 
 fn build_skill_search_text(name: &str, description: &str, content: &str) -> String {
     normalize_skill_search_text(&format!("{}\n{}\n{}", name, description, content))
@@ -539,6 +680,42 @@ mod tests {
             .get("wd-only")
             .expect("working-dir local skill should load");
         assert_eq!(skill.description, "Test skill wd-only");
+        assert!(skill.path.starts_with(temp.path()));
+    }
+
+    #[test]
+    fn load_for_working_dir_includes_builtin_omx_workflows() {
+        let temp = tempfile::tempdir().expect("tempdir");
+
+        let registry = SkillRegistry::load_for_working_dir(Some(temp.path())).expect("load skills");
+
+        let autopilot = registry
+            .get("autopilot")
+            .expect("builtin autopilot should load without external skill files");
+        assert!(autopilot.description.contains("OMX native"));
+        assert!(
+            autopilot
+                .content
+                .contains("ralplan -> ralph -> code-review")
+        );
+        assert_eq!(
+            autopilot.path,
+            PathBuf::from("<builtin>/omx/autopilot/SKILL.md")
+        );
+        assert!(registry.get("ralph").is_some());
+        assert!(registry.get("ultrawork").is_some());
+        assert!(registry.get("team").is_some());
+    }
+
+    #[test]
+    fn project_local_skill_overrides_builtin_workflow() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        write_test_skill(temp.path(), ".jcode", "autopilot");
+
+        let registry = SkillRegistry::load_for_working_dir(Some(temp.path())).expect("load skills");
+
+        let skill = registry.get("autopilot").expect("autopilot should load");
+        assert_eq!(skill.description, "Test skill autopilot");
         assert!(skill.path.starts_with(temp.path()));
     }
 

--- a/src/tool/ambient.rs
+++ b/src/tool/ambient.rs
@@ -909,7 +909,7 @@ fn parse_schedule_target(s: Option<&str>, session_id: &str) -> Result<ScheduleTa
     })
 }
 
-fn nudge_schedule_runner() {
+pub(crate) fn nudge_schedule_runner() {
     let runner = SCHEDULE_RUNNER
         .get_or_init(|| Mutex::new(None))
         .lock()

--- a/src/tool/ambient.rs
+++ b/src/tool/ambient.rs
@@ -855,6 +855,7 @@ impl Tool for ScheduleTool {
 
         let mut manager = AmbientManager::new()?;
         let id = manager.schedule(request)?;
+        nudge_schedule_runner();
 
         let when = if let Some(ref ts) = params.wake_at {
             ts.clone()

--- a/src/tool/mod.rs
+++ b/src/tool/mod.rs
@@ -22,6 +22,7 @@ mod memory;
 mod multiedit;
 mod open;
 mod patch;
+mod pr_watch;
 mod read;
 pub mod selfdev;
 mod session_search;
@@ -135,6 +136,7 @@ impl Registry {
                 multiedit::MultiEditTool::new,
             );
             Self::insert_tool_timed(&mut m, &mut timings, "patch", patch::PatchTool::new);
+            Self::insert_tool_timed(&mut m, &mut timings, "pr_watch", pr_watch::PrWatchTool::new);
             Self::insert_tool_timed(
                 &mut m,
                 &mut timings,

--- a/src/tool/pr_watch.rs
+++ b/src/tool/pr_watch.rs
@@ -32,6 +32,7 @@ enum PrWatchAction {
     Stop,
     Readiness,
     Handoff,
+    AckBaseline,
 }
 
 #[derive(Debug, Deserialize)]
@@ -61,7 +62,7 @@ impl Tool for PrWatchTool {
                 "intent": super::intent_schema_property(),
                 "action": {
                     "type": "string",
-                    "enum": ["start", "status", "list", "poll_now", "stop", "readiness", "handoff"],
+                    "enum": ["start", "status", "list", "poll_now", "ack_baseline", "stop", "readiness", "handoff"],
                     "description": "Action. poll_now performs read-only gh CLI collection and updates local state; no mutations are performed."
                 },
                 "repo": {"type": "string", "description": "Repository in owner/name form."},
@@ -83,6 +84,7 @@ impl Tool for PrWatchTool {
             PrWatchAction::Start => start_watch(&store, params),
             PrWatchAction::List => list_watches(&store),
             PrWatchAction::PollNow => poll_now(&root, &store, params),
+            PrWatchAction::AckBaseline => ack_baseline(&root, &store, params),
             PrWatchAction::Status | PrWatchAction::Readiness | PrWatchAction::Handoff => {
                 status_like(&store, params)
             }
@@ -150,6 +152,235 @@ fn list_watches(store: &Path) -> Result<ToolOutput> {
     Ok(ToolOutput::new(lines.join("\n"))
         .with_title(format!("{} watches", states.len()))
         .with_metadata(json!({"watches": states.into_iter().map(|(_, s)| s).collect::<Vec<_>>() })))
+}
+
+fn ack_baseline(root: &Path, store: &Path, params: PrWatchInput) -> Result<ToolOutput> {
+    let mut state = load_state_for_params(store, &params)?;
+    let path = state_path(store, &state.watch_id);
+    let collected_at = now_iso();
+    let collection = collect_with_gh(root, &state.pr.repo, state.pr.number);
+    let partial_failure = apply_baseline_from_collection(&mut state, collection, &collected_at);
+    let would_write = !params.dry_run.unwrap_or(false);
+    if would_write {
+        fs::write(&path, serde_json::to_vec_pretty(&state)?)?;
+    }
+    let text = format!(
+        "PR watch baseline acknowledged: {}\nRepo: {}\nPR: #{}\nUnresolved threads: {}\nReview comments seen: {}\nIssue comments seen: {}\nReviews seen: {}\nPartial failure: {}{}",
+        state.watch_id,
+        state.pr.repo,
+        state.pr.number,
+        state.baseline.unresolved_thread_ids.len(),
+        state.last_seen.review_comments.len(),
+        state.last_seen.issue_comments.len(),
+        state.last_seen.reviews.len(),
+        partial_failure,
+        if would_write {
+            ""
+        } else {
+            "\nDry run: no file written"
+        }
+    );
+    Ok(ToolOutput::new(text)
+        .with_title(format!("baseline {}", state.watch_id))
+        .with_metadata(
+            json!({"watch": state, "partial_failure": partial_failure, "written": would_write}),
+        ))
+}
+
+fn apply_baseline_from_collection(
+    state: &mut PrWatchState,
+    collection: GhCollection,
+    collected_at: &str,
+) -> bool {
+    state.updated_at = Some(collected_at.to_string());
+    state.baseline.established_at = Some(collected_at.to_string());
+    state.polling.quiet_cycles = 0;
+    state.pending_actionable.clear();
+    state.last_cycle.completed_at = Some(collected_at.to_string());
+    state.last_cycle.status = jcode_pr_watch_core::CycleStatus::BaselineEstablished;
+    state.last_cycle.actionable_count = 0;
+    state.last_cycle.pending_check_count = 0;
+    state.last_cycle.failed_check_count = 0;
+    state.last_cycle.surfaces_checked = vec![
+        "metadata".to_string(),
+        "checks".to_string(),
+        "review_comments".to_string(),
+        "issue_comments".to_string(),
+        "reviews".to_string(),
+        "review_threads".to_string(),
+    ];
+    state.last_cycle.surface_counts = BTreeMap::new();
+    let mut partial_failure = false;
+
+    match collection.metadata {
+        Ok(metadata) => {
+            state.pr = metadata.identity;
+            state.baseline.head_sha = state.pr.head_sha.clone();
+            state
+                .last_successful_fetch
+                .insert("metadata".to_string(), collected_at.to_string());
+            state
+                .last_cycle
+                .surface_counts
+                .insert("metadata".to_string(), 1);
+        }
+        Err(err) => {
+            partial_failure = true;
+            state.push_event(surface_error_event(collected_at, err));
+        }
+    }
+
+    match collection.checks {
+        Ok(checks) => {
+            state.last_checks_for_sha.head_sha = state.pr.head_sha.clone();
+            state.last_checks_for_sha.runs = checks;
+            state
+                .last_successful_fetch
+                .insert("checks".to_string(), collected_at.to_string());
+            state
+                .last_cycle
+                .surface_counts
+                .insert("checks".to_string(), state.last_checks_for_sha.runs.len());
+        }
+        Err(err) => {
+            partial_failure = true;
+            state.push_event(surface_error_event(collected_at, err));
+        }
+    }
+
+    match collection.review_comments {
+        Ok(comments) => {
+            state.baseline.review_comment_count = comments.len();
+            state
+                .last_cycle
+                .surface_counts
+                .insert("review_comments".to_string(), comments.len());
+            state
+                .last_successful_fetch
+                .insert("review_comments".to_string(), collected_at.to_string());
+            for comment in comments {
+                state.last_seen.review_comments.insert(
+                    comment.id.clone(),
+                    Marker {
+                        id: comment.id,
+                        updated_at: comment.updated_at,
+                        author: comment.author,
+                        body_hash: comment.body.as_ref().map(|body| stable_body_hash(body)),
+                        url: comment.url,
+                    },
+                );
+            }
+        }
+        Err(err) => {
+            partial_failure = true;
+            state.push_event(surface_error_event(collected_at, err));
+        }
+    }
+
+    match collection.issue_comments {
+        Ok(comments) => {
+            state.baseline.issue_comment_count = comments.len();
+            state
+                .last_cycle
+                .surface_counts
+                .insert("issue_comments".to_string(), comments.len());
+            state
+                .last_successful_fetch
+                .insert("issue_comments".to_string(), collected_at.to_string());
+            for comment in comments {
+                state.last_seen.issue_comments.insert(
+                    comment.id.clone(),
+                    Marker {
+                        id: comment.id,
+                        updated_at: comment.updated_at,
+                        author: comment.author,
+                        body_hash: comment.body.as_ref().map(|body| stable_body_hash(body)),
+                        url: comment.url,
+                    },
+                );
+            }
+        }
+        Err(err) => {
+            partial_failure = true;
+            state.push_event(surface_error_event(collected_at, err));
+        }
+    }
+
+    match collection.reviews {
+        Ok(reviews) => {
+            state.baseline.review_count = reviews.len();
+            state
+                .last_cycle
+                .surface_counts
+                .insert("reviews".to_string(), reviews.len());
+            state
+                .last_successful_fetch
+                .insert("reviews".to_string(), collected_at.to_string());
+            for review in reviews {
+                state.last_seen.reviews.insert(
+                    review.id.clone(),
+                    Marker {
+                        id: review.id,
+                        updated_at: review.submitted_at,
+                        author: review.author,
+                        body_hash: review.body.as_ref().map(|body| stable_body_hash(body)),
+                        url: None,
+                    },
+                );
+            }
+        }
+        Err(err) => {
+            partial_failure = true;
+            state.push_event(surface_error_event(collected_at, err));
+        }
+    }
+
+    match collection.review_threads {
+        Ok(threads) => {
+            state.baseline.unresolved_thread_ids = threads
+                .iter()
+                .filter(|thread| !thread.is_resolved && !thread.is_outdated)
+                .map(|thread| thread.id.clone())
+                .collect();
+            state
+                .last_cycle
+                .surface_counts
+                .insert("review_threads".to_string(), threads.len());
+            state
+                .last_successful_fetch
+                .insert("review_threads".to_string(), collected_at.to_string());
+            for thread in threads {
+                state.last_seen.review_threads.insert(
+                    thread.id.clone(),
+                    jcode_pr_watch_core::ReviewThreadMarker {
+                        id: thread.id,
+                        updated_at: thread.updated_at,
+                        resolved: thread.is_resolved,
+                        outdated: thread.is_outdated,
+                        body_hash: thread.body.as_ref().map(|body| stable_body_hash(body)),
+                        url: thread.url,
+                    },
+                );
+            }
+        }
+        Err(err) => {
+            partial_failure = true;
+            state.push_event(surface_error_event(collected_at, err));
+        }
+    }
+
+    state.push_event(WatchEvent {
+        at: collected_at.to_string(),
+        kind: "baseline_acknowledged".to_string(),
+        data: json!({
+            "partial_failure": partial_failure,
+            "review_comment_count": state.baseline.review_comment_count,
+            "issue_comment_count": state.baseline.issue_comment_count,
+            "review_count": state.baseline.review_count,
+            "unresolved_thread_count": state.baseline.unresolved_thread_ids.len(),
+        }),
+    });
+    partial_failure
 }
 
 fn poll_now(root: &Path, store: &Path, params: PrWatchInput) -> Result<ToolOutput> {
@@ -734,6 +965,7 @@ mod tests {
             .unwrap();
         assert!(actions.iter().any(|value| value == "start"));
         assert!(actions.iter().any(|value| value == "poll_now"));
+        assert!(actions.iter().any(|value| value == "ack_baseline"));
         assert!(!actions.iter().any(|value| value == "authorize"));
     }
 
@@ -824,6 +1056,97 @@ mod tests {
         );
     }
 
+    #[test]
+    fn ack_baseline_marks_current_feedback_seen_without_actionable() {
+        let mut state = PrWatchState::new(PrTarget {
+            repo: "owner/repo".into(),
+            number: 11,
+        });
+        let collection = GhCollection {
+            metadata: Ok(jcode_pr_watch_core::PrMetadata {
+                identity: jcode_pr_watch_core::PrIdentity {
+                    repo: "owner/repo".into(),
+                    number: 11,
+                    url: Some("https://github.com/owner/repo/pull/11".into()),
+                    state: Some("OPEN".into()),
+                    base_ref: Some("main".into()),
+                    head_ref: Some("feature".into()),
+                    head_sha: Some("sha1".into()),
+                    merge_state: Some("CLEAN".into()),
+                    review_decision: None,
+                },
+                is_draft: Some(false),
+            }),
+            checks: Ok(Vec::new()),
+            review_comments: Ok(vec![jcode_pr_watch_core::ReviewComment {
+                id: "RC_BASE".into(),
+                path: Some("src/lib.rs".into()),
+                line: Some(1),
+                url: Some("https://comment".into()),
+                updated_at: Some("2026-05-13T18:00:00Z".into()),
+                author: Some("reviewer".into()),
+                body: Some("Existing comment".into()),
+            }]),
+            issue_comments: Ok(Vec::new()),
+            reviews: Ok(Vec::new()),
+            review_threads: Ok(vec![jcode_pr_watch_core::ReviewThread {
+                id: "THREAD_BASE".into(),
+                is_resolved: false,
+                is_outdated: false,
+                path: Some("src/lib.rs".into()),
+                line: Some(2),
+                url: Some("https://thread".into()),
+                updated_at: Some("2026-05-13T18:00:00Z".into()),
+                author: Some("reviewer".into()),
+                body: Some("Existing thread".into()),
+            }]),
+        };
+        let partial =
+            apply_baseline_from_collection(&mut state, collection, "2026-05-13T18:00:00Z");
+        assert!(!partial);
+        assert!(state.pending_actionable.is_empty());
+        assert_eq!(
+            state.last_cycle.status,
+            jcode_pr_watch_core::CycleStatus::BaselineEstablished
+        );
+        assert_eq!(state.baseline.head_sha.as_deref(), Some("sha1"));
+        assert_eq!(state.baseline.review_comment_count, 1);
+        assert_eq!(
+            state.baseline.unresolved_thread_ids,
+            vec!["THREAD_BASE".to_string()]
+        );
+        assert!(state.last_seen.review_comments.contains_key("RC_BASE"));
+        assert!(state.last_seen.review_threads.contains_key("THREAD_BASE"));
+
+        let collection = GhCollection {
+            metadata: Err(SurfaceError::transient("metadata", "skip")),
+            checks: Ok(Vec::new()),
+            review_comments: Ok(vec![jcode_pr_watch_core::ReviewComment {
+                id: "RC_BASE".into(),
+                path: Some("src/lib.rs".into()),
+                line: Some(1),
+                url: Some("https://comment".into()),
+                updated_at: Some("2026-05-13T18:00:00Z".into()),
+                author: Some("reviewer".into()),
+                body: Some("Existing comment".into()),
+            }]),
+            issue_comments: Ok(Vec::new()),
+            reviews: Ok(Vec::new()),
+            review_threads: Ok(vec![jcode_pr_watch_core::ReviewThread {
+                id: "THREAD_BASE".into(),
+                is_resolved: false,
+                is_outdated: false,
+                path: Some("src/lib.rs".into()),
+                line: Some(2),
+                url: Some("https://thread".into()),
+                updated_at: Some("2026-05-13T18:00:00Z".into()),
+                author: Some("reviewer".into()),
+                body: Some("Existing thread".into()),
+            }]),
+        };
+        update_state_from_collection(&mut state, collection, "2026-05-13T18:05:00Z");
+        assert!(state.pending_actionable.is_empty());
+    }
     #[test]
     fn unresolved_review_threads_are_actionable_and_resolved_are_not() {
         let mut state = PrWatchState::new(PrTarget {

--- a/src/tool/pr_watch.rs
+++ b/src/tool/pr_watch.rs
@@ -5,7 +5,7 @@ use chrono::Utc;
 use jcode_pr_watch_core::{
     ActionableItem, CheckRunState, CycleOutcome, Marker, PrTarget, PrWatchState, SurfaceError,
     WatchEvent, normalize_watch_state_json, parse_gh_checks, parse_gh_issue_comments,
-    parse_gh_pr_view, parse_gh_review_comments, parse_gh_reviews,
+    parse_gh_pr_view, parse_gh_review_comments, parse_gh_review_threads, parse_gh_reviews,
 };
 use serde::Deserialize;
 use serde_json::{Value, json};
@@ -200,6 +200,8 @@ fn collect_with_gh(root: &Path, repo: &str, pr: u64) -> GhCollection {
             .and_then(|stdout| parse_gh_issue_comments(&stdout).map_err(|err| SurfaceError::transient("issue_comments", err.to_string()))),
         reviews: run_gh(root, &["api", &format!("repos/{repo}/pulls/{pr}/reviews"), "--paginate"])
             .and_then(|stdout| parse_gh_reviews(&stdout).map_err(|err| SurfaceError::transient("reviews", err.to_string()))),
+        review_threads: run_gh_graphql_review_threads(root, repo, pr)
+            .and_then(|stdout| parse_gh_review_threads(&stdout).map_err(|err| SurfaceError::transient("review_threads", err.to_string()))),
     }
 }
 
@@ -210,6 +212,55 @@ struct GhCollection {
     review_comments: Result<Vec<jcode_pr_watch_core::ReviewComment>, SurfaceError>,
     issue_comments: Result<Vec<jcode_pr_watch_core::IssueComment>, SurfaceError>,
     reviews: Result<Vec<jcode_pr_watch_core::Review>, SurfaceError>,
+    review_threads: Result<Vec<jcode_pr_watch_core::ReviewThread>, SurfaceError>,
+}
+
+fn run_gh_graphql_review_threads(root: &Path, repo: &str, pr: u64) -> Result<String, SurfaceError> {
+    let (owner, name) = repo
+        .split_once('/')
+        .ok_or_else(|| SurfaceError::permanent("review_threads", "repo must be owner/name"))?;
+    let pr_s = pr.to_string();
+    let query = r#"
+query($owner:String!, $name:String!, $number:Int!) {
+  repository(owner:$owner, name:$name) {
+    pullRequest(number:$number) {
+      reviewThreads(first:100) {
+        nodes {
+          id
+          isResolved
+          isOutdated
+          comments(first:1) {
+            nodes {
+              path
+              line
+              url
+              body
+              createdAt
+              updatedAt
+              author { login }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+"#;
+    run_gh(
+        root,
+        &[
+            "api",
+            "graphql",
+            "-f",
+            &format!("owner={owner}"),
+            "-f",
+            &format!("name={name}"),
+            "-F",
+            &format!("number={pr_s}"),
+            "-f",
+            &format!("query={query}"),
+        ],
+    )
 }
 
 fn run_gh(root: &Path, args: &[&str]) -> Result<String, SurfaceError> {
@@ -240,6 +291,7 @@ fn update_state_from_collection(
         "review_comments".to_string(),
         "issue_comments".to_string(),
         "reviews".to_string(),
+        "review_threads".to_string(),
     ];
     state.last_cycle.surface_counts = BTreeMap::new();
 
@@ -364,6 +416,53 @@ fn update_state_from_collection(
                         url: comment.url,
                         path: None,
                         status: Some("new".to_string()),
+                    });
+                }
+            }
+        }
+        Err(err) => {
+            partial_failure = true;
+            state.push_event(surface_error_event(collected_at, err));
+        }
+    }
+
+    match collection.review_threads {
+        Ok(threads) => {
+            state
+                .last_cycle
+                .surface_counts
+                .insert("review_threads".to_string(), threads.len());
+            state
+                .last_successful_fetch
+                .insert("review_threads".to_string(), collected_at.to_string());
+            state.baseline.unresolved_thread_ids = threads
+                .iter()
+                .filter(|thread| !thread.is_resolved && !thread.is_outdated)
+                .map(|thread| thread.id.clone())
+                .collect();
+            for thread in threads {
+                let is_new = !state.last_seen.review_threads.contains_key(&thread.id);
+                state.last_seen.review_threads.insert(
+                    thread.id.clone(),
+                    jcode_pr_watch_core::ReviewThreadMarker {
+                        id: thread.id.clone(),
+                        updated_at: thread.updated_at.clone(),
+                        resolved: thread.is_resolved,
+                        outdated: thread.is_outdated,
+                        body_hash: thread.body.as_ref().map(|body| stable_body_hash(body)),
+                        url: thread.url.clone(),
+                    },
+                );
+                if is_new && !thread.is_resolved && !thread.is_outdated {
+                    pending_actionable.push(ActionableItem {
+                        id: thread.id,
+                        surface: "review_threads".to_string(),
+                        summary: thread
+                            .body
+                            .unwrap_or_else(|| "Unresolved review thread".to_string()),
+                        url: thread.url,
+                        path: thread.path,
+                        status: Some("unresolved".to_string()),
                     });
                 }
             }
@@ -707,6 +806,7 @@ mod tests {
             }]),
             issue_comments: Err(SurfaceError::transient("issue_comments", "timeout")),
             reviews: Ok(Vec::new()),
+            review_threads: Ok(Vec::new()),
         };
         let outcome = update_state_from_collection(&mut state, collection, "2026-05-13T17:00:00Z");
         assert!(outcome.partial_failure);
@@ -724,6 +824,59 @@ mod tests {
         );
     }
 
+    #[test]
+    fn unresolved_review_threads_are_actionable_and_resolved_are_not() {
+        let mut state = PrWatchState::new(PrTarget {
+            repo: "owner/repo".into(),
+            number: 10,
+        });
+        let collection = GhCollection {
+            metadata: Err(SurfaceError::transient("metadata", "skip")),
+            checks: Ok(Vec::new()),
+            review_comments: Ok(Vec::new()),
+            issue_comments: Ok(Vec::new()),
+            reviews: Ok(Vec::new()),
+            review_threads: Ok(vec![
+                jcode_pr_watch_core::ReviewThread {
+                    id: "THREAD_OPEN".into(),
+                    is_resolved: false,
+                    is_outdated: false,
+                    path: Some("src/lib.rs".into()),
+                    line: Some(12),
+                    url: Some("https://thread-open".into()),
+                    updated_at: Some("2026-05-13T17:00:00Z".into()),
+                    author: Some("reviewer".into()),
+                    body: Some("Please address this thread".into()),
+                },
+                jcode_pr_watch_core::ReviewThread {
+                    id: "THREAD_RESOLVED".into(),
+                    is_resolved: true,
+                    is_outdated: false,
+                    path: Some("src/lib.rs".into()),
+                    line: Some(20),
+                    url: Some("https://thread-resolved".into()),
+                    updated_at: Some("2026-05-13T17:00:00Z".into()),
+                    author: Some("reviewer".into()),
+                    body: Some("Already resolved".into()),
+                },
+            ]),
+        };
+        let outcome = update_state_from_collection(&mut state, collection, "2026-05-13T17:00:00Z");
+        assert!(outcome.partial_failure);
+        assert_eq!(state.pending_actionable.len(), 1);
+        assert_eq!(state.pending_actionable[0].id, "THREAD_OPEN");
+        assert_eq!(
+            state.baseline.unresolved_thread_ids,
+            vec!["THREAD_OPEN".to_string()]
+        );
+        assert!(state.last_seen.review_threads.contains_key("THREAD_OPEN"));
+        assert!(
+            state
+                .last_seen
+                .review_threads
+                .contains_key("THREAD_RESOLVED")
+        );
+    }
     #[test]
     fn automation_chatter_is_not_actionable() {
         assert!(is_automation_chatter(

--- a/src/tool/pr_watch.rs
+++ b/src/tool/pr_watch.rs
@@ -1,11 +1,18 @@
 use super::{Tool, ToolContext, ToolOutput};
 use anyhow::{Context, Result, bail};
 use async_trait::async_trait;
-use jcode_pr_watch_core::{PrTarget, PrWatchState, normalize_watch_state_json};
+use chrono::Utc;
+use jcode_pr_watch_core::{
+    ActionableItem, CheckRunState, CycleOutcome, Marker, PrTarget, PrWatchState, SurfaceError,
+    WatchEvent, normalize_watch_state_json, parse_gh_checks, parse_gh_issue_comments,
+    parse_gh_pr_view, parse_gh_review_comments, parse_gh_reviews,
+};
 use serde::Deserialize;
 use serde_json::{Value, json};
+use std::collections::BTreeMap;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::process::Command;
 
 pub struct PrWatchTool;
 
@@ -55,7 +62,7 @@ impl Tool for PrWatchTool {
                 "action": {
                     "type": "string",
                     "enum": ["start", "status", "list", "poll_now", "stop", "readiness", "handoff"],
-                    "description": "Action. This phase is read-only/local-state only; poll_now does not contact GitHub yet."
+                    "description": "Action. poll_now performs read-only gh CLI collection and updates local state; no mutations are performed."
                 },
                 "repo": {"type": "string", "description": "Repository in owner/name form."},
                 "pr": {"type": "integer", "description": "Pull request number."},
@@ -75,10 +82,10 @@ impl Tool for PrWatchTool {
         match params.action {
             PrWatchAction::Start => start_watch(&store, params),
             PrWatchAction::List => list_watches(&store),
-            PrWatchAction::Status
-            | PrWatchAction::Readiness
-            | PrWatchAction::Handoff
-            | PrWatchAction::PollNow => status_like(&store, params),
+            PrWatchAction::PollNow => poll_now(&root, &store, params),
+            PrWatchAction::Status | PrWatchAction::Readiness | PrWatchAction::Handoff => {
+                status_like(&store, params)
+            }
             PrWatchAction::Stop => stop_watch(&store, params),
         }
     }
@@ -111,7 +118,7 @@ fn start_watch(store: &Path, params: PrWatchInput) -> Result<ToolOutput> {
         fs::write(&path, serde_json::to_vec_pretty(&state)?)?;
     }
     Ok(ToolOutput::new(format!(
-        "PR watch initialized: {}\nPath: {}\nMode: local state only, no GitHub polling yet{}",
+        "PR watch initialized: {}\nPath: {}\nMode: local state initialized. Use poll_now for read-only gh collection{}",
         state.watch_id,
         path.display(),
         if would_write {
@@ -145,11 +152,385 @@ fn list_watches(store: &Path) -> Result<ToolOutput> {
         .with_metadata(json!({"watches": states.into_iter().map(|(_, s)| s).collect::<Vec<_>>() })))
 }
 
+fn poll_now(root: &Path, store: &Path, params: PrWatchInput) -> Result<ToolOutput> {
+    let mut state = load_state_for_params(store, &params)?;
+    let path = state_path(store, &state.watch_id);
+    let collected_at = now_iso();
+    let result = collect_with_gh(root, &state.pr.repo, state.pr.number);
+    let outcome = update_state_from_collection(&mut state, result, &collected_at);
+    let would_write = !params.dry_run.unwrap_or(false);
+    if would_write {
+        fs::write(&path, serde_json::to_vec_pretty(&state)?)?;
+    }
+    let readiness = state.readiness();
+    let text = format!(
+        "PR watch polled: {}\nRepo: {}\nPR: #{}\nState: {:?}\nReadiness: {:?}\nQuiet cycles: {}/{}\nActionable: {}\nPending checks: {}\nFailed checks: {}\nPartial failure: {}\nFailed surfaces: {}{}",
+        state.watch_id,
+        state.pr.repo,
+        state.pr.number,
+        state.last_cycle.status,
+        readiness,
+        state.polling.quiet_cycles,
+        state.polling.required_quiet_cycles,
+        state.pending_actionable.len(),
+        state.last_cycle.pending_check_count,
+        state.last_cycle.failed_check_count,
+        outcome.partial_failure,
+        failed_surface_names(&state).join(", "),
+        if would_write {
+            ""
+        } else {
+            "\nDry run: no file written"
+        }
+    );
+    Ok(ToolOutput::new(text)
+        .with_title(format!("{} {:?}", state.watch_id, state.last_cycle.status))
+        .with_metadata(json!({"watch": state, "readiness": readiness, "written": would_write})))
+}
+
+fn collect_with_gh(root: &Path, repo: &str, pr: u64) -> GhCollection {
+    GhCollection {
+        metadata: run_gh(root, &["pr", "view", &pr.to_string(), "--repo", repo, "--json", "url,state,baseRefName,headRefName,headRefOid,mergeStateStatus,reviewDecision,isDraft"])
+            .and_then(|stdout| parse_gh_pr_view(repo, pr, &stdout).map_err(|err| SurfaceError::transient("metadata", err.to_string()))),
+        checks: run_gh(root, &["pr", "checks", &pr.to_string(), "--repo", repo, "--json", "name,status,conclusion,detailsUrl"])
+            .and_then(|stdout| parse_gh_checks(&stdout).map_err(|err| SurfaceError::transient("checks", err.to_string()))),
+        review_comments: run_gh(root, &["api", &format!("repos/{repo}/pulls/{pr}/comments"), "--paginate"])
+            .and_then(|stdout| parse_gh_review_comments(&stdout).map_err(|err| SurfaceError::transient("review_comments", err.to_string()))),
+        issue_comments: run_gh(root, &["api", &format!("repos/{repo}/issues/{pr}/comments"), "--paginate"])
+            .and_then(|stdout| parse_gh_issue_comments(&stdout).map_err(|err| SurfaceError::transient("issue_comments", err.to_string()))),
+        reviews: run_gh(root, &["api", &format!("repos/{repo}/pulls/{pr}/reviews"), "--paginate"])
+            .and_then(|stdout| parse_gh_reviews(&stdout).map_err(|err| SurfaceError::transient("reviews", err.to_string()))),
+    }
+}
+
+#[derive(Debug)]
+struct GhCollection {
+    metadata: Result<jcode_pr_watch_core::PrMetadata, SurfaceError>,
+    checks: Result<Vec<CheckRunState>, SurfaceError>,
+    review_comments: Result<Vec<jcode_pr_watch_core::ReviewComment>, SurfaceError>,
+    issue_comments: Result<Vec<jcode_pr_watch_core::IssueComment>, SurfaceError>,
+    reviews: Result<Vec<jcode_pr_watch_core::Review>, SurfaceError>,
+}
+
+fn run_gh(root: &Path, args: &[&str]) -> Result<String, SurfaceError> {
+    let output = Command::new("gh")
+        .args(args)
+        .current_dir(root)
+        .output()
+        .map_err(|err| SurfaceError::transient("gh", format!("failed to run gh: {err}")))?;
+    if !output.status.success() {
+        return Err(SurfaceError::transient(
+            "gh",
+            String::from_utf8_lossy(&output.stderr).trim().to_string(),
+        ));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
+fn update_state_from_collection(
+    state: &mut PrWatchState,
+    collection: GhCollection,
+    collected_at: &str,
+) -> CycleOutcome {
+    state.updated_at = Some(collected_at.to_string());
+    state.last_cycle.completed_at = Some(collected_at.to_string());
+    state.last_cycle.surfaces_checked = vec![
+        "metadata".to_string(),
+        "checks".to_string(),
+        "review_comments".to_string(),
+        "issue_comments".to_string(),
+        "reviews".to_string(),
+    ];
+    state.last_cycle.surface_counts = BTreeMap::new();
+
+    let mut partial_failure = false;
+    let mut pending_actionable = Vec::new();
+    let mut pending_check_count = 0;
+    let mut failed_check_count = 0;
+
+    match collection.metadata {
+        Ok(metadata) => {
+            state.pr = metadata.identity;
+            state
+                .last_successful_fetch
+                .insert("metadata".to_string(), collected_at.to_string());
+            state
+                .last_cycle
+                .surface_counts
+                .insert("metadata".to_string(), 1);
+        }
+        Err(err) => {
+            partial_failure = true;
+            state.push_event(surface_error_event(collected_at, err));
+        }
+    }
+
+    match collection.checks {
+        Ok(checks) => {
+            pending_check_count = checks
+                .iter()
+                .filter(|check| is_pending_check(check))
+                .count();
+            failed_check_count = checks.iter().filter(|check| is_failed_check(check)).count();
+            state.last_checks_for_sha.head_sha = state.pr.head_sha.clone();
+            state.last_checks_for_sha.runs = checks;
+            state
+                .last_successful_fetch
+                .insert("checks".to_string(), collected_at.to_string());
+            state
+                .last_cycle
+                .surface_counts
+                .insert("checks".to_string(), state.last_checks_for_sha.runs.len());
+        }
+        Err(err) => {
+            partial_failure = true;
+            state.push_event(surface_error_event(collected_at, err));
+        }
+    }
+
+    match collection.review_comments {
+        Ok(comments) => {
+            state
+                .last_cycle
+                .surface_counts
+                .insert("review_comments".to_string(), comments.len());
+            state
+                .last_successful_fetch
+                .insert("review_comments".to_string(), collected_at.to_string());
+            for comment in comments {
+                let is_new = !state.last_seen.review_comments.contains_key(&comment.id);
+                state.last_seen.review_comments.insert(
+                    comment.id.clone(),
+                    Marker {
+                        id: comment.id.clone(),
+                        updated_at: comment.updated_at.clone(),
+                        author: comment.author.clone(),
+                        body_hash: comment.body.as_ref().map(|body| stable_body_hash(body)),
+                        url: comment.url.clone(),
+                    },
+                );
+                if is_new
+                    && !is_automation_chatter(comment.author.as_deref(), comment.body.as_deref())
+                {
+                    pending_actionable.push(ActionableItem {
+                        id: comment.id,
+                        surface: "review_comments".to_string(),
+                        summary: comment
+                            .body
+                            .unwrap_or_else(|| "New review comment".to_string()),
+                        url: comment.url,
+                        path: comment.path,
+                        status: Some("new".to_string()),
+                    });
+                }
+            }
+        }
+        Err(err) => {
+            partial_failure = true;
+            state.push_event(surface_error_event(collected_at, err));
+        }
+    }
+
+    match collection.issue_comments {
+        Ok(comments) => {
+            state
+                .last_cycle
+                .surface_counts
+                .insert("issue_comments".to_string(), comments.len());
+            state
+                .last_successful_fetch
+                .insert("issue_comments".to_string(), collected_at.to_string());
+            for comment in comments {
+                let is_new = !state.last_seen.issue_comments.contains_key(&comment.id);
+                state.last_seen.issue_comments.insert(
+                    comment.id.clone(),
+                    Marker {
+                        id: comment.id.clone(),
+                        updated_at: comment.updated_at.clone(),
+                        author: comment.author.clone(),
+                        body_hash: comment.body.as_ref().map(|body| stable_body_hash(body)),
+                        url: comment.url.clone(),
+                    },
+                );
+                if is_new
+                    && !is_automation_chatter(comment.author.as_deref(), comment.body.as_deref())
+                {
+                    pending_actionable.push(ActionableItem {
+                        id: comment.id,
+                        surface: "issue_comments".to_string(),
+                        summary: comment
+                            .body
+                            .unwrap_or_else(|| "New issue comment".to_string()),
+                        url: comment.url,
+                        path: None,
+                        status: Some("new".to_string()),
+                    });
+                }
+            }
+        }
+        Err(err) => {
+            partial_failure = true;
+            state.push_event(surface_error_event(collected_at, err));
+        }
+    }
+
+    match collection.reviews {
+        Ok(reviews) => {
+            state
+                .last_cycle
+                .surface_counts
+                .insert("reviews".to_string(), reviews.len());
+            state
+                .last_successful_fetch
+                .insert("reviews".to_string(), collected_at.to_string());
+            for review in reviews {
+                let is_new = !state.last_seen.reviews.contains_key(&review.id);
+                state.last_seen.reviews.insert(
+                    review.id.clone(),
+                    Marker {
+                        id: review.id.clone(),
+                        updated_at: review.submitted_at.clone(),
+                        author: review.author.clone(),
+                        body_hash: review.body.as_ref().map(|body| stable_body_hash(body)),
+                        url: None,
+                    },
+                );
+                if is_new && review.state.as_deref() == Some("CHANGES_REQUESTED") {
+                    pending_actionable.push(ActionableItem {
+                        id: review.id,
+                        surface: "reviews".to_string(),
+                        summary: review
+                            .body
+                            .unwrap_or_else(|| "Review requested changes".to_string()),
+                        url: None,
+                        path: None,
+                        status: review.state,
+                    });
+                }
+            }
+        }
+        Err(err) => {
+            partial_failure = true;
+            state.push_event(surface_error_event(collected_at, err));
+        }
+    }
+
+    let outcome = CycleOutcome {
+        pending_actionable,
+        pending_check_count,
+        failed_check_count,
+        partial_failure,
+    };
+    state.apply_cycle_outcome(outcome.clone());
+    state.push_event(WatchEvent {
+        at: collected_at.to_string(),
+        kind: "poll_completed".to_string(),
+        data: json!({
+            "status": format!("{:?}", state.last_cycle.status),
+            "actionable_count": state.pending_actionable.len(),
+            "pending_check_count": state.last_cycle.pending_check_count,
+            "failed_check_count": state.last_cycle.failed_check_count,
+            "partial_failure": partial_failure,
+        }),
+    });
+    outcome
+}
+
+fn surface_error_event(at: &str, err: SurfaceError) -> WatchEvent {
+    WatchEvent {
+        at: at.to_string(),
+        kind: "surface_error".to_string(),
+        data: json!({"surface": err.surface, "message": err.message, "transient": err.transient}),
+    }
+}
+
+fn failed_surface_names(state: &PrWatchState) -> Vec<String> {
+    state
+        .events
+        .iter()
+        .rev()
+        .take(10)
+        .filter_map(|event| {
+            if event.kind == "surface_error" {
+                event
+                    .data
+                    .get("surface")
+                    .and_then(Value::as_str)
+                    .map(str::to_string)
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+fn is_pending_check(check: &CheckRunState) -> bool {
+    let status = check
+        .status
+        .as_deref()
+        .unwrap_or_default()
+        .to_ascii_uppercase();
+    let conclusion = check
+        .conclusion
+        .as_deref()
+        .unwrap_or_default()
+        .to_ascii_uppercase();
+    matches!(
+        status.as_str(),
+        "IN_PROGRESS" | "QUEUED" | "PENDING" | "WAITING" | "REQUESTED"
+    ) || (conclusion.is_empty()
+        && !matches!(
+            status.as_str(),
+            "COMPLETED" | "SUCCESS" | "FAILURE" | "ERROR" | "CANCELLED" | "SKIPPED"
+        ))
+}
+
+fn is_failed_check(check: &CheckRunState) -> bool {
+    let conclusion = check
+        .conclusion
+        .as_deref()
+        .unwrap_or_default()
+        .to_ascii_uppercase();
+    let status = check
+        .status
+        .as_deref()
+        .unwrap_or_default()
+        .to_ascii_uppercase();
+    matches!(
+        conclusion.as_str(),
+        "FAILURE" | "ERROR" | "TIMED_OUT" | "ACTION_REQUIRED" | "CANCELLED"
+    ) || matches!(status.as_str(), "FAILURE" | "ERROR" | "FAILED")
+}
+
+fn is_automation_chatter(author: Option<&str>, body: Option<&str>) -> bool {
+    let author = author.unwrap_or_default().to_ascii_lowercase();
+    let body = body.unwrap_or_default().to_ascii_lowercase();
+    author.ends_with("[bot]")
+        || matches!(
+            author.as_str(),
+            "github-actions" | "claude" | "codex" | "gemini-code-assist"
+        )
+        || body.starts_with("fix-summary:")
+        || body.contains("triggered the review bot")
+        || body.contains("automation progress")
+}
+
+fn stable_body_hash(body: &str) -> String {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    body.hash(&mut hasher);
+    format!("hash:{:016x}", hasher.finish())
+}
+
+fn now_iso() -> String {
+    Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string()
+}
+
 fn status_like(store: &Path, params: PrWatchInput) -> Result<ToolOutput> {
     let state = load_state_for_params(store, &params)?;
     let readiness = state.readiness();
     let text = format!(
-        "PR watch: {}\nRepo: {}\nPR: #{}\nState: {:?}\nReadiness: {:?}\nQuiet cycles: {}/{}\nActionable: {}\nPending checks: {}\nFailed checks: {}\nPolicy: local_fix={}, commit={}, push={}, comment={}, resolve_threads={}\nNote: poll_now is a local-state placeholder in this phase and does not contact GitHub.",
+        "PR watch: {}\nRepo: {}\nPR: #{}\nState: {:?}\nReadiness: {:?}\nQuiet cycles: {}/{}\nActionable: {}\nPending checks: {}\nFailed checks: {}\nPolicy: local_fix={}, commit={}, push={}, comment={}, resolve_threads={}",
         state.watch_id,
         state.pr.repo,
         state.pr.number,
@@ -255,5 +636,107 @@ mod tests {
         assert!(actions.iter().any(|value| value == "start"));
         assert!(actions.iter().any(|value| value == "poll_now"));
         assert!(!actions.iter().any(|value| value == "authorize"));
+    }
+
+    #[test]
+    fn check_classification_detects_pending_and_failed() {
+        let pending = CheckRunState {
+            id: None,
+            name: "ci".into(),
+            status: Some("IN_PROGRESS".into()),
+            conclusion: None,
+            url: None,
+        };
+        let failed = CheckRunState {
+            id: None,
+            name: "lint".into(),
+            status: Some("COMPLETED".into()),
+            conclusion: Some("FAILURE".into()),
+            url: None,
+        };
+        let passed = CheckRunState {
+            id: None,
+            name: "test".into(),
+            status: Some("COMPLETED".into()),
+            conclusion: Some("SUCCESS".into()),
+            url: None,
+        };
+        assert!(is_pending_check(&pending));
+        assert!(!is_failed_check(&pending));
+        assert!(is_failed_check(&failed));
+        assert!(!is_pending_check(&passed));
+        assert!(!is_failed_check(&passed));
+    }
+
+    #[test]
+    fn update_state_from_collection_preserves_partial_failure_and_actionable() {
+        let mut state = PrWatchState::new(PrTarget {
+            repo: "owner/repo".into(),
+            number: 9,
+        });
+        let collection = GhCollection {
+            metadata: Ok(jcode_pr_watch_core::PrMetadata {
+                identity: jcode_pr_watch_core::PrIdentity {
+                    repo: "owner/repo".into(),
+                    number: 9,
+                    url: Some("https://github.com/owner/repo/pull/9".into()),
+                    state: Some("OPEN".into()),
+                    base_ref: Some("main".into()),
+                    head_ref: Some("feature".into()),
+                    head_sha: Some("abc".into()),
+                    merge_state: Some("CLEAN".into()),
+                    review_decision: None,
+                },
+                is_draft: Some(false),
+            }),
+            checks: Ok(vec![CheckRunState {
+                id: Some("1".into()),
+                name: "ci".into(),
+                status: Some("COMPLETED".into()),
+                conclusion: Some("SUCCESS".into()),
+                url: None,
+            }]),
+            review_comments: Ok(vec![jcode_pr_watch_core::ReviewComment {
+                id: "RC_1".into(),
+                path: Some("src/lib.rs".into()),
+                line: Some(7),
+                url: Some("https://comment".into()),
+                updated_at: Some("2026-05-13T17:00:00Z".into()),
+                author: Some("reviewer".into()),
+                body: Some("Please fix".into()),
+            }]),
+            issue_comments: Err(SurfaceError::transient("issue_comments", "timeout")),
+            reviews: Ok(Vec::new()),
+        };
+        let outcome = update_state_from_collection(&mut state, collection, "2026-05-13T17:00:00Z");
+        assert!(outcome.partial_failure);
+        assert_eq!(state.pending_actionable.len(), 1);
+        assert_eq!(
+            state.last_cycle.status,
+            jcode_pr_watch_core::CycleStatus::ActionRequired
+        );
+        assert!(state.last_seen.review_comments.contains_key("RC_1"));
+        assert!(
+            state
+                .events
+                .iter()
+                .any(|event| event.kind == "surface_error")
+        );
+    }
+
+    #[test]
+    fn automation_chatter_is_not_actionable() {
+        assert!(is_automation_chatter(
+            Some("github-actions[bot]"),
+            Some("Progress update")
+        ));
+        assert!(is_automation_chatter(
+            Some("human"),
+            Some("fix-summary: addressed feedback")
+        ));
+        assert!(!is_automation_chatter(
+            Some("reviewer"),
+            Some("Please fix this")
+        ));
     }
 }

--- a/src/tool/pr_watch.rs
+++ b/src/tool/pr_watch.rs
@@ -95,9 +95,9 @@ impl Tool for PrWatchTool {
             PrWatchAction::List => list_watches(&store),
             PrWatchAction::PollNow => poll_now(&root, &store, params, &ctx),
             PrWatchAction::AckBaseline => ack_baseline(&root, &store, params, &ctx),
-            PrWatchAction::Status | PrWatchAction::Readiness | PrWatchAction::Handoff => {
-                status_like(&store, params)
-            }
+            PrWatchAction::Status => status_like(&store, params),
+            PrWatchAction::Readiness => readiness_report(&store, params),
+            PrWatchAction::Handoff => handoff_report(&store, params),
             PrWatchAction::Stop => stop_watch(&store, params),
         }
     }
@@ -960,8 +960,80 @@ fn now_iso() -> String {
 fn status_like(store: &Path, params: PrWatchInput) -> Result<ToolOutput> {
     let state = load_state_for_params(store, &params)?;
     let readiness = state.readiness();
-    let text = format!(
-        "PR watch: {}\nRepo: {}\nPR: #{}\nState: {:?}\nReadiness: {:?}\nQuiet cycles: {}/{}\nActionable: {}\nPending checks: {}\nFailed checks: {}\nPolicy: local_fix={}, commit={}, push={}, comment={}, resolve_threads={}",
+    let text = format_status_report(&state, readiness_label(&readiness));
+    Ok(ToolOutput::new(text)
+        .with_title(format!(
+            "{} {}",
+            state.watch_id,
+            readiness_label(&readiness)
+        ))
+        .with_metadata(json!({"watch": state, "readiness": readiness})))
+}
+
+fn readiness_report(store: &Path, params: PrWatchInput) -> Result<ToolOutput> {
+    let state = load_state_for_params(store, &params)?;
+    let readiness = state.readiness();
+    let mut text = format_status_report(&state, readiness_label(&readiness));
+    text.push_str("\n\nReadiness decision:\n");
+    text.push_str(&format!("- {}\n", readiness_label(&readiness)));
+    for reason in readiness_reasons(&state) {
+        text.push_str(&format!("- {}\n", reason));
+    }
+    Ok(ToolOutput::new(text)
+        .with_title(format!("readiness {}", readiness_label(&readiness)))
+        .with_metadata(json!({"watch": state, "readiness": readiness})))
+}
+
+fn handoff_report(store: &Path, params: PrWatchInput) -> Result<ToolOutput> {
+    let state = load_state_for_params(store, &params)?;
+    let readiness = state.readiness();
+    let mut text = String::new();
+    text.push_str(&format!("# PR watch handoff: {}\n\n", state.watch_id));
+    text.push_str(&format!("- PR: {}/#{}\n", state.pr.repo, state.pr.number));
+    if let Some(url) = &state.pr.url {
+        text.push_str(&format!("- URL: {}\n", url));
+    }
+    text.push_str(&format!("- Readiness: {}\n", readiness_label(&readiness)));
+    text.push_str(&format!(
+        "- Current status: {:?}\n",
+        state.last_cycle.status
+    ));
+    text.push_str(&format!(
+        "- Quiet cycles: {}/{}\n",
+        state.polling.quiet_cycles, state.polling.required_quiet_cycles
+    ));
+    text.push_str("\n## Evidence\n");
+    for line in evidence_lines(&state) {
+        text.push_str(&format!("- {}\n", line));
+    }
+    text.push_str("\n## Pending actionable items\n");
+    if state.pending_actionable.is_empty() {
+        text.push_str("- None recorded.\n");
+    } else {
+        for item in &state.pending_actionable {
+            text.push_str(&format!(
+                "- [{}] {}{}\n",
+                item.surface,
+                item.summary,
+                item.url
+                    .as_ref()
+                    .map(|u| format!(" ({u})"))
+                    .unwrap_or_default()
+            ));
+        }
+    }
+    text.push_str("\n## Human next step\n");
+    text.push_str(&human_next_step(&state));
+    text.push('\n');
+    text.push_str("\nNo mutation was performed by this report. Do not merge unless repository policy and a human maintainer approve it.\n");
+    Ok(ToolOutput::new(text)
+        .with_title(format!("handoff {}", readiness_label(&readiness)))
+        .with_metadata(json!({"watch": state, "readiness": readiness})))
+}
+
+fn format_status_report(state: &PrWatchState, readiness: &str) -> String {
+    let mut text = format!(
+        "PR watch: {}\nRepo: {}\nPR: #{}\nState: {:?}\nReadiness: {}\nQuiet cycles: {}/{}\nActionable: {}\nPending checks: {}\nFailed checks: {}\nUnresolved threads: {}\nNext poll: {}\nPolicy: local_fix={}, commit={}, push={}, comment={}, resolve_threads={}",
         state.watch_id,
         state.pr.repo,
         state.pr.number,
@@ -972,15 +1044,131 @@ fn status_like(store: &Path, params: PrWatchInput) -> Result<ToolOutput> {
         state.pending_actionable.len(),
         state.last_cycle.pending_check_count,
         state.last_cycle.failed_check_count,
+        state.baseline.unresolved_thread_ids.len(),
+        state
+            .polling
+            .next_poll_at
+            .as_deref()
+            .unwrap_or("not scheduled"),
         state.policy.local_fix,
         state.policy.commit,
         state.policy.push,
         state.policy.comment,
         state.policy.resolve_threads,
     );
-    Ok(ToolOutput::new(text)
-        .with_title(format!("{} {:?}", state.watch_id, readiness))
-        .with_metadata(json!({"watch": state, "readiness": readiness})))
+    if !state.last_successful_fetch.is_empty() {
+        text.push_str("\nLast successful fetch:");
+        for (surface, at) in &state.last_successful_fetch {
+            text.push_str(&format!("\n- {}: {}", surface, at));
+        }
+    }
+    text
+}
+
+fn readiness_label(readiness: &jcode_pr_watch_core::Readiness) -> &'static str {
+    match readiness {
+        jcode_pr_watch_core::Readiness::NotReadyActionRequired => "not_ready_action_required",
+        jcode_pr_watch_core::Readiness::NotReadyChecksPending => "not_ready_checks_pending",
+        jcode_pr_watch_core::Readiness::NotReadyChecksFailed => "not_ready_checks_failed",
+        jcode_pr_watch_core::Readiness::NotReadyValidationStale => "not_ready_validation_stale",
+        jcode_pr_watch_core::Readiness::ReadyForHumanReview => "ready_for_human_review",
+        jcode_pr_watch_core::Readiness::ReadyForHumanPush => "ready_for_human_push",
+        jcode_pr_watch_core::Readiness::ReadyForHumanMerge => "ready_for_human_merge",
+        jcode_pr_watch_core::Readiness::BlockedByPolicy => "blocked_by_policy",
+        jcode_pr_watch_core::Readiness::BlockedByClosedPr => "blocked_by_closed_pr",
+    }
+}
+
+fn readiness_reasons(state: &PrWatchState) -> Vec<String> {
+    let mut reasons = Vec::new();
+    if state.pr.state.as_deref() != Some("OPEN") && state.pr.state.is_some() {
+        reasons.push("PR is not open.".to_string());
+    }
+    if !state.pending_actionable.is_empty() {
+        reasons.push(format!(
+            "{} actionable item(s) need attention.",
+            state.pending_actionable.len()
+        ));
+    }
+    if state.last_cycle.failed_check_count > 0 {
+        reasons.push(format!(
+            "{} check(s) failed.",
+            state.last_cycle.failed_check_count
+        ));
+    }
+    if state.last_cycle.pending_check_count > 0 {
+        reasons.push(format!(
+            "{} check(s) are pending.",
+            state.last_cycle.pending_check_count
+        ));
+    }
+    if state.polling.quiet_cycles < state.polling.required_quiet_cycles {
+        reasons.push(format!(
+            "Quiet cycle requirement not yet met: {}/{}.",
+            state.polling.quiet_cycles, state.polling.required_quiet_cycles
+        ));
+    }
+    if state.last_successful_fetch.is_empty() {
+        reasons.push("No successful fetch evidence recorded yet.".to_string());
+    }
+    if reasons.is_empty() {
+        reasons.push("Required quiet cycles are satisfied and no actionable items or blocking checks are recorded.".to_string());
+    }
+    reasons
+}
+
+fn evidence_lines(state: &PrWatchState) -> Vec<String> {
+    let mut lines = Vec::new();
+    lines.push(format!(
+        "Last cycle completed: {}",
+        state
+            .last_cycle
+            .completed_at
+            .as_deref()
+            .unwrap_or("unknown")
+    ));
+    lines.push(format!(
+        "Surfaces checked: {}",
+        if state.last_cycle.surfaces_checked.is_empty() {
+            "none".to_string()
+        } else {
+            state.last_cycle.surfaces_checked.join(", ")
+        }
+    ));
+    lines.push(format!(
+        "Checks: {} pending, {} failed",
+        state.last_cycle.pending_check_count, state.last_cycle.failed_check_count
+    ));
+    lines.push(format!(
+        "Actionable items: {}",
+        state.pending_actionable.len()
+    ));
+    lines.push(format!(
+        "Unresolved review threads at baseline/latest poll: {}",
+        state.baseline.unresolved_thread_ids.len()
+    ));
+    if let Some(head) = &state.pr.head_sha {
+        lines.push(format!("Head SHA: {}", head));
+    }
+    if let Some(next) = &state.polling.next_poll_at {
+        lines.push(format!("Next scheduled poll: {}", next));
+    }
+    lines
+}
+
+fn human_next_step(state: &PrWatchState) -> String {
+    let readiness = state.readiness();
+    match readiness {
+        jcode_pr_watch_core::Readiness::ReadyForHumanMerge => format!(
+            "- Human maintainer may review repository policy and choose an approved merge strategy, for example: `gh pr merge {} --repo {} [--squash|--merge|--rebase]`",
+            state.pr.number, state.pr.repo
+        ),
+        jcode_pr_watch_core::Readiness::NotReadyActionRequired => "- Address actionable review feedback, validate locally, then run `pr_watch poll_now` again.".to_string(),
+        jcode_pr_watch_core::Readiness::NotReadyChecksPending => "- Wait for pending checks, then run `pr_watch poll_now` again.".to_string(),
+        jcode_pr_watch_core::Readiness::NotReadyChecksFailed => "- Investigate failing checks, fix locally if appropriate, then run `pr_watch poll_now` again.".to_string(),
+        jcode_pr_watch_core::Readiness::BlockedByClosedPr => "- PR is closed; stop the watcher or reopen the PR before continuing.".to_string(),
+        _ => "- Continue monitoring until quiet-cycle and validation requirements are satisfied.".to_string(),
+    }
 }
 
 fn stop_watch(store: &Path, params: PrWatchInput) -> Result<ToolOutput> {
@@ -1157,6 +1345,47 @@ mod tests {
         );
     }
 
+    #[test]
+    fn readiness_reasons_explain_actionable_items() {
+        let mut state = PrWatchState::new(PrTarget {
+            repo: "owner/repo".into(),
+            number: 14,
+        });
+        state.pending_actionable.push(ActionableItem {
+            id: "a1".into(),
+            surface: "review_threads".into(),
+            summary: "Fix thread".into(),
+            url: Some("https://thread".into()),
+            path: Some("src/lib.rs".into()),
+            status: Some("unresolved".into()),
+        });
+        let reasons = readiness_reasons(&state);
+        assert!(reasons.iter().any(|reason| reason.contains("actionable")));
+        assert!(human_next_step(&state).contains("Address actionable"));
+    }
+
+    #[test]
+    fn handoff_helpers_include_merge_template_only_when_ready() {
+        let mut state = PrWatchState::new(PrTarget {
+            repo: "owner/repo".into(),
+            number: 15,
+        });
+        state.pr.state = Some("OPEN".into());
+        state.polling.quiet_cycles = 3;
+        state.polling.required_quiet_cycles = 3;
+        state.last_cycle.completed_at = Some("2026-05-13T19:00:00Z".into());
+        let status = format_status_report(&state, "ready_for_human_merge");
+        assert!(status.contains("Next poll: not scheduled"));
+        let next = human_next_step(&state);
+        assert!(next.contains("gh pr merge 15 --repo owner/repo"));
+        assert!(next.contains("[--squash|--merge|--rebase]"));
+        let evidence = evidence_lines(&state);
+        assert!(
+            evidence
+                .iter()
+                .any(|line| line.contains("Last cycle completed"))
+        );
+    }
     #[test]
     fn schedule_fields_set_interval_and_next_poll() {
         let mut state = PrWatchState::new(PrTarget {

--- a/src/tool/pr_watch.rs
+++ b/src/tool/pr_watch.rs
@@ -1,0 +1,259 @@
+use super::{Tool, ToolContext, ToolOutput};
+use anyhow::{Context, Result, bail};
+use async_trait::async_trait;
+use jcode_pr_watch_core::{PrTarget, PrWatchState, normalize_watch_state_json};
+use serde::Deserialize;
+use serde_json::{Value, json};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+pub struct PrWatchTool;
+
+impl PrWatchTool {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum PrWatchAction {
+    Start,
+    Status,
+    List,
+    PollNow,
+    Stop,
+    Readiness,
+    Handoff,
+}
+
+#[derive(Debug, Deserialize)]
+struct PrWatchInput {
+    action: PrWatchAction,
+    repo: Option<String>,
+    pr: Option<u64>,
+    watch_id: Option<String>,
+    dry_run: Option<bool>,
+}
+
+#[async_trait]
+impl Tool for PrWatchTool {
+    fn name(&self) -> &str {
+        "pr_watch"
+    }
+
+    fn description(&self) -> &str {
+        "Read-only PR feedback watch state. Start a local watch state, list watches, show status, or compute readiness. No GitHub network calls, scheduling, pushes, comments, thread resolution, or merges are performed in this phase."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "required": ["action"],
+            "properties": {
+                "intent": super::intent_schema_property(),
+                "action": {
+                    "type": "string",
+                    "enum": ["start", "status", "list", "poll_now", "stop", "readiness", "handoff"],
+                    "description": "Action. This phase is read-only/local-state only; poll_now does not contact GitHub yet."
+                },
+                "repo": {"type": "string", "description": "Repository in owner/name form."},
+                "pr": {"type": "integer", "description": "Pull request number."},
+                "watch_id": {"type": "string", "description": "Existing watch ID, e.g. owner-repo-pr-123."},
+                "dry_run": {"type": "boolean", "description": "Preview changes without writing state."}
+            }
+        })
+    }
+
+    async fn execute(&self, input: Value, ctx: ToolContext) -> Result<ToolOutput> {
+        let params: PrWatchInput = serde_json::from_value(input)?;
+        let root = ctx
+            .working_dir
+            .clone()
+            .unwrap_or_else(|| PathBuf::from("."));
+        let store = watch_dir(&root);
+        match params.action {
+            PrWatchAction::Start => start_watch(&store, params),
+            PrWatchAction::List => list_watches(&store),
+            PrWatchAction::Status
+            | PrWatchAction::Readiness
+            | PrWatchAction::Handoff
+            | PrWatchAction::PollNow => status_like(&store, params),
+            PrWatchAction::Stop => stop_watch(&store, params),
+        }
+    }
+}
+
+fn watch_dir(root: &Path) -> PathBuf {
+    root.join(".jcode").join("pr-feedback-watch")
+}
+
+fn state_path(store: &Path, watch_id: &str) -> PathBuf {
+    store.join(format!("{watch_id}-state.json"))
+}
+
+fn target_from_params(params: &PrWatchInput) -> Result<PrTarget> {
+    let repo = params.repo.clone().context("repo is required")?;
+    let number = params.pr.context("pr is required")?;
+    Ok(PrTarget { repo, number })
+}
+
+fn start_watch(store: &Path, params: PrWatchInput) -> Result<ToolOutput> {
+    let target = target_from_params(&params)?;
+    let state = PrWatchState::new(target);
+    let path = state_path(store, &state.watch_id);
+    let would_write = !params.dry_run.unwrap_or(false);
+    if would_write {
+        fs::create_dir_all(store)?;
+        if path.exists() {
+            bail!("watch state already exists: {}", path.display());
+        }
+        fs::write(&path, serde_json::to_vec_pretty(&state)?)?;
+    }
+    Ok(ToolOutput::new(format!(
+        "PR watch initialized: {}\nPath: {}\nMode: local state only, no GitHub polling yet{}",
+        state.watch_id,
+        path.display(),
+        if would_write {
+            ""
+        } else {
+            "\nDry run: no file written"
+        }
+    ))
+    .with_title(format!("watch {}", state.watch_id))
+    .with_metadata(json!({"watch": state, "path": path, "written": would_write})))
+}
+
+fn list_watches(store: &Path) -> Result<ToolOutput> {
+    let states = load_all_states(store)?;
+    let mut lines = vec![format!("{} PR watches", states.len())];
+    for (path, state) in &states {
+        lines.push(format!(
+            "- {}: {}/#{} quiet={}/{} actionable={} status={:?} path={}",
+            state.watch_id,
+            state.pr.repo,
+            state.pr.number,
+            state.polling.quiet_cycles,
+            state.polling.required_quiet_cycles,
+            state.pending_actionable.len(),
+            state.last_cycle.status,
+            path.display()
+        ));
+    }
+    Ok(ToolOutput::new(lines.join("\n"))
+        .with_title(format!("{} watches", states.len()))
+        .with_metadata(json!({"watches": states.into_iter().map(|(_, s)| s).collect::<Vec<_>>() })))
+}
+
+fn status_like(store: &Path, params: PrWatchInput) -> Result<ToolOutput> {
+    let state = load_state_for_params(store, &params)?;
+    let readiness = state.readiness();
+    let text = format!(
+        "PR watch: {}\nRepo: {}\nPR: #{}\nState: {:?}\nReadiness: {:?}\nQuiet cycles: {}/{}\nActionable: {}\nPending checks: {}\nFailed checks: {}\nPolicy: local_fix={}, commit={}, push={}, comment={}, resolve_threads={}\nNote: poll_now is a local-state placeholder in this phase and does not contact GitHub.",
+        state.watch_id,
+        state.pr.repo,
+        state.pr.number,
+        state.last_cycle.status,
+        readiness,
+        state.polling.quiet_cycles,
+        state.polling.required_quiet_cycles,
+        state.pending_actionable.len(),
+        state.last_cycle.pending_check_count,
+        state.last_cycle.failed_check_count,
+        state.policy.local_fix,
+        state.policy.commit,
+        state.policy.push,
+        state.policy.comment,
+        state.policy.resolve_threads,
+    );
+    Ok(ToolOutput::new(text)
+        .with_title(format!("{} {:?}", state.watch_id, readiness))
+        .with_metadata(json!({"watch": state, "readiness": readiness})))
+}
+
+fn stop_watch(store: &Path, params: PrWatchInput) -> Result<ToolOutput> {
+    let mut state = load_state_for_params(store, &params)?;
+    state.terminal = true;
+    state.stop_reason = Some("stopped_by_pr_watch_tool".to_string());
+    let path = state_path(store, &state.watch_id);
+    let would_write = !params.dry_run.unwrap_or(false);
+    if would_write {
+        fs::write(&path, serde_json::to_vec_pretty(&state)?)?;
+    }
+    Ok(ToolOutput::new(format!(
+        "PR watch stopped: {}{}",
+        state.watch_id,
+        if would_write {
+            ""
+        } else {
+            "\nDry run: no file written"
+        }
+    ))
+    .with_title(format!("stopped {}", state.watch_id))
+    .with_metadata(json!({"watch": state, "written": would_write})))
+}
+
+fn load_state_for_params(store: &Path, params: &PrWatchInput) -> Result<PrWatchState> {
+    let watch_id = match &params.watch_id {
+        Some(id) => id.clone(),
+        None => target_from_params(params)?.watch_id(),
+    };
+    let path = state_path(store, &watch_id);
+    let text =
+        fs::read_to_string(&path).with_context(|| format!("failed to read {}", path.display()))?;
+    normalize_watch_state_json(&text).with_context(|| format!("failed to parse {}", path.display()))
+}
+
+fn load_all_states(store: &Path) -> Result<Vec<(PathBuf, PrWatchState)>> {
+    let mut states = Vec::new();
+    if !store.exists() {
+        return Ok(states);
+    }
+    for entry in fs::read_dir(store)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) != Some("json") {
+            continue;
+        }
+        if !path
+            .file_name()
+            .and_then(|s| s.to_str())
+            .unwrap_or("")
+            .ends_with("-state.json")
+        {
+            continue;
+        }
+        let text = fs::read_to_string(&path)?;
+        if let Ok(state) = normalize_watch_state_json(&text) {
+            states.push((path, state));
+        }
+    }
+    states.sort_by(|a, b| a.1.watch_id.cmp(&b.1.watch_id));
+    Ok(states)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn state_path_uses_watch_id() {
+        assert_eq!(
+            state_path(Path::new("/tmp/watch"), "owner-repo-pr-1"),
+            PathBuf::from("/tmp/watch/owner-repo-pr-1-state.json")
+        );
+    }
+
+    #[test]
+    fn schema_lists_read_only_actions() {
+        let schema = PrWatchTool::new().parameters_schema();
+        let actions = schema
+            .pointer("/properties/action/enum")
+            .unwrap()
+            .as_array()
+            .unwrap();
+        assert!(actions.iter().any(|value| value == "start"));
+        assert!(actions.iter().any(|value| value == "poll_now"));
+        assert!(!actions.iter().any(|value| value == "authorize"));
+    }
+}

--- a/src/tool/pr_watch.rs
+++ b/src/tool/pr_watch.rs
@@ -1,7 +1,8 @@
 use super::{Tool, ToolContext, ToolOutput};
+use crate::ambient::{AmbientManager, Priority, ScheduleRequest, ScheduleTarget};
 use anyhow::{Context, Result, bail};
 use async_trait::async_trait;
-use chrono::Utc;
+use chrono::{Duration, Utc};
 use jcode_pr_watch_core::{
     ActionableItem, CheckRunState, CycleOutcome, Marker, PrTarget, PrWatchState, SurfaceError,
     WatchEvent, normalize_watch_state_json, parse_gh_checks, parse_gh_issue_comments,
@@ -42,6 +43,12 @@ struct PrWatchInput {
     pr: Option<u64>,
     watch_id: Option<String>,
     dry_run: Option<bool>,
+    #[serde(default)]
+    schedule_next: bool,
+    #[serde(default)]
+    poll_interval_seconds: Option<u64>,
+    #[serde(default)]
+    target: Option<String>,
 }
 
 #[async_trait]
@@ -68,7 +75,10 @@ impl Tool for PrWatchTool {
                 "repo": {"type": "string", "description": "Repository in owner/name form."},
                 "pr": {"type": "integer", "description": "Pull request number."},
                 "watch_id": {"type": "string", "description": "Existing watch ID, e.g. owner-repo-pr-123."},
-                "dry_run": {"type": "boolean", "description": "Preview changes without writing state."}
+                "dry_run": {"type": "boolean", "description": "Preview changes without writing state."},
+                "schedule_next": {"type": "boolean", "description": "If true, schedule the next visible poll wakeup after start, poll_now, or ack_baseline."},
+                "poll_interval_seconds": {"type": "integer", "description": "Interval for the next scheduled poll. Defaults to state polling interval."},
+                "target": {"type": "string", "enum": ["resume", "spawn"], "description": "Schedule delivery target. Defaults to resuming the current session."}
             }
         })
     }
@@ -81,10 +91,10 @@ impl Tool for PrWatchTool {
             .unwrap_or_else(|| PathBuf::from("."));
         let store = watch_dir(&root);
         match params.action {
-            PrWatchAction::Start => start_watch(&store, params),
+            PrWatchAction::Start => start_watch(&store, params, &ctx),
             PrWatchAction::List => list_watches(&store),
-            PrWatchAction::PollNow => poll_now(&root, &store, params),
-            PrWatchAction::AckBaseline => ack_baseline(&root, &store, params),
+            PrWatchAction::PollNow => poll_now(&root, &store, params, &ctx),
+            PrWatchAction::AckBaseline => ack_baseline(&root, &store, params, &ctx),
             PrWatchAction::Status | PrWatchAction::Readiness | PrWatchAction::Handoff => {
                 status_like(&store, params)
             }
@@ -107,10 +117,12 @@ fn target_from_params(params: &PrWatchInput) -> Result<PrTarget> {
     Ok(PrTarget { repo, number })
 }
 
-fn start_watch(store: &Path, params: PrWatchInput) -> Result<ToolOutput> {
+fn start_watch(store: &Path, params: PrWatchInput, ctx: &ToolContext) -> Result<ToolOutput> {
     let target = target_from_params(&params)?;
-    let state = PrWatchState::new(target);
+    let mut state = PrWatchState::new(target);
     let path = state_path(store, &state.watch_id);
+    apply_schedule_fields(&mut state, &params);
+    let scheduled = maybe_schedule_next(ctx, &state, &params)?;
     let would_write = !params.dry_run.unwrap_or(false);
     if would_write {
         fs::create_dir_all(store)?;
@@ -120,9 +132,10 @@ fn start_watch(store: &Path, params: PrWatchInput) -> Result<ToolOutput> {
         fs::write(&path, serde_json::to_vec_pretty(&state)?)?;
     }
     Ok(ToolOutput::new(format!(
-        "PR watch initialized: {}\nPath: {}\nMode: local state initialized. Use poll_now for read-only gh collection{}",
+        "PR watch initialized: {}\nPath: {}\nMode: local state initialized. Use poll_now for read-only gh collection{}{}",
         state.watch_id,
         path.display(),
+        scheduled.as_deref().map(|s| format!("\nScheduled: {s}")).unwrap_or_default(),
         if would_write {
             ""
         } else {
@@ -154,18 +167,91 @@ fn list_watches(store: &Path) -> Result<ToolOutput> {
         .with_metadata(json!({"watches": states.into_iter().map(|(_, s)| s).collect::<Vec<_>>() })))
 }
 
-fn ack_baseline(root: &Path, store: &Path, params: PrWatchInput) -> Result<ToolOutput> {
+fn apply_schedule_fields(state: &mut PrWatchState, params: &PrWatchInput) {
+    if let Some(seconds) = params.poll_interval_seconds {
+        state.polling.poll_interval_seconds = seconds.max(60);
+    }
+    if params.schedule_next {
+        let wake_at = Utc::now() + Duration::seconds(state.polling.poll_interval_seconds as i64);
+        state.polling.next_poll_at = Some(wake_at.format("%Y-%m-%dT%H:%M:%SZ").to_string());
+    }
+}
+
+fn maybe_schedule_next(
+    ctx: &ToolContext,
+    state: &PrWatchState,
+    params: &PrWatchInput,
+) -> Result<Option<String>> {
+    if !params.schedule_next || params.dry_run.unwrap_or(false) {
+        return Ok(None);
+    }
+    let wake_at = Utc::now() + Duration::seconds(state.polling.poll_interval_seconds as i64);
+    let task = scheduled_poll_prompt(state);
+    let target = match params.target.as_deref() {
+        Some("spawn") => ScheduleTarget::Spawn {
+            parent_session_id: ctx.session_id.clone(),
+        },
+        Some("resume") | None => ScheduleTarget::Session {
+            session_id: ctx.session_id.clone(),
+        },
+        Some(other) => bail!("invalid schedule target {other}; expected resume or spawn"),
+    };
+    let mut manager = AmbientManager::new()?;
+    let id = manager.schedule(ScheduleRequest {
+        wake_in_minutes: None,
+        wake_at: Some(wake_at),
+        context: task.clone(),
+        priority: Priority::Normal,
+        target,
+        created_by_session: ctx.session_id.clone(),
+        working_dir: ctx
+            .working_dir
+            .as_ref()
+            .map(|path| path.display().to_string()),
+        task_description: Some(task),
+        relevant_files: vec![format!(
+            ".jcode/pr-feedback-watch/{}-state.json",
+            state.watch_id
+        )],
+        git_branch: None,
+        additional_context: Some(
+            "Scheduled by pr_watch schedule_next; read-only poll only.".to_string(),
+        ),
+    })?;
+    super::ambient::nudge_schedule_runner();
+    Ok(Some(format!(
+        "{} at {}",
+        id,
+        wake_at.format("%Y-%m-%dT%H:%M:%SZ")
+    )))
+}
+
+fn scheduled_poll_prompt(state: &PrWatchState) -> String {
+    format!(
+        "Run the next read-only PR watch poll for {}. Use pr_watch with action=poll_now, repo={}, pr={}, watch_id={}, schedule_next=true. Do not push, comment, resolve threads, or merge.",
+        state.watch_id, state.pr.repo, state.pr.number, state.watch_id
+    )
+}
+
+fn ack_baseline(
+    root: &Path,
+    store: &Path,
+    params: PrWatchInput,
+    ctx: &ToolContext,
+) -> Result<ToolOutput> {
     let mut state = load_state_for_params(store, &params)?;
     let path = state_path(store, &state.watch_id);
     let collected_at = now_iso();
     let collection = collect_with_gh(root, &state.pr.repo, state.pr.number);
     let partial_failure = apply_baseline_from_collection(&mut state, collection, &collected_at);
+    apply_schedule_fields(&mut state, &params);
+    let scheduled = maybe_schedule_next(ctx, &state, &params)?;
     let would_write = !params.dry_run.unwrap_or(false);
     if would_write {
         fs::write(&path, serde_json::to_vec_pretty(&state)?)?;
     }
     let text = format!(
-        "PR watch baseline acknowledged: {}\nRepo: {}\nPR: #{}\nUnresolved threads: {}\nReview comments seen: {}\nIssue comments seen: {}\nReviews seen: {}\nPartial failure: {}{}",
+        "PR watch baseline acknowledged: {}\nRepo: {}\nPR: #{}\nUnresolved threads: {}\nReview comments seen: {}\nIssue comments seen: {}\nReviews seen: {}\nPartial failure: {}{}{}",
         state.watch_id,
         state.pr.repo,
         state.pr.number,
@@ -174,6 +260,10 @@ fn ack_baseline(root: &Path, store: &Path, params: PrWatchInput) -> Result<ToolO
         state.last_seen.issue_comments.len(),
         state.last_seen.reviews.len(),
         partial_failure,
+        scheduled
+            .as_deref()
+            .map(|s| format!("\nScheduled: {s}"))
+            .unwrap_or_default(),
         if would_write {
             ""
         } else {
@@ -383,19 +473,26 @@ fn apply_baseline_from_collection(
     partial_failure
 }
 
-fn poll_now(root: &Path, store: &Path, params: PrWatchInput) -> Result<ToolOutput> {
+fn poll_now(
+    root: &Path,
+    store: &Path,
+    params: PrWatchInput,
+    ctx: &ToolContext,
+) -> Result<ToolOutput> {
     let mut state = load_state_for_params(store, &params)?;
     let path = state_path(store, &state.watch_id);
     let collected_at = now_iso();
     let result = collect_with_gh(root, &state.pr.repo, state.pr.number);
     let outcome = update_state_from_collection(&mut state, result, &collected_at);
+    apply_schedule_fields(&mut state, &params);
+    let scheduled = maybe_schedule_next(ctx, &state, &params)?;
     let would_write = !params.dry_run.unwrap_or(false);
     if would_write {
         fs::write(&path, serde_json::to_vec_pretty(&state)?)?;
     }
     let readiness = state.readiness();
     let text = format!(
-        "PR watch polled: {}\nRepo: {}\nPR: #{}\nState: {:?}\nReadiness: {:?}\nQuiet cycles: {}/{}\nActionable: {}\nPending checks: {}\nFailed checks: {}\nPartial failure: {}\nFailed surfaces: {}{}",
+        "PR watch polled: {}\nRepo: {}\nPR: #{}\nState: {:?}\nReadiness: {:?}\nQuiet cycles: {}/{}\nActionable: {}\nPending checks: {}\nFailed checks: {}\nPartial failure: {}\nFailed surfaces: {}{}{}",
         state.watch_id,
         state.pr.repo,
         state.pr.number,
@@ -408,6 +505,10 @@ fn poll_now(root: &Path, store: &Path, params: PrWatchInput) -> Result<ToolOutpu
         state.last_cycle.failed_check_count,
         outcome.partial_failure,
         failed_surface_names(&state).join(", "),
+        scheduled
+            .as_deref()
+            .map(|s| format!("\nScheduled: {s}"))
+            .unwrap_or_default(),
         if would_write {
             ""
         } else {
@@ -1056,6 +1157,40 @@ mod tests {
         );
     }
 
+    #[test]
+    fn schedule_fields_set_interval_and_next_poll() {
+        let mut state = PrWatchState::new(PrTarget {
+            repo: "owner/repo".into(),
+            number: 12,
+        });
+        let params = PrWatchInput {
+            action: PrWatchAction::PollNow,
+            repo: None,
+            pr: None,
+            watch_id: Some(state.watch_id.clone()),
+            dry_run: Some(true),
+            schedule_next: true,
+            poll_interval_seconds: Some(1),
+            target: None,
+        };
+        apply_schedule_fields(&mut state, &params);
+        assert_eq!(state.polling.poll_interval_seconds, 60);
+        assert!(state.polling.next_poll_at.is_some());
+    }
+
+    #[test]
+    fn scheduled_prompt_is_read_only_and_specific() {
+        let state = PrWatchState::new(PrTarget {
+            repo: "owner/repo".into(),
+            number: 13,
+        });
+        let prompt = scheduled_poll_prompt(&state);
+        assert!(prompt.contains("action=poll_now"));
+        assert!(prompt.contains("repo=owner/repo"));
+        assert!(prompt.contains("pr=13"));
+        assert!(prompt.contains("Do not push"));
+        assert!(prompt.contains("merge"));
+    }
     #[test]
     fn ack_baseline_marks_current_feedback_seen_without_actionable() {
         let mut state = PrWatchState::new(PrTarget {


### PR DESCRIPTION
## Summary

This PR introduces native PR feedback watch support for Jcode, based on the biz-agents and concierge-app PR-watch workflows.

It includes:

- Architecture docs for first-class PR feedback watching and Claude review disposition.
- New `jcode-pr-watch-core` crate with schema v2, v1 normalization, authorization envelopes, typed markers, bounded events, quiet-cycle/readiness logic, and `gh` JSON parsers.
- New `pr_watch` tool for local watch state, read-only GitHub polling, baseline acknowledgement, recurring scheduled follow-up polls, readiness, and handoff reports.
- Read-only `gh` collection for PR metadata, checks, review comments, issue comments, reviews, and review threads.
- Baseline acknowledgement so existing feedback can be marked seen before subsequent watch cycles.
- Human-readable status/readiness/handoff reports with explicit non-mutation guardrails.

## Safety / Mutation Boundaries

- No merge authorization is stored or exposed.
- No push/comment/thread-resolution behavior is implemented.
- `poll_now` only runs read-only `gh` commands and updates local `.jcode/pr-feedback-watch/*-state.json` state.
- Scheduled follow-ups are visible session/spawn wakeups, not hidden long-running loops.

## Validation

Ran during implementation:

- `cargo test -p jcode-pr-watch-core` passed, 13 tests.
- `cargo test -p jcode pr_watch --lib` passed, 11 tests.
- `cargo check -p jcode --bin jcode` passed.

## Notes

This branch also includes three pre-existing local commits ahead of `origin/master` before the PR-watch work:

- `e1d85511 Harden overnight validation status parsing`
- `89f24f1b Fix initial session context workspace refresh`
- `0fb8674c Harden scheduled task delivery retries`

The PR-watch-specific sequence starts at `dad9bdc4 docs: plan native PR feedback watch`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/1jehuang/codesmith/jcode/pr/208"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->