### PR TITLE
fix(agent/streaming): emit 💭 prefix once per thinking burst

### DIFF
--- a/crates/jcode-app-core/src/agent/streaming.rs
+++ b/crates/jcode-app-core/src/agent/streaming.rs
@@ -30,3 +30,76 @@ pub(super) fn send_stream_keepalive_mpsc(event_tx: &mpsc::UnboundedSender<Server
         id: STREAM_KEEPALIVE_PONG_ID,
     });
 }
+
+/// Wrap a single `ThinkingDelta` chunk for transport to the TUI.
+///
+/// Providers fragment reasoning into many small deltas. The TUI shows a single
+/// `💭 ` marker at the head of a thinking burst; appending it to every chunk would
+/// render `💭 chunk 💭 chunk 💭 chunk…` interleaved with the eventual answer once
+/// markdown collapses single newlines into spaces. Caller owns `prefix_emitted`
+/// and resets it on every `ThinkingStart` / `ThinkingEnd` / `ThinkingDone`.
+pub(super) fn format_thinking_delta_payload(text: &str, prefix_emitted: &mut bool) -> String {
+    if !*prefix_emitted {
+        *prefix_emitted = true;
+        format!("💭 {}", text)
+    } else {
+        text.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::format_thinking_delta_payload;
+
+    #[test]
+    fn first_delta_in_burst_gets_prefix() {
+        let mut emitted = false;
+        let payload = format_thinking_delta_payload("Hello", &mut emitted);
+        assert_eq!(payload, "💭 Hello");
+        assert!(emitted);
+    }
+
+    #[test]
+    fn subsequent_deltas_in_burst_are_raw() {
+        let mut emitted = false;
+        let _ = format_thinking_delta_payload("Hello", &mut emitted);
+        let second = format_thinking_delta_payload(" world", &mut emitted);
+        let third = format_thinking_delta_payload(", how are you", &mut emitted);
+        assert_eq!(second, " world");
+        assert_eq!(third, ", how are you");
+    }
+
+    #[test]
+    fn reconcatenated_stream_has_exactly_one_prefix() {
+        // Simulate a provider that fragments thinking into many chunks.
+        let chunks = [
+            "I",
+            "'m",
+            " reviewing",
+            " the",
+            " memory",
+            " files",
+            " in",
+            " jcode",
+            ".",
+        ];
+        let mut emitted = false;
+        let joined: String = chunks
+            .iter()
+            .map(|c| format_thinking_delta_payload(c, &mut emitted))
+            .collect();
+        assert_eq!(joined, "💭 I'm reviewing the memory files in jcode.");
+        assert_eq!(joined.matches("💭").count(), 1);
+    }
+
+    #[test]
+    fn burst_boundary_resets_prefix() {
+        // Caller resets the flag at burst boundaries (ThinkingStart/End/Done).
+        let mut emitted = false;
+        let _ = format_thinking_delta_payload("first burst", &mut emitted);
+        // Boundary reached -> caller flips back to false.
+        emitted = false;
+        let next = format_thinking_delta_payload("second burst", &mut emitted);
+        assert_eq!(next, "💭 second burst");
+    }
+}

--- a/crates/jcode-app-core/src/agent/turn_streaming_broadcast.rs
+++ b/crates/jcode-app-core/src/agent/turn_streaming_broadcast.rs
@@ -212,6 +212,10 @@ impl Agent {
             let store_reasoning_content =
                 crate::provider::stores_reasoning_content_for_context(&provider_name);
             let mut reasoning_content = String::new();
+            // Emit the 💭 prefix only once per thinking burst; subsequent deltas are streamed
+            // raw so providers that fragment reasoning into many small chunks don't render
+            // "💭 chunk 💭 chunk 💭 chunk…" interleaved with the actual answer.
+            let mut thinking_prefix_emitted = false;
             let mut reasoning_signature = String::new();
             let mut openai_reasoning_items: Vec<ContentBlock> = Vec::new();
             let mut openai_native_compaction: Option<(String, usize)> = None;
@@ -303,6 +307,7 @@ impl Agent {
 
                 match event {
                     StreamEvent::ThinkingStart => {
+                        thinking_prefix_emitted = false;
                         // Reasoning tokens are counted in provider output usage even when
                         // `display.show_thinking` hides the text. Let remote clients start
                         // their TPS timer without forcing hidden reasoning into the transcript.
@@ -310,7 +315,19 @@ impl Agent {
                             phase: crate::message::ConnectionPhase::Streaming.to_string(),
                         });
                     }
-                    StreamEvent::ThinkingEnd => {}
+                    StreamEvent::ThinkingEnd => {
+                        // If this burst surfaced a 💭 prefix into the transcript, emit a blank
+                        // line before the model's regular answer so they don't visually fuse.
+                        // Providers that emit ThinkingDone separately will append `\nThought
+                        // for…\n` and supply their own separator there instead.
+                        if thinking_prefix_emitted && crate::config::config().display.show_thinking
+                        {
+                            let _ = event_tx.send(ServerEvent::TextDelta {
+                                text: "\n\n".to_string(),
+                            });
+                        }
+                        thinking_prefix_emitted = false;
+                    }
                     StreamEvent::ThinkingSignatureDelta(signature) => {
                         if store_reasoning_content {
                             reasoning_signature.push_str(&signature);
@@ -319,17 +336,20 @@ impl Agent {
                     StreamEvent::ThinkingDelta(thinking_text) => {
                         // Only send thinking content if enabled in config
                         if crate::config::config().display.show_thinking {
-                            let _ = event_tx.send(ServerEvent::TextDelta {
-                                text: format!("💭 {}\n", thinking_text),
-                            });
+                            let payload = super::streaming::format_thinking_delta_payload(
+                                &thinking_text,
+                                &mut thinking_prefix_emitted,
+                            );
+                            let _ = event_tx.send(ServerEvent::TextDelta { text: payload });
                         }
                         if store_reasoning_content {
                             reasoning_content.push_str(&thinking_text);
                         }
                     }
                     StreamEvent::ThinkingDone { duration_secs } => {
+                        thinking_prefix_emitted = false;
                         let _ = event_tx.send(ServerEvent::TextDelta {
-                            text: format!("Thought for {:.1}s\n", duration_secs),
+                            text: format!("\nThought for {:.1}s\n", duration_secs),
                         });
                     }
                     StreamEvent::TextDelta(text) => {

--- a/crates/jcode-app-core/src/agent/turn_streaming_mpsc.rs
+++ b/crates/jcode-app-core/src/agent/turn_streaming_mpsc.rs
@@ -245,6 +245,10 @@ impl Agent {
             let store_reasoning_content =
                 crate::provider::stores_reasoning_content_for_context(&provider_name);
             let mut reasoning_content = String::new();
+            // Emit the 💭 prefix only once per thinking burst; subsequent deltas are streamed
+            // raw so providers that fragment reasoning into many small chunks don't render
+            // "💭 chunk 💭 chunk 💭 chunk…" interleaved with the actual answer.
+            let mut thinking_prefix_emitted = false;
             let mut reasoning_signature = String::new();
             let mut openai_reasoning_items: Vec<ContentBlock> = Vec::new();
             let mut openai_native_compaction: Option<(String, usize)> = None;
@@ -351,6 +355,7 @@ impl Agent {
 
                 match event {
                     StreamEvent::ThinkingStart => {
+                        thinking_prefix_emitted = false;
                         // Reasoning tokens are counted in provider output usage even when
                         // `display.show_thinking` hides the text. Let remote clients start
                         // their TPS timer without forcing hidden reasoning into the transcript.
@@ -358,7 +363,19 @@ impl Agent {
                             phase: crate::message::ConnectionPhase::Streaming.to_string(),
                         });
                     }
-                    StreamEvent::ThinkingEnd => {}
+                    StreamEvent::ThinkingEnd => {
+                        // If this burst surfaced a 💭 prefix into the transcript, emit a blank
+                        // line before the model's regular answer so they don't visually fuse.
+                        // Providers that emit ThinkingDone separately will append `\nThought
+                        // for…\n` and supply their own separator there instead.
+                        if thinking_prefix_emitted && crate::config::config().display.show_thinking
+                        {
+                            let _ = event_tx.send(ServerEvent::TextDelta {
+                                text: "\n\n".to_string(),
+                            });
+                        }
+                        thinking_prefix_emitted = false;
+                    }
                     StreamEvent::ThinkingSignatureDelta(signature) => {
                         if store_reasoning_content {
                             reasoning_signature.push_str(&signature);
@@ -367,17 +384,20 @@ impl Agent {
                     StreamEvent::ThinkingDelta(thinking_text) => {
                         // Only send thinking content if enabled in config
                         if crate::config::config().display.show_thinking {
-                            let _ = event_tx.send(ServerEvent::TextDelta {
-                                text: format!("💭 {}\n", thinking_text),
-                            });
+                            let payload = super::streaming::format_thinking_delta_payload(
+                                &thinking_text,
+                                &mut thinking_prefix_emitted,
+                            );
+                            let _ = event_tx.send(ServerEvent::TextDelta { text: payload });
                         }
                         if store_reasoning_content {
                             reasoning_content.push_str(&thinking_text);
                         }
                     }
                     StreamEvent::ThinkingDone { duration_secs } => {
+                        thinking_prefix_emitted = false;
                         let _ = event_tx.send(ServerEvent::TextDelta {
-                            text: format!("Thought for {:.1}s\n", duration_secs),
+                            text: format!("\nThought for {:.1}s\n", duration_secs),
                         });
                     }
                     StreamEvent::TextDelta(text) => {

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -12,6 +12,7 @@ mod burst_spawn;
 mod provider_behavior;
 mod safety;
 mod session_flow;
+mod streaming_thinking;
 mod transport;
 #[cfg(windows)]
 mod windows_lifecycle;

--- a/tests/e2e/streaming_thinking.rs
+++ b/tests/e2e/streaming_thinking.rs
@@ -1,0 +1,240 @@
+//! End-to-end tests for thinking-burst delta wrapping in streaming paths.
+//!
+//! Verifies that the `💭 ` marker is emitted exactly once per thinking burst
+//! even when the provider fragments reasoning across many `ThinkingDelta`
+//! events. Regression test for a bug where every delta was wrapped with
+//! `format!("💭 {}\n", text)`; once markdown collapsed the single newlines
+//! into spaces, the 💭 emoji ended up interleaved every ~10 characters across
+//! the visible response on Ghostty / macOS.
+
+use crate::test_support::*;
+use tokio::sync::broadcast;
+
+/// Set `JCODE_SHOW_THINKING=true` for the duration of the test so the streaming
+/// paths actually surface `ThinkingDelta` events as `TextDelta` payloads. We
+/// use the env override instead of writing `config.toml` because the global
+/// config cache only re-fingerprints the env keys it explicitly tracks, and
+/// `JCODE_SHOW_THINKING` is one of them — that gives us a reliable per-test
+/// toggle that survives the `OnceLock`-backed cache across multiple tests in
+/// the same process.
+fn enable_show_thinking() -> EnvVarGuard {
+    let guard = EnvVarGuard::set("JCODE_SHOW_THINKING", "true");
+    // The global config cache has a 500 ms throttle in non-test builds (the
+    // `jcode-base` crate is compiled as a dep here, so `cfg!(test)` is false
+    // for it). Force a reload immediately so the next `config()` call observes
+    // our env override instead of a cached snapshot from a previous test.
+    jcode::config::invalidate_config_cache();
+    guard
+}
+
+/// Counterpart to `enable_show_thinking` for tests that want to assert the
+/// thinking path is fully suppressed: also invalidate the cache so we don't
+/// inherit a `show_thinking = true` snapshot from a sibling test.
+fn ensure_show_thinking_disabled() {
+    jcode::config::invalidate_config_cache();
+}
+
+/// Drain every `ServerEvent` that arrives on the broadcast receiver until the
+/// agent task finishes (the sender is dropped once `run_once_streaming`
+/// returns).
+async fn collect_server_events(mut rx: broadcast::Receiver<ServerEvent>) -> Vec<ServerEvent> {
+    let mut events = Vec::new();
+    loop {
+        match rx.recv().await {
+            Ok(event) => events.push(event),
+            Err(broadcast::error::RecvError::Closed) => break,
+            Err(broadcast::error::RecvError::Lagged(_)) => continue,
+        }
+    }
+    events
+}
+
+/// Concatenate every `TextDelta { text }` payload in order, mirroring what a
+/// remote TUI client renders into the transcript.
+fn reconstruct_text(events: &[ServerEvent]) -> String {
+    let mut out = String::new();
+    for event in events {
+        if let ServerEvent::TextDelta { text } = event {
+            out.push_str(text);
+        }
+    }
+    out
+}
+
+/// Regression: a single thinking burst fragmented into many `ThinkingDelta`
+/// events must surface exactly one `💭 ` marker, not one per delta.
+#[tokio::test]
+async fn streaming_thinking_emits_single_marker_per_burst() -> Result<()> {
+    let _env = setup_test_env()?;
+    let _show_thinking = enable_show_thinking();
+
+    let provider = MockProvider::new();
+    // Fragmented thinking burst: 8 tiny deltas the way reasoning providers
+    // actually stream them today (Claude / OpenAI / Gemini).
+    provider.queue_response(vec![
+        StreamEvent::ThinkingStart,
+        StreamEvent::ThinkingDelta("I".into()),
+        StreamEvent::ThinkingDelta("'m".into()),
+        StreamEvent::ThinkingDelta(" reviewing".into()),
+        StreamEvent::ThinkingDelta(" the".into()),
+        StreamEvent::ThinkingDelta(" memory".into()),
+        StreamEvent::ThinkingDelta(" files".into()),
+        StreamEvent::ThinkingDelta(" in".into()),
+        StreamEvent::ThinkingDelta(" jcode.".into()),
+        StreamEvent::ThinkingEnd,
+        StreamEvent::TextDelta("## Answer\n\nDone.".into()),
+        StreamEvent::MessageEnd {
+            stop_reason: Some("end_turn".into()),
+        },
+        StreamEvent::SessionId("session-thinking-1".into()),
+    ]);
+
+    let provider: Arc<dyn jcode::provider::Provider> = Arc::new(provider);
+    let registry = Registry::new(provider.clone()).await;
+    let mut agent = Agent::new(provider, registry);
+
+    let (tx, rx) = broadcast::channel(256);
+    let collector = tokio::spawn(collect_server_events(rx));
+    agent.run_once_streaming("Test", tx).await?;
+    let events = collector.await?;
+
+    let stream_text = reconstruct_text(&events);
+
+    // Exactly one 💭 in the entire reconstructed stream.
+    assert_eq!(
+        stream_text.matches("💭").count(),
+        1,
+        "expected exactly one 💭 marker per thinking burst, got stream={:?}",
+        stream_text
+    );
+
+    // The marker prefixes the very first thinking fragment.
+    assert!(
+        stream_text.starts_with("💭 I"),
+        "expected 💭 to lead the burst, got stream={:?}",
+        stream_text
+    );
+
+    // The reconstructed thinking body matches the concatenated fragments
+    // with no interleaved newlines or stray markers between them.
+    assert!(
+        stream_text.contains("💭 I'm reviewing the memory files in jcode."),
+        "expected thinking body reconstruct cleanly, got stream={:?}",
+        stream_text
+    );
+
+    // ThinkingEnd must insert a blank line so the answer does not visually
+    // fuse onto the tail of the thinking burst.
+    assert!(
+        stream_text.contains("💭 I'm reviewing the memory files in jcode.\n\n## Answer"),
+        "expected `\\n\\n` separator between thinking burst and answer, got stream={:?}",
+        stream_text
+    );
+
+    Ok(())
+}
+
+/// A turn that contains two separate thinking bursts (separated by tool use or
+/// inter-burst answer text) must emit one 💭 marker per burst, not one total.
+#[tokio::test]
+async fn streaming_thinking_resets_prefix_between_bursts() -> Result<()> {
+    let _env = setup_test_env()?;
+    let _show_thinking = enable_show_thinking();
+
+    let provider = MockProvider::new();
+    provider.queue_response(vec![
+        // First burst.
+        StreamEvent::ThinkingStart,
+        StreamEvent::ThinkingDelta("first".into()),
+        StreamEvent::ThinkingDelta(" burst".into()),
+        StreamEvent::ThinkingEnd,
+        StreamEvent::TextDelta("Interlude.\n".into()),
+        // Second burst.
+        StreamEvent::ThinkingStart,
+        StreamEvent::ThinkingDelta("second".into()),
+        StreamEvent::ThinkingDelta(" burst".into()),
+        StreamEvent::ThinkingEnd,
+        StreamEvent::TextDelta("Answer.".into()),
+        StreamEvent::MessageEnd {
+            stop_reason: Some("end_turn".into()),
+        },
+        StreamEvent::SessionId("session-thinking-2".into()),
+    ]);
+
+    let provider: Arc<dyn jcode::provider::Provider> = Arc::new(provider);
+    let registry = Registry::new(provider.clone()).await;
+    let mut agent = Agent::new(provider, registry);
+
+    let (tx, rx) = broadcast::channel(256);
+    let collector = tokio::spawn(collect_server_events(rx));
+    agent.run_once_streaming("Test", tx).await?;
+    let events = collector.await?;
+
+    let stream_text = reconstruct_text(&events);
+
+    assert_eq!(
+        stream_text.matches("💭").count(),
+        2,
+        "expected one 💭 marker per burst (2 total), got stream={:?}",
+        stream_text
+    );
+    assert!(stream_text.contains("💭 first burst"));
+    assert!(stream_text.contains("💭 second burst"));
+
+    Ok(())
+}
+
+/// When `display.show_thinking = false`, no `💭` marker (or any thinking
+/// payload at all) must reach the broadcast stream, but the answer text must
+/// still arrive cleanly with no spurious separator from the suppressed burst.
+#[tokio::test]
+async fn streaming_thinking_hidden_emits_no_marker() -> Result<()> {
+    let _env = setup_test_env()?;
+    // Don't call enable_show_thinking(); rely on the config-types default
+    // (`show_thinking = false`). Still flush the cache so a sibling test's
+    // `show_thinking = true` snapshot doesn't leak into this assertion.
+    ensure_show_thinking_disabled();
+
+    let provider = MockProvider::new();
+    provider.queue_response(vec![
+        StreamEvent::ThinkingStart,
+        StreamEvent::ThinkingDelta("hidden".into()),
+        StreamEvent::ThinkingDelta(" reasoning".into()),
+        StreamEvent::ThinkingEnd,
+        StreamEvent::TextDelta("Just the answer.".into()),
+        StreamEvent::MessageEnd {
+            stop_reason: Some("end_turn".into()),
+        },
+        StreamEvent::SessionId("session-thinking-3".into()),
+    ]);
+
+    let provider: Arc<dyn jcode::provider::Provider> = Arc::new(provider);
+    let registry = Registry::new(provider.clone()).await;
+    let mut agent = Agent::new(provider, registry);
+
+    let (tx, rx) = broadcast::channel(256);
+    let collector = tokio::spawn(collect_server_events(rx));
+    agent.run_once_streaming("Test", tx).await?;
+    let events = collector.await?;
+
+    let stream_text = reconstruct_text(&events);
+
+    assert_eq!(
+        stream_text.matches("💭").count(),
+        0,
+        "expected zero 💭 markers when show_thinking is disabled, got stream={:?}",
+        stream_text
+    );
+    assert!(
+        !stream_text.contains("hidden reasoning"),
+        "expected thinking body to be suppressed, got stream={:?}",
+        stream_text
+    );
+    assert!(
+        stream_text.contains("Just the answer."),
+        "expected the visible answer to still stream, got stream={:?}",
+        stream_text
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Fixes a UX regression on v0.18.x where the 💭 (thought balloon) emoji appears interleaved every ~10–15 characters throughout streaming responses on Ghostty / macOS whenever `display.show_thinking = true`. Visible as "cloud characters" smeared across the answer body.

## Root cause

Server streaming paths (`turn_streaming_broadcast.rs` + `turn_streaming_mpsc.rs`) wrap **every** `ThinkingDelta` chunk with `format!("💭 {}\n", text)`. Reasoning providers (Claude, OpenAI o-series, Gemini) fragment a single thinking burst into many small deltas, so the client receives:

```
💭 I
💭 'm reviewing
💭  the memory
💭  files
...
```

Markdown then collapses single newlines into spaces, which surfaces the emoji every ~10 characters throughout the rendered transcript. The local in-process turn path (`turn.rs`) was already correct: it tracks a `thinking_prefix_emitted` flag and only prepends the marker to the first delta in a burst. The two server streaming paths simply hadn't been kept in sync.

## Fix

1. Factor the wrap logic into a pure helper `agent::streaming::format_thinking_delta_payload(text, &mut prefix_emitted) -> String` so both transport paths share one implementation.
2. Track `thinking_prefix_emitted` in each server streaming loop; reset it on every `ThinkingStart` / `ThinkingEnd` / `ThinkingDone` (burst boundaries).
3. On `ThinkingEnd`, if a 💭 prefix was surfaced into the transcript this burst, emit `\n\n` so the answer doesn't visually fuse onto the tail of the reasoning. Providers that emit `ThinkingDone` separately keep their existing `\nThought for…\n` separator (slightly adjusted to lead with a newline).

## Tests

**Unit** (`agent::streaming::tests`, 4 tests):
- `first_delta_in_burst_gets_prefix`
- `subsequent_deltas_in_burst_are_raw`
- `reconcatenated_stream_has_exactly_one_prefix` — 9 fragmented chunks → exactly one `💭`
- `burst_boundary_resets_prefix`

**E2E** (`tests/e2e/streaming_thinking.rs`, 3 tests) — queue fragmented `ThinkingDelta` sequences into `MockProvider`, drive `Agent::run_once_streaming` (the same broadcast path the server uses for remote TUI clients), and assert on the reconstructed `TextDelta` stream:
- `streaming_thinking_emits_single_marker_per_burst` — 8 fragments → exactly 1 marker, body reconstructs cleanly, `\n\n` separator before the answer
- `streaming_thinking_resets_prefix_between_bursts` — 2 separate bursts → exactly 2 markers
- `streaming_thinking_hidden_emits_no_marker` — `display.show_thinking = false` → zero markers, no thinking body in stream, answer still streams

All 4 unit + 3 e2e tests pass, full e2e suite (50 tests) green.

## Live verification

Built a release canary from this branch and ran a thinking-heavy prompt against Claude (OAuth, `claude-opus-4-7`) on Ghostty / macOS aarch64:

**Before (v0.18.4 release):**
```
💭 I'm reviewing💭  the memory💭  files💭  in jcode💭 . The user wants 💭 ...
```
(💭 interleaved every ~10 chars across the entire response.)

**After (this branch):**
```
💭 I'm reviewing the memory files in jcode. The user wants...

## Answer

...
```
(Single 💭 at the head of the burst, blank line, then clean answer.)

## Scope

Targeted at the two server streaming paths only. The local `turn.rs` path is unchanged. No public API surface changes. No config changes.
