### PR TITLE
Satisfy latest CI guardrails

### DIFF
--- a/crates/jcode-compaction-core/src/lib.rs
+++ b/crates/jcode-compaction-core/src/lib.rs
@@ -216,10 +216,10 @@ pub fn safe_compaction_cutoff(messages: &[Message], initial_cutoff: usize) -> us
                     available_tool_ids.insert(id.clone());
                     missing_tool_ids.remove(id);
                 }
-                ContentBlock::ToolResult { tool_use_id, .. } => {
-                    if !available_tool_ids.contains(tool_use_id) {
-                        missing_tool_ids.insert(tool_use_id.clone());
-                    }
+                ContentBlock::ToolResult { tool_use_id, .. }
+                    if !available_tool_ids.contains(tool_use_id) =>
+                {
+                    missing_tool_ids.insert(tool_use_id.clone());
                 }
                 _ => {}
             }
@@ -239,10 +239,10 @@ pub fn safe_compaction_cutoff(messages: &[Message], initial_cutoff: usize) -> us
                     available_tool_ids.insert(id.clone());
                     missing_tool_ids.remove(id);
                 }
-                ContentBlock::ToolResult { tool_use_id, .. } => {
-                    if !available_tool_ids.contains(tool_use_id) {
-                        missing_tool_ids.insert(tool_use_id.clone());
-                    }
+                ContentBlock::ToolResult { tool_use_id, .. }
+                    if !available_tool_ids.contains(tool_use_id) =>
+                {
+                    missing_tool_ids.insert(tool_use_id.clone());
                 }
                 _ => {}
             }

--- a/crates/jcode-import-core/src/lib.rs
+++ b/crates/jcode-import-core/src/lib.rs
@@ -359,10 +359,8 @@ pub fn parse_rfc3339_json(value: Option<&serde_json::Value>) -> Option<DateTime<
 pub fn extract_external_text_from_json(value: &serde_json::Value, include_tools: bool) -> String {
     fn visit(value: &serde_json::Value, include_tools: bool, out: &mut Vec<String>) {
         match value {
-            serde_json::Value::String(text) => {
-                if !text.trim().is_empty() {
-                    out.push(text.trim().to_string());
-                }
+            serde_json::Value::String(text) if !text.trim().is_empty() => {
+                out.push(text.trim().to_string());
             }
             serde_json::Value::Array(items) => {
                 for item in items {
@@ -789,10 +787,8 @@ fn truncate_title_text(text: &str, max_chars: usize) -> String {
 pub fn extract_text_from_json_value(value: &serde_json::Value) -> String {
     fn visit(value: &serde_json::Value, out: &mut Vec<String>) {
         match value {
-            serde_json::Value::String(text) => {
-                if !text.trim().is_empty() {
-                    out.push(text.trim().to_string());
-                }
+            serde_json::Value::String(text) if !text.trim().is_empty() => {
+                out.push(text.trim().to_string());
             }
             serde_json::Value::Array(items) => {
                 for item in items {

--- a/crates/jcode-tui-mermaid/src/mermaid_viewport.rs
+++ b/crates/jcode-tui-mermaid/src/mermaid_viewport.rs
@@ -87,11 +87,10 @@ fn kitty_scaled_image_for_zoom(source: &DynamicImage, zoom_percent: u8) -> Dynam
 }
 
 fn div_ceil_u32_local(value: u32, divisor: u32) -> u32 {
-    if divisor == 0 {
-        value
-    } else {
-        value.saturating_add(divisor - 1) / divisor
-    }
+    value
+        .saturating_add(divisor.saturating_sub(1))
+        .checked_div(divisor)
+        .unwrap_or(value)
 }
 
 fn kitty_full_rect_for_image(img: &DynamicImage, font_size: (u16, u16)) -> (u16, u16) {

--- a/src/auth/lifecycle.rs
+++ b/src/auth/lifecycle.rs
@@ -324,15 +324,15 @@ fn apply_auth_provider_runtime(provider_id: Option<&str>) -> Option<String> {
             }
         }
         Some(provider_id) => {
-            if let Some(activation) = direct_provider_activation(provider_id) {
-                if let Err(error) = activation.apply_env() {
-                    let message = error.to_string();
-                    crate::logging::auth_event(
-                        "auth_changed_runtime_activation_failed",
-                        provider_id,
-                        &[("reason", message.as_str())],
-                    );
-                }
+            if let Some(activation) = direct_provider_activation(provider_id)
+                && let Err(error) = activation.apply_env()
+            {
+                let message = error.to_string();
+                crate::logging::auth_event(
+                    "auth_changed_runtime_activation_failed",
+                    provider_id,
+                    &[("reason", message.as_str())],
+                );
             }
             None
         }

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -707,12 +707,10 @@ impl MultiProvider {
         if let Some(pref) = default_provider.and_then(|pref| {
             let trimmed = pref.trim();
             (!trimmed.is_empty()).then_some(trimmed)
-        }) {
-            if let Some(selection) =
-                Self::resolve_config_provider_selection(pref, crate::config::config())
-            {
-                return self.set_model_on_provider(selection.active_provider(), model);
-            }
+        }) && let Some(selection) =
+            Self::resolve_config_provider_selection(pref, crate::config::config())
+        {
+            return self.set_model_on_provider(selection.active_provider(), model);
         }
 
         self.set_model(model)

--- a/src/server/provider_control.rs
+++ b/src/server/provider_control.rs
@@ -533,6 +533,7 @@ pub(super) async fn handle_set_compaction_mode(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(super) async fn handle_notify_auth_changed(
     id: u64,
     provider_hint: Option<String>,

--- a/src/server/provider_control_tests.rs
+++ b/src/server/provider_control_tests.rs
@@ -921,11 +921,11 @@ async fn auth_model_first_prompt_e2e_state_space_is_bounded_by_selection_source(
             loop {
                 match client_event_rx.recv().await {
                     Some(ServerEvent::ModelChanged {
-                        id,
+                        id: 248,
                         model: changed,
                         error,
                         ..
-                    }) if id == 248 => {
+                    }) => {
                         assert_eq!(error, None, "{}: manual model switch failed", scenario.name);
                         assert_eq!(
                             changed, model,


### PR DESCRIPTION
This PR was originally used for issue #201 validation, but the Windows browser setup fixes are now already on `master`:

- d4fda75 Require Firefox bridge host asset during setup
- a68185c Use file URLs for browser extension install
- 719b4a5 Always refresh Windows native host registry
- 95db8ae Repair browser setup when native host is missing

After rebasing on current `master`, this PR only carries unrelated CI guardrail cleanup for newer rustfmt/clippy behavior. It is no longer required to close #201.
