### PR TITLE
feat: add Telegram bridge for direct message integration

### DIFF
--- a/scripts/telegram-bridge/.env.example
+++ b/scripts/telegram-bridge/.env.example
@@ -1,0 +1,15 @@
+# Telegram Bot Token (get from https://t.me/botfather)
+TELEGRAM_BOT_TOKEN=your_bot_token_here
+
+# Jcode debug socket path (auto-detected if left empty)
+# Typically:
+#   /run/user/1000/jcode-debug.sock  (systemd user session)
+#   /tmp/jcode-debug.sock             (manual socket)
+JCODE_DEBUG_SOCKET=
+
+# Data directory (default: ~/.jcode/telegram)
+TELEGRAM_DATA_DIR=
+
+# Poll intervals (seconds)
+RESPONSE_POLL_INTERVAL=1.5
+RESPONSE_TIMEOUT=120

--- a/scripts/telegram-bridge/README.md
+++ b/scripts/telegram-bridge/README.md
@@ -1,0 +1,86 @@
+# Telegram Bridge — Connect Jcode to Telegram
+
+This directory provides a bridge between Jcode and Telegram, allowing users to message a Jcode instance directly via a Telegram bot.
+
+## Architecture
+
+```
+Telegram user → Bot API → Bridge polls getUpdates → Injects into Jcode debug socket → Jcode responds naturally → Bridge polls last_response → Sends back to Telegram
+```
+
+- **Zero dependencies** — pure Python stdlib
+- **No webhooks needed** — simple long-polling
+- **Direct session injection** — messages appear in Jcode's terminal as `📩 *Telegram from X*: ...`
+- **Auto .env loading** — bridge reads config from `~/.jcode/telegram/.env` on startup
+
+## Quick Start
+
+```bash
+# Install
+bash <(curl -s https://raw.githubusercontent.com/LAG-Yadav/jcode-telegram-bridge/main/install.sh)
+
+# Or after cloning the jcode repo:
+cp -r scripts/telegram-bridge ~/.jcode/telegram
+
+# Configure
+nano ~/.jcode/telegram/.env
+# Set: TELEGRAM_BOT_TOKEN=your_token_here
+
+# Start
+tgstart
+```
+
+## Prerequisites
+
+1. **Jcode** with `debug_socket` enabled in `~/.jcode/config.toml`:
+   ```toml
+   [display]
+   debug_socket = true
+   ```
+2. A **Telegram bot token** from [@BotFather](https://t.me/botfather)
+3. **Python 3** (stdlib only — no pip packages needed)
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `bridge.py` | Main daemon — polls Telegram, injects into Jcode, watches for responses |
+| `.env.example` | Configuration template |
+| `bin/tgstart` | Start the bridge daemon |
+| `bin/tgstatus` | Check bridge status and message counts |
+| `bin/tgread` | Read recent Telegram messages from terminal |
+| `bin/tgsend` | Send a message to a Telegram chat via debug socket |
+
+## System Prompt
+
+Add this to your Jcode system prompt so the AI knows about the bridge:
+
+```markdown
+## Telegram Bridge
+
+I have a Telegram bridge running. Messages from Telegram users appear 
+in my terminal as: `📩 *Telegram from {name}*: {message}`
+
+When I see one of these, I should:
+1. Understand it's a user sending me a message via Telegram
+2. Respond naturally to their query/request
+3. My response will automatically be sent back to them via the bridge
+
+The bridge handles delivery automatically — I just need to reply normally.
+Messages from Telegram users are real requests that need my attention.
+```
+
+## Design Decisions
+
+- **Polling over webhooks**: Webhooks require a public HTTPS endpoint. Polling works anywhere Jcode runs (laptop, VPS, headless server).
+- **Debug socket injection**: Rather than spawning a subprocess or using Jcode's CLI, we inject directly into the running session. This preserves context and allows natural multi-turn conversations.
+- **File-based persistence**: Inbox and sent logs are stored as JSONL files, surviving restarts.
+- **HTML entity -> Markdown conversion**: Jcode's responses use Markdown formatting. The bridge converts it to Telegram's HTML subset for proper rendering.
+
+## Troubleshooting
+
+**"Socket not found"**: Make sure Jcode is running with `debug_socket = true` in config.
+
+**"TELEGRAM_BOT_TOKEN not set"**: Create `~/.jcode/telegram/.env` with your token, or export it as an environment variable.
+
+**"Can't parse entities"**: The bridge now automatically converts Markdown to Telegram HTML, so bold, italic, code blocks, and links should render correctly.

--- a/scripts/telegram-bridge/bin/tgread
+++ b/scripts/telegram-bridge/bin/tgread
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+"""tgread - Read recent Telegram messages from the bridge inbox."""
+import json, os, sys
+from datetime import datetime
+
+INBOX = os.path.expanduser("~/.jcode/telegram/inbox.jsonl")
+LINES = int(sys.argv[1]) if len(sys.argv) > 1 else 10
+
+if not os.path.exists(INBOX):
+    print("No messages yet (inbox doesn't exist)")
+    sys.exit(0)
+
+with open(INBOX) as f:
+    messages = [json.loads(line) for line in f if line.strip()]
+
+if not messages:
+    print("No messages yet")
+    sys.exit(0)
+
+show = messages[-LINES:]
+print(f"=== Last {len(show)} of {len(messages)} Telegram messages ===\n")
+for m in show:
+    ts = datetime.fromtimestamp(m.get("timestamp", 0)).strftime("%H:%M:%S")
+    name = m.get("first_name", "") or m.get("username", "") or str(m.get("user_id", ""))
+    text = m.get("text", "") or "(non-text)"
+    print(f"[{ts}] {name}: {text}")

--- a/scripts/telegram-bridge/bin/tgsend
+++ b/scripts/telegram-bridge/bin/tgsend
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""tgsend - Send a message to a Telegram user via the bridge.
+
+Usage from terminal:
+  tgsend <chat_id> Your message here
+
+Usage from Jcode (via debug socket):
+  echo '{"chat_id": 12345, "text": "hello"}' | tgsend
+"""
+import json, os, sys, time, socket
+
+def find_socket():
+    env = os.environ.get("JCODE_DEBUG_SOCKET", "")
+    if env and os.path.exists(env):
+        return env
+    for c in ["/run/user/1000/jcode-debug.sock",
+              os.path.expanduser("~/.jcode/debug.sock"),
+              "/tmp/jcode-debug.sock"]:
+        if os.path.exists(c):
+            return c
+    return None
+
+def inject_msg(text):
+    """Inject a message into Jcode via debug socket, which triggers a bridge response."""
+    sock = find_socket()
+    if not sock:
+        print("❌ Jcode socket not found")
+        sys.exit(1)
+    
+    cmd = f"client:message:📤 {text}"
+    
+    s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    s.settimeout(5)
+    try:
+        s.connect(sock)
+        msg = json.dumps({"type": "debug_command", "id": int(time.time()*1000), "command": cmd}) + "\n"
+        s.sendall(msg.encode())
+        time.sleep(0.2)
+        data = b""
+        s.settimeout(3)
+        try:
+            while True:
+                chunk = s.recv(8192)
+                if not chunk: break
+                data += chunk
+        except socket.timeout:
+            pass
+        print(f"✅ Sent to Telegram via Jcode: {text[:50]}...")
+    except Exception as e:
+        print(f"❌ Error: {e}")
+        sys.exit(1)
+    finally:
+        s.close()
+
+if __name__ == "__main__":
+    # Support piped JSON: {"chat_id": 123, "text": "hello"}
+    if not sys.stdin.isatty():
+        try:
+            piped = sys.stdin.read().strip()
+            if piped:
+                data = json.loads(piped)
+                chat_id = data.get("chat_id", "")
+                text = data.get("text", "")
+                if chat_id and text:
+                    inject_msg(f"[to {chat_id}] {text}")
+                    sys.exit(0)
+        except:
+            pass
+    
+    # CLI mode
+    if len(sys.argv) < 3:
+        print("Usage: tgsend <chat_id> <message>")
+        sys.exit(1)
+    
+    chat_id = sys.argv[1]
+    text = " ".join(sys.argv[2:])
+    inject_msg(f"[to {chat_id}] {text}")

--- a/scripts/telegram-bridge/bin/tgstart
+++ b/scripts/telegram-bridge/bin/tgstart
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""tgstart - Start the Jcode Telegram Bridge daemon."""
+import os, sys, signal
+
+DIR = os.path.expanduser("~/.jcode/telegram")
+PID_FILE = os.path.join(DIR, "bridge.pid")
+LOG_FILE = os.path.join(DIR, "bridge.log")
+BRIDGE_SCRIPT = os.path.join(DIR, "bridge.py")
+
+os.makedirs(DIR, exist_ok=True)
+
+# Check if already running
+if os.path.exists(PID_FILE):
+    pid = open(PID_FILE).read().strip()
+    try:
+        os.kill(int(pid), 0)
+        print(f"Bridge already running (PID {pid})")
+        sys.exit(0)
+    except:
+        os.remove(PID_FILE)
+
+# Check if bridge.py exists in data dir or in same dir as this script
+if not os.path.exists(BRIDGE_SCRIPT):
+    # Try same directory
+    same_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "bridge.py")
+    if os.path.exists(same_dir):
+        BRIDGE_SCRIPT = os.path.abspath(same_dir)
+    else:
+        print("❌ bridge.py not found. Install the bridge first.")
+        print("   See: https://github.com/LAG-Yadav/jcode-telegram-bridge")
+        sys.exit(1)
+
+import subprocess
+proc = subprocess.Popen(
+    ["python3", "-u", BRIDGE_SCRIPT],
+    stdout=open(LOG_FILE, "a"),
+    stderr=subprocess.STDOUT,
+    env={**os.environ},
+    start_new_session=True
+)
+
+with open(PID_FILE, "w") as f:
+    f.write(str(proc.pid))
+
+print(f"✅ Bridge started (PID {proc.pid})")
+print(f"   Log: {LOG_FILE}")
+print(f"   Stop: kill {proc.pid}")

--- a/scripts/telegram-bridge/bin/tgstatus
+++ b/scripts/telegram-bridge/bin/tgstatus
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""tgstatus - Check if the Jcode Telegram Bridge is running."""
+import json, os, sys
+from datetime import datetime
+
+DIR = os.path.expanduser("~/.jcode/telegram")
+PID_FILE = os.path.join(DIR, "bridge.pid")
+LOG_FILE = os.path.join(DIR, "bridge.log")
+INBOX_FILE = os.path.join(DIR, "inbox.jsonl")
+SENT_FILE = os.path.join(DIR, "sent.jsonl")
+
+if os.path.exists(PID_FILE):
+    pid = open(PID_FILE).read().strip()
+    try:
+        os.kill(int(pid), 0)
+        print(f"✅ Bridge RUNNING (PID {pid})")
+    except:
+        print(f"❌ Bridge NOT running (stale PID {pid})")
+else:
+    print("❌ Bridge NOT running")
+
+# Message counts
+if os.path.exists(INBOX_FILE):
+    count = sum(1 for _ in open(INBOX_FILE))
+    print(f"📩 Messages received: {count}")
+if os.path.exists(SENT_FILE):
+    count = sum(1 for _ in open(SENT_FILE))
+    print(f"📤 Messages sent: {count}")
+
+# Last log line
+if os.path.exists(LOG_FILE):
+    lines = open(LOG_FILE).read().strip().split("\n")
+    if lines:
+        print(f"📋 Last log: {lines[-1][:100]}")

--- a/scripts/telegram-bridge/bridge.py
+++ b/scripts/telegram-bridge/bridge.py
@@ -287,13 +287,10 @@ def handle_message(user_name, text, chat_id):
         _active_chats.add(chat_id)
         before = _last_seen_response
     
-    # Send instant acknowledgment
-    send_message(chat_id, f"📩 Message received from <b>{user_name}</b> — Jcode is processing it now. Responses will appear here automatically.")
-    
-    # Inject into Jcode
+    # Inject into Jcode (no ack — responses auto-send via watcher)
     inject_into_jcode(user_name, text)
     
-    log(f"✅ Acknowledged to {chat_id}, watching for responses...")
+    log(f"✅ Registered {chat_id} for auto-delivery")
 
 # ─── OFFSET PERSISTENCE ──────────────────────────────────────
 

--- a/scripts/telegram-bridge/bridge.py
+++ b/scripts/telegram-bridge/bridge.py
@@ -1,0 +1,391 @@
+#!/usr/bin/env python3
+"""
+jcode-telegram-bridge — Connect Telegram directly into your Jcode session.
+
+Architecture:
+  Telegram user → Bot API → Bridge injects into Jcode debug socket →
+  Jcode responds naturally → Bridge polls last_response → Sends back to Telegram
+
+No subprocess spawning. No separate AI provider config. Just straight into your session.
+"""
+import json, os, sys, time, socket, threading, urllib.request, urllib.error, re
+
+sys.stdout.reconfigure(line_buffering=True)
+sys.stderr.reconfigure(line_buffering=True)
+
+# ─── AUTO-LOAD .env if present in data dir or script dir ───
+_script_dir = os.path.dirname(os.path.abspath(__file__))
+for _env_dir in (_script_dir, os.path.expanduser("~/.jcode/telegram")):
+    _env_path = os.path.join(_env_dir, ".env")
+    if os.path.exists(_env_path):
+        with open(_env_path) as _f:
+            for _line in _f:
+                _line = _line.strip()
+                if not _line or _line.startswith("#"):
+                    continue
+                if "=" in _line:
+                    _k, _v = _line.split("=", 1)
+                    os.environ.setdefault(_k.strip(), _v.strip())
+
+# ─── CONFIG (from environment) ───────────────────────────────
+BOT_TOKEN = os.environ.get("TELEGRAM_BOT_TOKEN", "")
+if not BOT_TOKEN:
+    print("❌ TELEGRAM_BOT_TOKEN not set. Create a .env file or export it.", flush=True)
+    sys.exit(1)
+
+JCODE_SOCKET = os.environ.get(
+    "JCODE_DEBUG_SOCKET",
+    os.path.expanduser("~/.jcode/debug.sock")  # fallback path
+)
+# Auto-detect common socket locations if not set
+if not os.environ.get("JCODE_DEBUG_SOCKET"):
+    for candidate in [
+        "/run/user/1000/jcode-debug.sock",
+        os.path.expanduser("~/.jcode/debug.sock"),
+        "/tmp/jcode-debug.sock",
+    ]:
+        if os.path.exists(candidate):
+            JCODE_SOCKET = candidate
+            break
+
+DATA_DIR = os.environ.get("TELEGRAM_DATA_DIR", os.path.expanduser("~/.jcode/telegram"))
+BASE_URL = f"https://api.telegram.org/bot{BOT_TOKEN}"
+OFFSET_FILE = os.path.join(DATA_DIR, "offset.json")
+INBOX_FILE = os.path.join(DATA_DIR, "inbox.jsonl")
+SENT_FILE = os.path.join(DATA_DIR, "sent.jsonl")
+
+POLL_INTERVAL = float(os.environ.get("RESPONSE_POLL_INTERVAL", "1.5"))
+
+os.makedirs(DATA_DIR, exist_ok=True)
+
+# ─── STATE ───────────────────────────────────────────────────
+_last_known_response = None
+_response_lock = threading.Lock()
+
+def log(msg):
+    print(f"[{time.strftime('%H:%M:%S')}] {msg}", flush=True)
+
+# ─── TELEGRAM API ─────────────────────────────────────────────
+
+def tg_api(method, data=None, timeout=15):
+    url = f"{BASE_URL}/{method}"
+    body = json.dumps(data, ensure_ascii=False).encode('utf-8') if data else None
+    headers = {"Content-Type": "application/json"} if data else {}
+    try:
+        req = urllib.request.Request(url, data=body, headers=headers)
+        with urllib.request.urlopen(req, timeout=timeout) as r:
+            return json.loads(r.read())
+    except urllib.error.HTTPError as e:
+        try: return json.loads(e.read())
+        except: return {"ok": False, "description": f"HTTP {e.code}"}
+    except Exception as e:
+        return {"ok": False, "description": str(e)}
+
+def html_escape(text):
+    """Escape HTML entities so Telegram's HTML parser doesn't choke."""
+    return (
+        text.replace("&", "&amp;")
+            .replace("<", "&lt;")
+            .replace(">", "&gt;")
+            .replace('"', "&quot;")
+    )
+
+def markdown_to_telegram_html(text):
+    """Convert Markdown formatting to Telegram's supported HTML subset.
+    
+    Telegram HTML supports: <b>, <i>, <code>, <pre>, <a href="">
+    We convert common markdown patterns to these tags.
+    """
+    # Must escape HTML entities first (before adding tags)
+    text = html_escape(text)
+    
+    # Bold: **text** or __text__
+    text = re.sub(r'\*\*(.+?)\*\*', r'<b>\1</b>', text)
+    text = re.sub(r'(?<!/)__(.+?)__(?!/)', r'<b>\1</b>', text)
+    
+    # Italic: *text* or _text_ (but not inside words with underscores)
+    text = re.sub(r'(?<!\*)\*(?!\*)(.+?)(?<!\*)\*(?!\*)', r'<i>\1</i>', text)
+    # Single underscores for italic (word boundaries to avoid snake_case)
+    text = re.sub(r'(?<!\w)_(?!_)(.+?)(?<!\w)_(?!_)', r'<i>\1</i>', text)
+    
+    # Inline code: `text`
+    text = re.sub(r'`(.+?)`', r'<code>\1</code>', text)
+    
+    # Code block: ```text``` or ```language\ntext```
+    text = re.sub(r'```(?:\w+)?\n?(.+?)```', r'<pre>\1</pre>', text, flags=re.DOTALL)
+    
+    # Links: [text](url)
+    text = re.sub(r'\[(.+?)\]\((https?://[^\s)]+)\)', r'<a href="\2">\1</a>', text)
+    
+    # Headers: ### text -> <b>text</b>
+    text = re.sub(r'^#{1,6}\s+(.+?)$', r'<b>\1</b>', text, flags=re.MULTILINE)
+    
+    # List items: - text or * text -> • text
+    text = re.sub(r'^[\s]*[-*]\s+(.+?)$', r'• \1', text, flags=re.MULTILINE)
+    
+    # Numbered lists: 1. text -> just keep as-is
+    text = re.sub(r'^(\s*\d+\.\s+.+?)$', r'\1', text, flags=re.MULTILINE)
+    
+    return text.strip()
+
+def send_message(chat_id, text, parse_mode="HTML"):
+    # Convert Markdown formatting to Telegram-compatible HTML
+    safe_text = markdown_to_telegram_html(text)
+    r = tg_api("sendMessage", {"chat_id": chat_id, "text": safe_text, "parse_mode": parse_mode})
+    if r.get("ok"):
+        with open(SENT_FILE, "a") as f:
+            f.write(json.dumps({
+                "chat_id": chat_id,
+                "message_id": r["result"]["message_id"],
+                "text": text[:80],
+                "time": time.time()
+            }) + "\n")
+        log(f"✅ Sent to chat {chat_id}")
+        return True
+    else:
+        # Fallback: try plain text if HTML fails
+        log(f"⚠️ HTML failed ({r.get('description','')}), retrying as plain text...")
+        r2 = tg_api("sendMessage", {"chat_id": chat_id, "text": text})
+        if r2.get("ok"):
+            with open(SENT_FILE, "a") as f:
+                f.write(json.dumps({
+                    "chat_id": chat_id,
+                    "message_id": r2["result"]["message_id"],
+                    "text": text[:80],
+                    "time": time.time()
+                }) + "\n")
+            log(f"✅ Sent (plain text) to chat {chat_id}")
+            return True
+        log(f"❌ Send failed: {r2.get('description','')}")
+        return False
+
+def send_typing(chat_id):
+    tg_api("sendChatAction", {"chat_id": chat_id, "action": "typing"})
+
+def tg_poll(offset, timeout_sec=30):
+    """Long-poll Telegram for updates."""
+    return tg_api("getUpdates", {
+        "offset": offset,
+        "timeout": timeout_sec,
+        "allowed_updates": ["message"]
+    }, timeout=timeout_sec + 5)
+
+# ─── JCODE DEBUG SOCKET ──────────────────────────────────────
+
+def jcode_cmd(command, timeout_sec=5):
+    """Send a debug command to the Jcode server via Unix socket."""
+    if not os.path.exists(JCODE_SOCKET):
+        return f'{{"ok": false, "output": "Socket not found: {JCODE_SOCKET}"}}'
+    
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    sock.settimeout(timeout_sec)
+    try:
+        sock.connect(JCODE_SOCKET)
+        msg = json.dumps({
+            "type": "debug_command",
+            "id": int(time.time() * 1000),
+            "command": command
+        }) + "\n"
+        sock.sendall(msg.encode())
+        time.sleep(0.3)
+        data = b""
+        sock.settimeout(timeout_sec)
+        try:
+            while True:
+                chunk = sock.recv(8192)
+                if not chunk: break
+                data += chunk
+        except socket.timeout:
+            pass
+        return data.decode()
+    except ConnectionRefusedError:
+        return '{"ok": false, "output": "Connection refused"}'
+    except Exception as e:
+        return f'{{"ok": false, "output": "Error: {e}"}}'
+    finally:
+        sock.close()
+
+def inject_into_jcode(user_name, text):
+    """Inject a Telegram message into the Jcode session."""
+    safe_text = text.replace("\n", " ").replace("\r", "")
+    message = f"📩 *Telegram from {user_name}*: {safe_text}"
+    result = jcode_cmd(f"client:message:{message}")
+    log(f"📨 Injected: {safe_text[:60]}...")
+    return result
+
+def get_last_response():
+    """Get the last assistant response from the Jcode session."""
+    result = jcode_cmd("last_response", timeout_sec=3)
+    try:
+        data = json.loads(result)
+        if data.get("ok") and data.get("output"):
+            output = data["output"].strip()
+            # Remove JSON wrapping if present
+            if output.startswith('"') and output.endswith('"'):
+                output = json.loads(output)
+            return output
+    except (json.JSONDecodeError, KeyError):
+        pass
+    # Raw fallback
+    if result and result != '""':
+        return result.strip()
+    return None
+
+# ─── RESPONSE WATCHER ────────────────────────────────────────
+
+def response_watcher():
+    """Background thread: watches for new Jcode responses."""
+    global _last_known_response
+    seen = set()
+    
+    log(f"📡 Watching for Jcode responses every {POLL_INTERVAL}s")
+    
+    while True:
+        try:
+            resp = get_last_response()
+            if resp and resp not in seen:
+                seen.add(resp)
+                # Keep seen set bounded
+                if len(seen) > 100:
+                    seen = set(list(seen)[-50:])
+                
+                with _response_lock:
+                    _last_known_response = resp
+            
+            time.sleep(POLL_INTERVAL)
+        except Exception as e:
+            log(f"⚠️ Watcher: {e}")
+            time.sleep(3)
+
+# ─── MESSAGE HANDLER ─────────────────────────────────────────
+
+def handle_message(user_name, text, chat_id):
+    """Inject message into Jcode and wait for a response to send back."""
+    global _last_known_response
+    
+    with _response_lock:
+        before = _last_known_response
+    
+    # Show typing on Telegram
+    send_typing(chat_id)
+    
+    # Inject into Jcode
+    inject_into_jcode(user_name, text)
+    
+    # Poll until a new response appears
+    waited = 0
+    max_wait = int(os.environ.get("RESPONSE_TIMEOUT", "120"))
+    
+    while waited < max_wait:
+        send_typing(chat_id)
+        with _response_lock:
+            current = _last_known_response
+        
+        if current and current != before:
+            log(f"📤 New response detected, sending to Telegram...")
+            send_message(chat_id, current)
+            return True
+        
+        time.sleep(2)
+        waited += 2
+    
+    log(f"⏱️ Timeout after {max_wait}s waiting for Jcode response")
+    send_message(chat_id, "⏱️ Jcode didn't respond in time. Try again?")
+    return False
+
+# ─── OFFSET PERSISTENCE ──────────────────────────────────────
+
+def load_offset():
+    try:
+        with open(OFFSET_FILE) as f:
+            return json.load(f).get("offset", 0)
+    except:
+        return 0
+
+def save_offset(offset):
+    with open(OFFSET_FILE, "w") as f:
+        json.dump({"offset": offset}, f)
+
+# ─── MAIN ─────────────────────────────────────────────────────
+
+def main():
+    log(f"╔{'═'*50}╗")
+    log(f"║  Jcode Telegram Bridge v1                                       ║")
+    log(f"║  Bot: @{BOT_TOKEN.split(':')[0]}...")
+    log(f"║  Socket: {JCODE_SOCKET}")
+    log(f"║  Data: {DATA_DIR}")
+    log(f"╚{'═'*50}╝")
+
+    # Verify socket
+    if not os.path.exists(JCODE_SOCKET):
+        log(f"⚠️  Jcode socket not found at {JCODE_SOCKET}")
+        log(f"⚠️  Make sure Jcode is running with debug_socket enabled")
+        log(f"⚠️  See: https://github.com/YOUR_USER/jcode-telegram-bridge#troubleshooting")
+    
+    # Start watcher
+    rw = threading.Thread(target=response_watcher, daemon=True)
+    rw.start()
+
+    offset = load_offset()
+    log(f"📡 Polling Telegram from offset {offset}...")
+
+    while True:
+        try:
+            r = tg_poll(offset)
+            
+            if not r.get("ok"):
+                log(f"⚠️ Poll: {r.get('description','error')}")
+                time.sleep(3)
+                continue
+            
+            for update in r.get("result", []):
+                new_offset = update["update_id"] + 1
+                if new_offset > offset:
+                    offset = new_offset
+
+                msg = update.get("message")
+                if not msg:
+                    continue
+                if msg.get("from", {}).get("is_bot"):
+                    continue
+
+                chat_id = msg.get("chat", {}).get("id")
+                user = msg.get("from", {})
+                text = msg.get("text", "") or msg.get("caption", "") or ""
+                name = (user.get("first_name", "") or 
+                        user.get("username", "") or 
+                        str(user.get("id", "")))
+
+                # Log to inbox
+                entry = {
+                    "timestamp": time.time(),
+                    "chat_id": chat_id,
+                    "user_id": user.get("id"),
+                    "username": user.get("username", ""),
+                    "first_name": user.get("first_name", ""),
+                    "text": text,
+                }
+                with open(INBOX_FILE, "a") as f:
+                    f.write(json.dumps(entry) + "\n")
+                
+                log(f"📩 {name}: {text[:120]}")
+                
+                # Process in background thread
+                threading.Thread(
+                    target=handle_message,
+                    args=(name, text, chat_id),
+                    daemon=True
+                ).start()
+
+            if r.get("result"):
+                save_offset(offset)
+
+        except KeyboardInterrupt:
+            log("Bridge stopping.")
+            break
+        except Exception as e:
+            log(f"⚠️ Error: {e}")
+            time.sleep(3)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/telegram-bridge/bridge.py
+++ b/scripts/telegram-bridge/bridge.py
@@ -210,21 +210,36 @@ def inject_into_jcode(user_name, text):
     return result
 
 def get_last_response():
-    """Get the last assistant response from the Jcode session."""
-    result = jcode_cmd("last_response", timeout_sec=3)
+    """Get the last assistant response from the Jcode session by parsing client history."""
+    result = jcode_cmd("client:history", timeout_sec=3)
     try:
         data = json.loads(result)
-        if data.get("ok") and data.get("output"):
-            output = data["output"].strip()
-            # Remove JSON wrapping if present
-            if output.startswith('"') and output.endswith('"'):
+        if not isinstance(data, dict):
+            return None
+        output = data.get("output", data)
+        if isinstance(output, str):
+            try:
                 output = json.loads(output)
-            return output
-    except (json.JSONDecodeError, KeyError):
+            except:
+                pass
+        if isinstance(output, list):
+            # Walk backwards through display messages to find last assistant text
+            for msg in reversed(output):
+                role = msg.get("role", "")
+                content = msg.get("content", "")
+                if role == "assistant" and content and isinstance(content, str):
+                    # Skip tool calls (JSON wrapped in {})
+                    if content.strip().startswith("{"):
+                        continue
+                    return content
+                # Also check nested content arrays
+                if isinstance(content, list):
+                    texts = [c.get("text", "") for c in content if c.get("type") == "text"]
+                    text = " ".join(texts).strip()
+                    if text:
+                        return text
+    except (json.JSONDecodeError, Exception):
         pass
-    # Raw fallback
-    if result and result != '""':
-        return result.strip()
     return None
 
 # ─── RESPONSE WATCHER ────────────────────────────────────────

--- a/scripts/telegram-bridge/bridge.py
+++ b/scripts/telegram-bridge/bridge.py
@@ -58,10 +58,6 @@ POLL_INTERVAL = float(os.environ.get("RESPONSE_POLL_INTERVAL", "1.5"))
 
 os.makedirs(DATA_DIR, exist_ok=True)
 
-# ─── STATE ───────────────────────────────────────────────────
-_last_known_response = None
-_response_lock = threading.Lock()
-
 def log(msg):
     print(f"[{time.strftime('%H:%M:%S')}] {msg}", flush=True)
 
@@ -233,9 +229,13 @@ def get_last_response():
 
 # ─── RESPONSE WATCHER ────────────────────────────────────────
 
+_active_chats = set()  # chat_ids waiting for responses
+_response_lock = threading.Lock()
+_last_seen_response = None
+
 def response_watcher():
-    """Background thread: watches for new Jcode responses."""
-    global _last_known_response
+    """Background thread: watches for new Jcode responses and auto-sends to Telegram."""
+    global _last_seen_response
     seen = set()
     
     log(f"📡 Watching for Jcode responses every {POLL_INTERVAL}s")
@@ -245,12 +245,16 @@ def response_watcher():
             resp = get_last_response()
             if resp and resp not in seen:
                 seen.add(resp)
-                # Keep seen set bounded
                 if len(seen) > 100:
                     seen = set(list(seen)[-50:])
                 
                 with _response_lock:
-                    _last_known_response = resp
+                    _last_seen_response = resp
+                    
+                    # Auto-send to all active Telegram chats
+                    if _active_chats:
+                        for cid in list(_active_chats):
+                            send_message(cid, resp)
             
             time.sleep(POLL_INTERVAL)
         except Exception as e:
@@ -260,38 +264,21 @@ def response_watcher():
 # ─── MESSAGE HANDLER ─────────────────────────────────────────
 
 def handle_message(user_name, text, chat_id):
-    """Inject message into Jcode and wait for a response to send back."""
-    global _last_known_response
+    """Inject message into Jcode and acknowledge immediately (no blocking)."""
+    global _last_seen_response
     
+    # Register this chat for auto-response delivery
     with _response_lock:
-        before = _last_known_response
+        _active_chats.add(chat_id)
+        before = _last_seen_response
     
-    # Show typing on Telegram
-    send_typing(chat_id)
+    # Send instant acknowledgment
+    send_message(chat_id, f"📩 Message received from <b>{user_name}</b> — Jcode is processing it now. Responses will appear here automatically.")
     
     # Inject into Jcode
     inject_into_jcode(user_name, text)
     
-    # Poll until a new response appears
-    waited = 0
-    max_wait = int(os.environ.get("RESPONSE_TIMEOUT", "120"))
-    
-    while waited < max_wait:
-        send_typing(chat_id)
-        with _response_lock:
-            current = _last_known_response
-        
-        if current and current != before:
-            log(f"📤 New response detected, sending to Telegram...")
-            send_message(chat_id, current)
-            return True
-        
-        time.sleep(2)
-        waited += 2
-    
-    log(f"⏱️ Timeout after {max_wait}s waiting for Jcode response")
-    send_message(chat_id, "⏱️ Jcode didn't respond in time. Try again?")
-    return False
+    log(f"✅ Acknowledged to {chat_id}, watching for responses...")
 
 # ─── OFFSET PERSISTENCE ──────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Add a zero-dependency Python bridge that connects Telegram messages directly into a running Jcode session via the debug socket. Users can message a Jcode instance via Telegram and receive responses in real-time.

## Architecture

```
Telegram user → Bot API → Bridge polls getUpdates → Injects into Jcode debug socket → Jcode responds → Bridge sends back to Telegram
```

## What's Included

- `scripts/telegram-bridge/bridge.py` — Main daemon: polls Telegram, injects into Jcode via debug socket, watches for responses, sends replies
- `scripts/telegram-bridge/.env.example` — Configuration template
- `scripts/telegram-bridge/bin/` — Helper scripts: tgstart, tgstatus, tgread, tgsend
- `scripts/telegram-bridge/README.md` — Full documentation

## Key Design Decisions

- **Pure Python stdlib** — zero pip dependencies, works on any system with Python 3
- **Polling over webhooks** — works anywhere Jcode runs (laptop, VPS, headless), no HTTPS endpoint needed
- **Debug socket injection** — messages appear directly in the running session, preserving context for natural multi-turn conversations
- **Markdown→HTML conversion** — Jcode's Markdown responses are converted to Telegram's HTML subset for proper rendering of bold, italic, code blocks, and links
- **Auto .env loading** — bridge reads `~/.jcode/telegram/.env` on startup, survives restarts

## Usage

1. Create a Telegram bot via @BotFather
2. Set `TELEGRAM_BOT_TOKEN` in `~/.jcode/telegram/.env`
3. Enable `debug_socket = true` in Jcode config
4. Run `tgstart` to start the bridge
5. Message your bot on Telegram — messages appear in Jcode's terminal as `📩 *Telegram from X*: ...`

The bridge automatically delivers Jcode's responses back to the Telegram user.