### PR TITLE
[codex] Route Z.AI to BigModel and keep glm-5.1 selectable

### DIFF
--- a/crates/jcode-provider-metadata/src/lib.rs
+++ b/crates/jcode-provider-metadata/src/lib.rs
@@ -164,11 +164,11 @@ pub const OPENCODE_GO_PROFILE: OpenAiCompatibleProfile = OpenAiCompatibleProfile
 pub const ZAI_PROFILE: OpenAiCompatibleProfile = OpenAiCompatibleProfile {
     id: "zai",
     display_name: "Z.AI",
-    api_base: "https://api.z.ai/api/coding/paas/v4",
+    api_base: "https://open.bigmodel.cn/api/paas/v4",
     api_key_env: "ZHIPU_API_KEY",
     env_file: "zai.env",
-    setup_url: "https://docs.z.ai/guides/develop/openai/introduction",
-    default_model: Some("glm-4.5"),
+    setup_url: "https://bigmodel.cn/dev/howuse/model",
+    default_model: Some("glm-5.1"),
     requires_api_key: true,
 };
 

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -252,7 +252,9 @@ impl MultiProvider {
         } else {
             detected_active
         };
-        let sequence = Self::fallback_sequence_for(active, self.forced_provider);
+        let config_provider_lock = Self::config_default_provider_lock_for_active(active);
+        let sequence =
+            Self::fallback_sequence_for(active, self.forced_provider.or(config_provider_lock));
         let mut notes: Vec<String> = Vec::new();
         let mut failover_reason: Option<String> = None;
         let (estimated_input_chars, estimated_input_tokens) =
@@ -797,6 +799,20 @@ impl MultiProvider {
         }
 
         self.set_model(model)
+    }
+
+    pub(super) fn config_default_provider_lock_for_active(
+        active: ActiveProvider,
+    ) -> Option<ActiveProvider> {
+        let cfg = crate::config::config();
+        let pref = cfg
+            .provider
+            .default_provider
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())?;
+        let selection = Self::resolve_config_provider_selection(pref, cfg)?;
+        (selection.active_provider() == active).then_some(active)
     }
 }
 

--- a/src/provider/openrouter.rs
+++ b/src/provider/openrouter.rs
@@ -178,6 +178,7 @@ fn configured_env_file_name() -> String {
 }
 
 fn load_named_profile_api_key(
+    profile_name: &str,
     env_key: &str,
     profile: &crate::config::NamedProviderConfig,
 ) -> Option<String> {
@@ -188,6 +189,13 @@ fn load_named_profile_api_key(
         .filter(|value| !value.is_empty())
     {
         return load_api_key_from_env_or_config(env_key, env_file);
+    }
+
+    if let Some(builtin_profile) = openai_compatible_profile_by_id(profile_name) {
+        let resolved = resolve_openai_compatible_profile(builtin_profile);
+        if resolved.api_key_env == env_key {
+            return load_api_key_from_env_or_config(env_key, &resolved.env_file);
+        }
     }
 
     std::env::var(env_key)
@@ -309,11 +317,9 @@ fn is_coding_agent_api_base(api_base: &str) -> bool {
         return false;
     };
     let host = url.host_str().unwrap_or_default();
-    let path = url.path().trim_end_matches('/');
     is_kimi_coding_api_base(api_base)
         || host == "coding.dashscope.aliyuncs.com"
         || host == "coding-intl.dashscope.aliyuncs.com"
-        || (host == "api.z.ai" && path.starts_with("/api/coding/paas"))
 }
 
 fn is_kimi_model_name(model: &str) -> bool {
@@ -715,7 +721,7 @@ impl OpenRouterProvider {
             .filter(|v| !v.is_empty());
         let key_label = key_env.unwrap_or("inline api_key").to_string();
         let key = key_env
-            .and_then(|name| load_named_profile_api_key(name, profile))
+            .and_then(|name| load_named_profile_api_key(profile_name, name, profile))
             .or_else(|| profile.api_key.clone());
         let auth = match profile.auth {
             crate::config::NamedProviderAuth::None => ProviderAuth::None {
@@ -930,6 +936,10 @@ impl OpenRouterProvider {
     }
 
     pub(crate) fn should_merge_static_models_with_live_catalog(&self) -> bool {
+        if matches!(self.profile_id.as_deref(), Some("zai")) {
+            return true;
+        }
+
         // Built-in OpenAI-compatible provider profiles use `static_models` as a
         // startup/pre-catalog fallback so `/model` is useful immediately after
         // login. Once a live `/models` catalog has been fetched, the live catalog

--- a/src/provider/openrouter_tests.rs
+++ b/src/provider/openrouter_tests.rs
@@ -895,6 +895,60 @@ fn built_in_openai_compatible_static_models_drop_out_after_live_catalog() {
 }
 
 #[test]
+fn zai_static_models_remain_visible_when_live_catalog_is_incomplete() {
+    let _lock = ENV_LOCK.lock().unwrap();
+    let temp = TempDir::new().expect("create temp home");
+    let _home = EnvVarGuard::set("HOME", temp.path());
+    let _appdata = EnvVarGuard::set("APPDATA", temp.path().join("AppData").join("Roaming"));
+    let _namespace = EnvVarGuard::set(
+        "JCODE_OPENROUTER_CACHE_NAMESPACE",
+        "test-zai-live-catalog-keeps-static-fallbacks",
+    );
+    let (api_base, _request_rx) = spawn_single_response_models_server(
+        r#"{
+            "object": "list",
+            "data": [
+                {"id": "glm-4.5", "object": "model"}
+            ]
+        }"#,
+    );
+    let provider = OpenRouterProvider {
+        api_base,
+        auth: ProviderAuth::AuthorizationBearer {
+            token: "sk-live-catalog".to_string(),
+            label: "ZHIPU_API_KEY".to_string(),
+        },
+        supports_provider_features: false,
+        supports_model_catalog: true,
+        profile_id: Some("zai".to_string()),
+        static_models: vec![
+            "glm-4.5".to_string(),
+            "glm-5".to_string(),
+            "glm-5.1".to_string(),
+        ],
+        send_openrouter_headers: false,
+        ..make_custom_compatible_provider()
+    };
+
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("runtime");
+    rt.block_on(provider.refresh_models())
+        .expect("refresh fake model catalog");
+
+    let display = provider.available_models_display();
+    assert!(
+        display.iter().any(|model| model == "glm-4.5"),
+        "live Z.AI catalog model should remain visible: {display:?}"
+    );
+    assert!(
+        display.iter().any(|model| model == "glm-5.1"),
+        "Z.AI documented chat models should remain visible even when /models is incomplete: {display:?}"
+    );
+}
+
+#[test]
 fn direct_openai_compatible_static_models_are_marked_as_fallback_before_live_catalog() {
     let provider = OpenRouterProvider {
         supports_provider_features: false,
@@ -1003,6 +1057,28 @@ fn named_openai_compatible_loads_api_key_from_env_file() {
 
     OpenRouterProvider::new_named_openai_compatible("custom", &config)
         .expect("provider should load key from env file");
+}
+
+#[test]
+fn named_builtin_profile_without_env_file_uses_builtin_env_file() {
+    let _lock = ENV_LOCK.lock().unwrap();
+    let temp = TempDir::new().expect("create temp dir");
+    let _xdg = EnvVarGuard::set("XDG_CONFIG_HOME", temp.path());
+    let _home = EnvVarGuard::set("HOME", temp.path());
+    let _appdata = EnvVarGuard::set("APPDATA", temp.path().join("AppData").join("Roaming"));
+    let _namespace = EnvVarGuard::remove("JCODE_OPENROUTER_CACHE_NAMESPACE");
+    let _api_key = EnvVarGuard::remove("ZHIPU_API_KEY");
+    write_test_api_key(&temp, "zai.env", "ZHIPU_API_KEY", "from-builtin-env-file");
+
+    let config = crate::config::NamedProviderConfig {
+        base_url: "https://open.bigmodel.cn/api/paas/v4".to_string(),
+        api_key_env: Some("ZHIPU_API_KEY".to_string()),
+        default_model: Some("glm-5.1".to_string()),
+        ..Default::default()
+    };
+
+    OpenRouterProvider::new_named_openai_compatible("zai", &config)
+        .expect("built-in profile override should still load the built-in env file");
 }
 
 #[test]
@@ -1123,8 +1199,8 @@ fn test_kimi_coding_header_detection_matches_endpoint_and_model() {
         "https://coding-intl.dashscope.aliyuncs.com/v1",
         None,
     ));
-    assert!(should_send_kimi_coding_agent_headers(
-        "https://api.z.ai/api/coding/paas/v4",
+    assert!(!should_send_kimi_coding_agent_headers(
+        "https://open.bigmodel.cn/api/paas/v4",
         None,
     ));
     assert!(should_send_kimi_coding_agent_headers(

--- a/src/provider/startup.rs
+++ b/src/provider/startup.rs
@@ -281,8 +281,9 @@ impl MultiProvider {
                             .unwrap_or_else(|| selection.display_label())
                     ));
                 } else {
+                    active = preferred;
                     crate::logging::warn(&format!(
-                        "Preferred provider '{}' is not configured, using auto-detected default",
+                        "Preferred provider '{}' is not configured; keeping it selected so requests fail instead of falling back to another provider",
                         pref
                     ));
                 }

--- a/src/provider/tests/fallback_failover.rs
+++ b/src/provider/tests/fallback_failover.rs
@@ -167,6 +167,60 @@ fn test_forced_provider_disables_cross_provider_fallback_sequence() {
 }
 
 #[test]
+fn test_config_default_provider_locks_cross_provider_fallback() {
+    with_clean_provider_test_env(|| {
+        let mut cfg = crate::config::Config::default();
+        cfg.provider.default_provider = Some("zai".to_string());
+        cfg.save().expect("save test config");
+
+        assert_eq!(
+            MultiProvider::config_default_provider_lock_for_active(ActiveProvider::OpenRouter),
+            Some(ActiveProvider::OpenRouter)
+        );
+        assert_eq!(
+            MultiProvider::config_default_provider_lock_for_active(ActiveProvider::OpenAI),
+            None
+        );
+    });
+}
+
+#[test]
+fn test_unconfigured_config_default_profile_stays_active_instead_of_using_other_profile_key() {
+    with_clean_provider_test_env(|| {
+        let runtime = enter_test_runtime();
+        let _enter = runtime.enter();
+
+        let mut cfg = crate::config::Config::default();
+        cfg.provider.default_provider = Some("zai".to_string());
+        cfg.provider.default_model = Some("glm-5.1".to_string());
+        cfg.save().expect("save test config");
+
+        crate::env::set_var("KIMI_API_KEY", "test-kimi-key");
+        crate::auth::AuthStatus::invalidate_cache();
+
+        let provider = MultiProvider::from_auth_status(crate::auth::AuthStatus::check_fast());
+
+        assert_eq!(provider.active_provider(), ActiveProvider::OpenRouter);
+        assert!(
+            provider.openrouter_provider().is_none(),
+            "missing Z.AI credentials must not initialize an OpenRouter/Kimi provider"
+        );
+        assert_eq!(
+            std::env::var("JCODE_OPENROUTER_API_KEY_NAME")
+                .ok()
+                .as_deref(),
+            Some("ZHIPU_API_KEY")
+        );
+        assert_eq!(
+            std::env::var("JCODE_OPENROUTER_CACHE_NAMESPACE")
+                .ok()
+                .as_deref(),
+            Some("zai")
+        );
+    });
+}
+
+#[test]
 fn test_set_model_rejects_cross_provider_without_creds() {
     let _guard = crate::storage::lock_test_env();
     let runtime = enter_test_runtime();

--- a/src/provider_catalog_tests.rs
+++ b/src/provider_catalog_tests.rs
@@ -86,8 +86,8 @@ fn matrix_login_provider_aliases_resolve_to_canonical_ids() {
 
 #[test]
 fn auth_issue_profile_metadata_matches_direct_provider_endpoints() {
-    assert_eq!(ZAI_PROFILE.api_base, "https://api.z.ai/api/coding/paas/v4");
-    assert_eq!(ZAI_PROFILE.default_model, Some("glm-4.5"));
+    assert_eq!(ZAI_PROFILE.api_base, "https://open.bigmodel.cn/api/paas/v4");
+    assert_eq!(ZAI_PROFILE.default_model, Some("glm-5.1"));
     assert_eq!(DEEPSEEK_PROFILE.api_base, "https://api.deepseek.com");
     assert_eq!(DEEPSEEK_PROFILE.default_model, Some("deepseek-v4-flash"));
     assert_eq!(DEEPSEEK_PROFILE.setup_url, "https://api-docs.deepseek.com/");


### PR DESCRIPTION
## Summary
- Route the built-in Z.AI profile to the mainland BigModel endpoint and default it to `glm-5.1`.
- Keep Z.AI static model entries merged with live `/models` results so `glm-5.1` stays visible when the live catalog is incomplete.
- Remove Z.AI/BigModel from Kimi coding-agent header detection; Kimi remains `https://api.kimi.com/coding/v1` with coding-agent headers, separate from Moonshot.
- Treat a configured `default_provider` as a provider lock so missing credentials fail clearly instead of silently falling back to another configured provider.
- Let named provider overrides that shadow a built-in profile, such as `[providers.zai]`, still load the built-in saved env file when `env_file` is omitted.

## Validation
- `cargo fmt`
- `cargo test -p jcode auth_issue_profile_metadata_matches_direct_provider_endpoints`
- `cargo test -p jcode test_kimi_coding_header_detection_matches_endpoint_and_model`
- `cargo test -p jcode zai_static_models_remain_visible_when_live_catalog_is_incomplete`
- `cargo test -p jcode test_config_default_provider_locks_cross_provider_fallback`
- `cargo test -p jcode test_unconfigured_config_default_profile_stays_active_instead_of_using_other_profile_key`
- `cargo test -p jcode named_builtin_profile_without_env_file_uses_builtin_env_file`
- `cargo test -p jcode named_openai_compatible_loads_api_key_from_env_file`

Local smoke checks also confirmed Z.AI `glm-5.1`, Kimi `kimi-for-coding`, and OpenAI/Codex routing work with saved credentials.