### PR TITLE
Add MiniMax-M3 and make it the default model for the MiniMax provider

### DIFF
--- a/OAUTH.md
+++ b/OAUTH.md
@@ -267,7 +267,7 @@ Two notable presets are:
 - Stored env file: `~/.config/jcode/minimax.env`
 - API key env var: `OPENAI_API_KEY`
 - Base URL: `https://api.minimax.io/v1`
-- Default model hint: `MiniMax-M2.7`
+- Default model hint: `MiniMax-M3`
 - Docs: <https://platform.minimax.io/docs/guides/text-generation>
 
 These are first-class jcode provider presets, not just manual custom endpoint examples.

--- a/crates/jcode-base/src/live_tests.rs
+++ b/crates/jcode-base/src/live_tests.rs
@@ -255,7 +255,7 @@ const ISSUE_DRIVEN_LIVE_PROVIDER_TARGETS: &[IssueDrivenLiveProviderTarget] = &[
     IssueDrivenLiveProviderTarget {
         provider_id: "minimax",
         provider_label: "MiniMax",
-        model: Some("MiniMax-M2.7"),
+        model: Some("MiniMax-M3"),
         reason: "MiniMax endpoint/key-region selection and live balance/readiness",
         issue_refs: &["#110", "#131", "#189"],
     },

--- a/crates/jcode-base/src/provider/openrouter_tests.rs
+++ b/crates/jcode-base/src/provider/openrouter_tests.rs
@@ -280,9 +280,9 @@ fn minimax_profile_exposes_static_models_before_catalog_refresh() {
         jcode_provider_metadata::MINIMAX_PROFILE,
     );
 
+    assert!(models.iter().any(|model| model == "MiniMax-M3"));
     assert!(models.iter().any(|model| model == "MiniMax-M2.7"));
     assert!(models.iter().any(|model| model == "MiniMax-M2.7-highspeed"));
-    assert!(models.iter().any(|model| model == "MiniMax-M2"));
 }
 
 #[test]

--- a/crates/jcode-base/src/provider_catalog.rs
+++ b/crates/jcode-base/src/provider_catalog.rs
@@ -455,13 +455,9 @@ pub fn openai_compatible_profile_static_models(profile: OpenAiCompatibleProfile)
         // before the picker/routes are rebuilt. Keep the documented text models
         // selectable immediately after saving a key.
         "minimax" => {
+            push("MiniMax-M3");
             push("MiniMax-M2.7");
             push("MiniMax-M2.7-highspeed");
-            push("MiniMax-M2.5");
-            push("MiniMax-M2.5-highspeed");
-            push("MiniMax-M2.1");
-            push("MiniMax-M2.1-highspeed");
-            push("MiniMax-M2");
         }
         "alibaba-coding-plan" => {
             push("qwen3-coder-plus");

--- a/crates/jcode-provider-metadata/src/catalog.rs
+++ b/crates/jcode-provider-metadata/src/catalog.rs
@@ -298,7 +298,7 @@ pub const MINIMAX_PROFILE: OpenAiCompatibleProfile = OpenAiCompatibleProfile {
     api_key_env: "OPENAI_API_KEY",
     env_file: "minimax.env",
     setup_url: "https://platform.minimax.io/docs/guides/text-generation",
-    default_model: Some("MiniMax-M2.7"),
+    default_model: Some("MiniMax-M3"),
     requires_api_key: true,
 };
 


### PR DESCRIPTION
## Summary

MiniMax's flagship text model is now [MiniMax-M3](https://platform.minimax.io/docs/guides/text-generation). This PR pulls it into the `minimax` provider preset so users picking `jcode login --provider minimax` land on the current generation by default.

## Changes

- `crates/jcode-provider-metadata/src/catalog.rs`: bump `MINIMAX_PROFILE.default_model` from `MiniMax-M2.7` to `MiniMax-M3`.
- `crates/jcode-base/src/provider_catalog.rs`: rebuild the static model fallback for the `minimax` profile to expose `MiniMax-M3`, `MiniMax-M2.7`, and `MiniMax-M2.7-highspeed`. Drop the older `M2.5 / M2.5-highspeed / M2.1 / M2.1-highspeed / M2` entries; live `/v1/models` will still surface anything else the user's account has.
- `crates/jcode-base/src/provider/openrouter_tests.rs`: update the static-fallback regression to assert M3 is exposed (and replace the M2 assertion with the M3 one).
- `crates/jcode-base/src/live_tests.rs`: switch the `minimax` live-test target model from M2.7 to M3.
- `OAUTH.md`: refresh the default model hint in the MiniMax preset section.

Only the `minimax` provider's own list and default change; the other aggregators (`opencode`, `cortecs`, `302ai`, `alibaba-coding-plan`) that mention older MiniMax model IDs in their static catalogs are left alone, since those reflect what each upstream actually exposes.

API base URL, env-file layout, China endpoint resolution, and the existing `MiniMax-M2.7-highspeed` entry are all untouched.

## Notes

- Heavily generated, in line with the project's stated workflow. CONTRIBUTING.md notes large/generated PRs may be used as a reference rather than merged as-is, which is fine here, the diff is intentionally small.
- I did not run the full `cargo test -p jcode-base` suite locally because of build resource limits on the machine I have access to. The metadata crate (`cargo check -p jcode-provider-metadata`) builds clean. All edits are mechanical model-ID string replacements; the test changes line up 1:1 with the new static list.

## Test plan

- [ ] `cargo test -p jcode-provider-metadata`
- [ ] `cargo test -p jcode-base provider_catalog`
- [ ] `cargo test -p jcode-base openrouter`
- [ ] Smoke: `jcode login --provider minimax`, confirm picker leads with `MiniMax-M3` and that `M2.7` / `M2.7-highspeed` are still reachable.