### PR TITLE
[codex] Support Anthropic-compatible base URLs

### DIFF
--- a/crates/jcode-base/src/auth/active_method.rs
+++ b/crates/jcode-base/src/auth/active_method.rs
@@ -77,10 +77,12 @@ pub fn resolve_dual_credential_auth(
     let (has_oauth, has_api_key, forced) = match provider {
         ActiveProvider::Claude => {
             let has_oauth = auth.anthropic.has_oauth;
-            // `has_api_key` already folds in the ANTHROPIC_API_KEY env var via the
-            // auth probe, but re-check defensively so an env-only key set after the
+            // `has_api_key` already folds in Anthropic direct auth env vars via the
+            // auth probe, but re-check defensively so env-only auth set after the
             // cached snapshot still reports honestly.
-            let has_api_key = auth.anthropic.has_api_key || std::env::var("ANTHROPIC_API_KEY").is_ok();
+            let has_api_key = auth.anthropic.has_api_key
+                || std::env::var("ANTHROPIC_API_KEY").is_ok()
+                || std::env::var("ANTHROPIC_AUTH_TOKEN").is_ok();
             let forced = match runtime.as_deref() {
                 Some("claude-api" | "anthropic-api") => Some(ActiveCredential::ApiKey),
                 Some("claude" | "anthropic") => Some(ActiveCredential::OAuth),
@@ -123,6 +125,29 @@ mod tests {
     use super::*;
     use crate::auth::ProviderAuth;
 
+    struct EnvVarGuard {
+        key: &'static str,
+        previous: Option<std::ffi::OsString>,
+    }
+
+    impl EnvVarGuard {
+        fn remove(key: &'static str) -> Self {
+            let previous = std::env::var_os(key);
+            crate::env::remove_var(key);
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            if let Some(previous) = self.previous.take() {
+                crate::env::set_var(self.key, previous);
+            } else {
+                crate::env::remove_var(self.key);
+            }
+        }
+    }
+
     fn anthropic(has_oauth: bool, has_api_key: bool) -> AuthStatus {
         AuthStatus {
             anthropic: ProviderAuth {
@@ -154,7 +179,8 @@ mod tests {
     fn anthropic_explicit_selection_wins_over_auto() {
         let auth = anthropic(true, true);
         let resolved =
-            resolve_dual_credential_auth(ActiveProvider::Claude, &auth, Some("claude-api")).unwrap();
+            resolve_dual_credential_auth(ActiveProvider::Claude, &auth, Some("claude-api"))
+                .unwrap();
         assert_eq!(resolved.active, ActiveCredential::ApiKey);
         assert!(resolved.explicit);
         let resolved =
@@ -172,6 +198,8 @@ mod tests {
 
     #[test]
     fn anthropic_none_when_unconfigured() {
+        let _api_key = EnvVarGuard::remove("ANTHROPIC_API_KEY");
+        let _auth_token = EnvVarGuard::remove("ANTHROPIC_AUTH_TOKEN");
         let auth = anthropic(false, false);
         assert!(resolve_dual_credential_auth(ActiveProvider::Claude, &auth, None).is_none());
     }

--- a/crates/jcode-base/src/auth/mod.rs
+++ b/crates/jcode-base/src/auth/mod.rs
@@ -452,11 +452,11 @@ impl AuthStatus {
             _ => match provider.auth_state_key {
                 LoginProviderAuthStateKey::Anthropic => {
                     let detail = if self.anthropic.has_oauth && self.anthropic.has_api_key {
-                        "OAuth + API key"
+                        "OAuth + direct auth"
                     } else if self.anthropic.has_oauth {
                         "OAuth"
                     } else if self.anthropic.has_api_key {
-                        "API key"
+                        "direct auth"
                     } else {
                         "not configured"
                     };
@@ -914,6 +914,7 @@ fn assessment_for_key(
             let (source, detail) = summarize_sources(vec![
                 anthropic_oauth_source(status),
                 env_source("ANTHROPIC_API_KEY"),
+                env_source("ANTHROPIC_AUTH_TOKEN"),
             ]);
             (
                 source,

--- a/crates/jcode-base/src/auth/test_sandbox.rs
+++ b/crates/jcode-base/src/auth/test_sandbox.rs
@@ -133,6 +133,7 @@ fn tracked_env_vars() -> Vec<String> {
         "OPENAI_API_KEY",
         "OPENROUTER_API_KEY",
         "ANTHROPIC_API_KEY",
+        "ANTHROPIC_AUTH_TOKEN",
         "AZURE_OPENAI_ENDPOINT",
         "AZURE_OPENAI_MODEL",
         "AZURE_OPENAI_API_KEY",

--- a/crates/jcode-base/src/auth/tests.rs
+++ b/crates/jcode-base/src/auth/tests.rs
@@ -92,6 +92,7 @@ fn full_and_fast_auth_status_match_for_shared_probe_fields() {
         "HOME",
         crate::subscription_catalog::JCODE_API_KEY_ENV,
         "ANTHROPIC_API_KEY",
+        "ANTHROPIC_AUTH_TOKEN",
         "OPENAI_API_KEY",
         "OPENROUTER_API_KEY",
         "JCODE_OPENROUTER_API_BASE",

--- a/crates/jcode-base/src/provider/anthropic.rs
+++ b/crates/jcode-base/src/provider/anthropic.rs
@@ -38,11 +38,14 @@ pub fn is_cache_ttl_1h() -> bool {
     CACHE_TTL_1H.load(Ordering::Relaxed)
 }
 
-/// Anthropic Messages API endpoint
-const API_URL: &str = "https://api.anthropic.com/v1/messages";
+/// Default Anthropic Messages API base.
+const DEFAULT_API_BASE: &str = "https://api.anthropic.com/v1";
 
 /// OAuth endpoint (with beta=true query param)
 const API_URL_OAUTH: &str = "https://api.anthropic.com/v1/messages?beta=true";
+
+const ANTHROPIC_BASE_URL_ENV: &str = "ANTHROPIC_BASE_URL";
+const ANTHROPIC_AUTH_TOKEN_ENV: &str = "ANTHROPIC_AUTH_TOKEN";
 
 /// User-Agent for OAuth requests, matching the official Claude Code CLI.
 pub(crate) const CLAUDE_CLI_USER_AGENT: &str = "claude-cli/2.1.123 (external, sdk-cli)";
@@ -84,6 +87,65 @@ pub(crate) fn apply_oauth_attribution_headers(
         .header("X-Stainless-Runtime-Version", "v24.3.0")
         .header("X-Stainless-Timeout", "600")
         .header("anthropic-dangerous-direct-browser-access", "true")
+}
+
+fn load_anthropic_api_base_override() -> Option<String> {
+    let raw = crate::provider_catalog::load_env_value_from_env_or_config(
+        ANTHROPIC_BASE_URL_ENV,
+        "anthropic.env",
+    )?;
+    match crate::provider_catalog::normalize_api_base(&raw) {
+        Some(base) => Some(base),
+        None => {
+            crate::logging::warn(&format!(
+                "Ignoring invalid {ANTHROPIC_BASE_URL_ENV}='{}'; use https://... or an allowed private http:// host",
+                raw
+            ));
+            None
+        }
+    }
+}
+
+fn anthropic_messages_url_from_base(base: &str) -> String {
+    let base = base.trim_end_matches('/');
+    if base.ends_with("/messages") {
+        base.to_string()
+    } else {
+        format!("{base}/messages")
+    }
+}
+
+fn anthropic_messages_url(auth_kind: AnthropicAuthKind) -> String {
+    if auth_kind.is_oauth() {
+        return API_URL_OAUTH.to_string();
+    }
+
+    let base = load_anthropic_api_base_override().unwrap_or_else(|| DEFAULT_API_BASE.to_string());
+    anthropic_messages_url_from_base(&base)
+}
+
+fn direct_anthropic_model_catalog_auth(
+    token: &str,
+    auth_kind: AnthropicAuthKind,
+) -> Result<crate::provider::AnthropicModelCatalogAuth<'_>> {
+    match auth_kind {
+        AnthropicAuthKind::ApiKey => Ok(crate::provider::AnthropicModelCatalogAuth::ApiKey(token)),
+        AnthropicAuthKind::AuthToken => {
+            Ok(crate::provider::AnthropicModelCatalogAuth::Bearer(token))
+        }
+        AnthropicAuthKind::OAuth => {
+            anyhow::bail!("OAuth Anthropic catalog requests must use the OAuth catalog endpoint")
+        }
+    }
+}
+
+async fn fetch_direct_anthropic_model_catalog(
+    token: &str,
+    auth_kind: AnthropicAuthKind,
+) -> Result<crate::provider::AnthropicModelCatalog> {
+    let base = load_anthropic_api_base_override().unwrap_or_else(|| DEFAULT_API_BASE.to_string());
+    let auth = direct_anthropic_model_catalog_auth(token, auth_kind)?;
+    crate::provider::fetch_anthropic_model_catalog_with_base(&base, auth).await
 }
 
 #[derive(Debug, Clone, Default)]
@@ -428,13 +490,51 @@ impl AnthropicCredentialMode {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AnthropicAuthKind {
+    OAuth,
+    ApiKey,
+    AuthToken,
+}
+
+impl AnthropicAuthKind {
+    fn is_oauth(self) -> bool {
+        matches!(self, Self::OAuth)
+    }
+}
+
 pub(crate) fn load_anthropic_api_key() -> Result<String> {
     crate::provider_catalog::load_api_key_from_env_or_config("ANTHROPIC_API_KEY", "anthropic.env")
         .context("No Anthropic API key found")
 }
 
+fn load_anthropic_auth_token() -> Option<String> {
+    crate::provider_catalog::load_env_value_from_env_or_config(
+        ANTHROPIC_AUTH_TOKEN_ENV,
+        "anthropic.env",
+    )
+}
+
+fn load_anthropic_direct_auth() -> Result<(String, AnthropicAuthKind)> {
+    if load_anthropic_api_base_override().is_some()
+        && let Some(token) = load_anthropic_auth_token()
+    {
+        return Ok((token, AnthropicAuthKind::AuthToken));
+    }
+
+    if let Ok(key) = load_anthropic_api_key() {
+        return Ok((key, AnthropicAuthKind::ApiKey));
+    }
+
+    if let Some(token) = load_anthropic_auth_token() {
+        return Ok((token, AnthropicAuthKind::AuthToken));
+    }
+
+    anyhow::bail!("No Anthropic API key found; set ANTHROPIC_API_KEY or ANTHROPIC_AUTH_TOKEN")
+}
+
 pub(crate) fn has_anthropic_api_key() -> bool {
-    load_anthropic_api_key().is_ok()
+    load_anthropic_direct_auth().is_ok()
 }
 
 /// Direct Anthropic API provider
@@ -464,7 +564,8 @@ impl AnthropicProvider {
     /// resolution path the runtime uses. Returns the bearer token and an
     /// `is_oauth` flag so callers can pick the matching catalog endpoint.
     pub async fn resolve_access_token_for_doctor(&self) -> Result<(String, bool)> {
-        self.get_access_token().await
+        let (token, auth_kind) = self.get_access_token().await?;
+        Ok((token, auth_kind.is_oauth()))
     }
 
     /// Pin the credential mode (OAuth vs API key) for a provider-doctor run.
@@ -493,14 +594,14 @@ impl AnthropicProvider {
     /// live `GET /v1/models` endpoint works and that the model under test is in
     /// the live catalog.
     pub async fn fetch_live_model_ids_for_doctor(&self) -> Result<Vec<String>> {
-        let (token, is_oauth) = self.get_access_token().await?;
+        let (token, auth_kind) = self.get_access_token().await?;
         if token.trim().is_empty() {
             anyhow::bail!("resolved an empty Anthropic access token");
         }
-        let catalog = if is_oauth {
+        let catalog = if auth_kind.is_oauth() {
             crate::provider::fetch_anthropic_model_catalog_oauth(&token).await?
         } else {
-            crate::provider::fetch_anthropic_model_catalog(&token).await?
+            fetch_direct_anthropic_model_catalog(&token, auth_kind).await?
         };
         // Persist so the rest of the process benefits from the warm catalog,
         // exactly like the runtime's own prefetch.
@@ -725,14 +826,13 @@ impl AnthropicProvider {
     /// Get the access token from credentials
     /// Supports both OAuth tokens and direct API keys
     /// Automatically refreshes OAuth tokens when expired
-    async fn get_access_token(&self) -> Result<(String, bool)> {
+    async fn get_access_token(&self) -> Result<(String, AnthropicAuthKind)> {
         let mode = *self.credential_mode.read().await;
 
         // Explicit API-key mode: use the direct API key and surface an error if
         // one is not configured (never silently fall back to OAuth).
         if matches!(mode, AnthropicCredentialMode::ApiKey) {
-            let key = load_anthropic_api_key()?;
-            return Ok((key, false)); // false = not OAuth
+            return load_anthropic_direct_auth();
         }
 
         // Auto mode prefers OAuth (Claude subscription) when credentials are
@@ -742,15 +842,15 @@ impl AnthropicProvider {
         if matches!(mode, AnthropicCredentialMode::Auto)
             && auth::claude::load_credentials().is_err()
         {
-            if let Ok(key) = load_anthropic_api_key() {
-                return Ok((key, false));
+            if let Ok(auth) = load_anthropic_direct_auth() {
+                return Ok(auth);
             }
         }
 
         self.get_oauth_access_token().await
     }
 
-    async fn get_oauth_access_token(&self) -> Result<(String, bool)> {
+    async fn get_oauth_access_token(&self) -> Result<(String, AnthropicAuthKind)> {
         // Check cached credentials
         {
             let cached = self.credentials.read().await;
@@ -758,7 +858,7 @@ impl AnthropicProvider {
                 let now = chrono::Utc::now().timestamp_millis();
                 // Return cached token if not expired (with 5 min buffer)
                 if creds.expires_at > now + 300_000 {
-                    return Ok((creds.access_token.clone(), true));
+                    return Ok((creds.access_token.clone(), AnthropicAuthKind::OAuth));
                 }
             }
         }
@@ -801,7 +901,7 @@ impl AnthropicProvider {
                         expires_at: refreshed.expires_at,
                     });
 
-                    return Ok((refreshed.access_token, true));
+                    return Ok((refreshed.access_token, AnthropicAuthKind::OAuth));
                 }
                 Err(e) => {
                     crate::logging::error(&format!("OAuth token refresh failed: {}", e));
@@ -818,14 +918,14 @@ impl AnthropicProvider {
             expires_at: fresh_creds.expires_at,
         });
 
-        Ok((fresh_creds.access_token, true))
+        Ok((fresh_creds.access_token, AnthropicAuthKind::OAuth))
     }
 
     pub(crate) fn set_credential_mode(&self, mode: AnthropicCredentialMode) -> Result<()> {
         match mode {
             AnthropicCredentialMode::Auto => {}
             AnthropicCredentialMode::ApiKey => {
-                load_anthropic_api_key()?;
+                load_anthropic_direct_auth()?;
             }
             AnthropicCredentialMode::OAuth => {
                 auth::claude::load_credentials().context("Failed to load Claude credentials")?;
@@ -866,7 +966,8 @@ impl AnthropicProvider {
 
     #[cfg(test)]
     pub(crate) async fn test_access_token_and_oauth_mode(&self) -> Result<(String, bool)> {
-        self.get_access_token().await
+        let (token, auth_kind) = self.get_access_token().await?;
+        Ok((token, auth_kind.is_oauth()))
     }
 
     /// Convert our Message type to Anthropic API format
@@ -1068,7 +1169,9 @@ impl AnthropicProvider {
                         signature: signature.clone(),
                     });
                 }
-                ContentBlock::ToolUse { id, name, input, .. } => {
+                ContentBlock::ToolUse {
+                    id, name, input, ..
+                } => {
                     result.push(ApiContentBlock::ToolUse {
                         id: crate::message::sanitize_tool_id(id),
                         name: if is_oauth {
@@ -1272,7 +1375,8 @@ impl Provider for AnthropicProvider {
         system: &str,
         _resume_session_id: Option<&str>,
     ) -> Result<EventStream> {
-        let (token, is_oauth) = self.get_access_token().await?;
+        let (token, auth_kind) = self.get_access_token().await?;
+        let is_oauth = auth_kind.is_oauth();
         if is_oauth {
             ensure_oauth_preflight(
                 &self.client,
@@ -1347,7 +1451,7 @@ impl Provider for AnthropicProvider {
             run_stream_with_retries(
                 client,
                 token,
-                is_oauth,
+                auth_kind,
                 request,
                 tx,
                 credentials,
@@ -1488,12 +1592,12 @@ impl Provider for AnthropicProvider {
     }
 
     async fn prefetch_models(&self) -> Result<()> {
-        let (token, is_oauth) = self.get_access_token().await?;
+        let (token, auth_kind) = self.get_access_token().await?;
         if token.trim().is_empty() {
             return Ok(());
         }
 
-        let catalog = if is_oauth {
+        let catalog = if auth_kind.is_oauth() {
             match crate::provider::fetch_anthropic_model_catalog_oauth(&token).await {
                 Ok(catalog) => catalog,
                 Err(err) => {
@@ -1505,7 +1609,18 @@ impl Provider for AnthropicProvider {
                 }
             }
         } else {
-            crate::provider::fetch_anthropic_model_catalog(&token).await?
+            let custom_base = load_anthropic_api_base_override().is_some();
+            match fetch_direct_anthropic_model_catalog(&token, auth_kind).await {
+                Ok(catalog) => catalog,
+                Err(err) if custom_base => {
+                    crate::logging::warn(&format!(
+                        "Anthropic custom-base model catalog refresh failed; keeping fallback list: {}",
+                        err
+                    ));
+                    return Ok(());
+                }
+                Err(err) => return Err(err),
+            }
         };
         crate::provider::persist_anthropic_model_catalog(&catalog);
         if !catalog.context_limits.is_empty() {
@@ -1565,7 +1680,8 @@ impl Provider for AnthropicProvider {
         system_dynamic: &str,
         _resume_session_id: Option<&str>,
     ) -> Result<EventStream> {
-        let (token, is_oauth) = self.get_access_token().await?;
+        let (token, auth_kind) = self.get_access_token().await?;
+        let is_oauth = auth_kind.is_oauth();
         if is_oauth {
             ensure_oauth_preflight(
                 &self.client,
@@ -1639,7 +1755,7 @@ impl Provider for AnthropicProvider {
             run_stream_with_retries(
                 client,
                 token,
-                is_oauth,
+                auth_kind,
                 request,
                 tx,
                 credentials,
@@ -1660,7 +1776,7 @@ impl Provider for AnthropicProvider {
 async fn run_stream_with_retries(
     client: Client,
     initial_token: String,
-    is_oauth: bool,
+    auth_kind: AnthropicAuthKind,
     request: ApiRequest,
     tx: mpsc::Sender<Result<StreamEvent>>,
     credentials: Arc<RwLock<Option<CachedCredentials>>>,
@@ -1668,6 +1784,7 @@ async fn run_stream_with_retries(
     oauth_session_id: String,
 ) {
     let mut token = initial_token;
+    let is_oauth = auth_kind.is_oauth();
     let mut last_error = None;
     let mut attempted_forced_refresh = false;
 
@@ -1694,7 +1811,7 @@ async fn run_stream_with_retries(
         match stream_response(
             client.clone(),
             token.clone(),
-            is_oauth,
+            auth_kind,
             request.clone(),
             tx.clone(),
             &model_name,
@@ -1818,17 +1935,61 @@ async fn force_refresh_oauth_token(
     Ok(refreshed.access_token)
 }
 
+fn direct_api_beta_header(model_name: &str, thinking_enabled: bool) -> String {
+    let beta_header = if is_1m_model(model_name) {
+        "prompt-caching-2024-07-31,context-1m-2025-08-07"
+    } else {
+        "prompt-caching-2024-07-31"
+    };
+    anthropic_beta_header_with_thinking(beta_header, thinking_enabled)
+}
+
+fn apply_anthropic_auth_headers(
+    req: reqwest::RequestBuilder,
+    token: &str,
+    auth_kind: AnthropicAuthKind,
+    model_name: &str,
+    thinking_enabled: bool,
+    oauth_session_id: &str,
+) -> reqwest::RequestBuilder {
+    match auth_kind {
+        AnthropicAuthKind::OAuth => {
+            let beta_header = anthropic_beta_header_with_thinking(
+                oauth_beta_headers(model_name),
+                thinking_enabled,
+            );
+            apply_oauth_attribution_headers(
+                req.header("Authorization", format!("Bearer {}", token))
+                    .header("User-Agent", CLAUDE_CLI_USER_AGENT)
+                    .header("anthropic-beta", beta_header),
+                oauth_session_id,
+            )
+        }
+        AnthropicAuthKind::ApiKey => req.header("x-api-key", token).header(
+            "anthropic-beta",
+            direct_api_beta_header(model_name, thinking_enabled),
+        ),
+        AnthropicAuthKind::AuthToken => req
+            .header("Authorization", format!("Bearer {}", token))
+            .header(
+                "anthropic-beta",
+                direct_api_beta_header(model_name, thinking_enabled),
+            ),
+    }
+}
+
 /// Stream the response from Anthropic API
 async fn stream_response(
     client: Client,
     token: String,
-    is_oauth: bool,
+    auth_kind: AnthropicAuthKind,
     request: ApiRequest,
     tx: mpsc::Sender<Result<StreamEvent>>,
     model_name: &str,
     oauth_session_id: &str,
 ) -> Result<()> {
     use crate::message::ConnectionPhase;
+    let is_oauth = auth_kind.is_oauth();
     if std::env::var("JCODE_ANTHROPIC_DEBUG")
         .map(|v| v == "1")
         .unwrap_or(false)
@@ -1845,10 +2006,10 @@ async fn stream_response(
 
     let connect_start = std::time::Instant::now();
     // Build request with appropriate auth headers
-    let url = if is_oauth { API_URL_OAUTH } else { API_URL };
+    let url = anthropic_messages_url(auth_kind);
 
     let mut req = client
-        .post(url)
+        .post(&url)
         .header("anthropic-version", API_VERSION)
         .header("content-type", "application/json")
         .header(
@@ -1860,36 +2021,14 @@ async fn stream_response(
             },
         );
 
-    if is_oauth {
-        // OAuth tokens require:
-        // 1. Bearer auth (NOT x-api-key)
-        // 2. User-Agent matching Claude CLI
-        // 3. Multiple beta headers
-        // 4. ?beta=true query param (in URL above)
-        let beta_header = anthropic_beta_header_with_thinking(
-            oauth_beta_headers(model_name),
-            request.thinking.is_some(),
-        );
-        req = apply_oauth_attribution_headers(
-            req.header("Authorization", format!("Bearer {}", token))
-                .header("User-Agent", CLAUDE_CLI_USER_AGENT)
-                .header("anthropic-beta", beta_header),
-            oauth_session_id,
-        );
-    } else {
-        // Direct API keys use x-api-key
-        // Include prompt-caching beta header
-        let beta_header = if is_1m_model(model_name) {
-            "prompt-caching-2024-07-31,context-1m-2025-08-07"
-        } else {
-            "prompt-caching-2024-07-31"
-        };
-        let beta_header =
-            anthropic_beta_header_with_thinking(beta_header, request.thinking.is_some());
-        req = req
-            .header("x-api-key", &token)
-            .header("anthropic-beta", beta_header);
-    }
+    req = apply_anthropic_auth_headers(
+        req,
+        &token,
+        auth_kind,
+        model_name,
+        request.thinking.is_some(),
+        oauth_session_id,
+    );
 
     let response = req
         .json(&request)

--- a/crates/jcode-base/src/provider/anthropic_tests.rs
+++ b/crates/jcode-base/src/provider/anthropic_tests.rs
@@ -6,6 +6,18 @@ struct EnvVarGuard {
 }
 
 impl EnvVarGuard {
+    fn set(key: &'static str, value: &str) -> Self {
+        let previous = std::env::var_os(key);
+        crate::env::set_var(key, value);
+        Self { key, previous }
+    }
+
+    fn remove(key: &'static str) -> Self {
+        let previous = std::env::var_os(key);
+        crate::env::remove_var(key);
+        Self { key, previous }
+    }
+
     fn set_if_missing(key: &'static str, value: &str) -> Option<Self> {
         if std::env::var_os(key).is_some() {
             return None;
@@ -75,6 +87,105 @@ async fn test_available_models() {
     assert!(models.contains(&"claude-sonnet-4-6"));
     assert!(models.contains(&"claude-sonnet-4-6[1m]"));
     assert!(models.contains(&"claude-haiku-4-5"));
+}
+
+#[test]
+fn anthropic_messages_url_defaults_to_official_api_base() {
+    let _lock = crate::storage::lock_test_env();
+    let temp = tempfile::tempdir().expect("temp jcode home");
+    let _home = EnvVarGuard::set("JCODE_HOME", temp.path().to_string_lossy().as_ref());
+    let _base = EnvVarGuard::remove("ANTHROPIC_BASE_URL");
+
+    assert_eq!(
+        anthropic_messages_url(AnthropicAuthKind::ApiKey),
+        "https://api.anthropic.com/v1/messages"
+    );
+    assert_eq!(
+        anthropic_messages_url(AnthropicAuthKind::OAuth),
+        "https://api.anthropic.com/v1/messages?beta=true"
+    );
+}
+
+#[test]
+fn anthropic_messages_url_uses_configured_base_url() {
+    let _lock = crate::storage::lock_test_env();
+    let temp = tempfile::tempdir().expect("temp jcode home");
+    let _home = EnvVarGuard::set("JCODE_HOME", temp.path().to_string_lossy().as_ref());
+    let _base = EnvVarGuard::set(
+        "ANTHROPIC_BASE_URL",
+        "http://127.0.0.1:15721/claude-desktop/v1/",
+    );
+
+    assert_eq!(
+        anthropic_messages_url(AnthropicAuthKind::ApiKey),
+        "http://127.0.0.1:15721/claude-desktop/v1/messages"
+    );
+}
+
+#[test]
+fn direct_auth_prefers_auth_token_for_configured_base_url() {
+    let _lock = crate::storage::lock_test_env();
+    let temp = tempfile::tempdir().expect("temp jcode home");
+    let _home = EnvVarGuard::set("JCODE_HOME", temp.path().to_string_lossy().as_ref());
+    let _base = EnvVarGuard::set(
+        "ANTHROPIC_BASE_URL",
+        "http://127.0.0.1:15721/claude-desktop/v1",
+    );
+    let _api_key = EnvVarGuard::set("ANTHROPIC_API_KEY", "sk-ant-test");
+    let _auth_token = EnvVarGuard::set("ANTHROPIC_AUTH_TOKEN", "gateway-token");
+
+    let (token, auth_kind) = load_anthropic_direct_auth().expect("direct auth");
+
+    assert_eq!(token, "gateway-token");
+    assert_eq!(auth_kind, AnthropicAuthKind::AuthToken);
+}
+
+#[test]
+fn direct_api_key_requests_keep_x_api_key_auth() {
+    let request = reqwest::Client::new().post("http://127.0.0.1:1/v1/messages");
+    let request = apply_anthropic_auth_headers(
+        request,
+        "sk-ant-test",
+        AnthropicAuthKind::ApiKey,
+        "claude-sonnet-4-6",
+        false,
+        "session",
+    )
+    .build()
+    .expect("request");
+
+    assert_eq!(
+        request
+            .headers()
+            .get("x-api-key")
+            .and_then(|v| v.to_str().ok()),
+        Some("sk-ant-test")
+    );
+    assert!(request.headers().get("authorization").is_none());
+}
+
+#[test]
+fn auth_token_requests_use_bearer_auth() {
+    let request = reqwest::Client::new().post("http://127.0.0.1:1/v1/messages");
+    let request = apply_anthropic_auth_headers(
+        request,
+        "gateway-token",
+        AnthropicAuthKind::AuthToken,
+        "claude-sonnet-4-6",
+        false,
+        "session",
+    )
+    .build()
+    .expect("request");
+
+    assert_eq!(
+        request
+            .headers()
+            .get("authorization")
+            .and_then(|v| v.to_str().ok()),
+        Some("Bearer gateway-token")
+    );
+    assert!(request.headers().get("x-api-key").is_none());
 }
 
 #[test]
@@ -474,11 +585,15 @@ async fn test_dangling_tool_use_repair() {
                 ContentBlock::ToolUse {
                     id: "tool_123".to_string(),
                     name: "bash".to_string(),
-                    input: serde_json::json!({"command": "ls"}), thought_signature: None, },
+                    input: serde_json::json!({"command": "ls"}),
+                    thought_signature: None,
+                },
                 ContentBlock::ToolUse {
                     id: "tool_456".to_string(),
                     name: "read".to_string(),
-                    input: serde_json::json!({"file_path": "/tmp/test"}), thought_signature: None, },
+                    input: serde_json::json!({"file_path": "/tmp/test"}),
+                    thought_signature: None,
+                },
             ],
             timestamp: None,
             tool_duration_ms: None,
@@ -542,7 +657,9 @@ async fn test_no_repair_when_tool_results_present() {
             content: vec![ContentBlock::ToolUse {
                 id: "tool_123".to_string(),
                 name: "bash".to_string(),
-                input: serde_json::json!({"command": "ls"}), thought_signature: None, }],
+                input: serde_json::json!({"command": "ls"}),
+                thought_signature: None,
+            }],
             timestamp: None,
             tool_duration_ms: None,
         },
@@ -616,15 +733,21 @@ async fn test_parallel_image_tool_results_stay_contiguous() {
                 ContentBlock::ToolUse {
                     id: "tool_a".to_string(),
                     name: "read".to_string(),
-                    input: serde_json::json!({"file_path": "a.png"}), thought_signature: None, },
+                    input: serde_json::json!({"file_path": "a.png"}),
+                    thought_signature: None,
+                },
                 ContentBlock::ToolUse {
                     id: "tool_b".to_string(),
                     name: "read".to_string(),
-                    input: serde_json::json!({"file_path": "b.png"}), thought_signature: None, },
+                    input: serde_json::json!({"file_path": "b.png"}),
+                    thought_signature: None,
+                },
                 ContentBlock::ToolUse {
                     id: "tool_c".to_string(),
                     name: "read".to_string(),
-                    input: serde_json::json!({"file_path": "c.png"}), thought_signature: None, },
+                    input: serde_json::json!({"file_path": "c.png"}),
+                    thought_signature: None,
+                },
             ],
             timestamp: None,
             tool_duration_ms: None,
@@ -1157,7 +1280,9 @@ async fn test_sanitize_tool_ids_with_dots() {
             content: vec![ContentBlock::ToolUse {
                 id: "chatcmpl-BF2xX.tool_call.0".to_string(),
                 name: "bash".to_string(),
-                input: serde_json::json!({"command": "ls"}), thought_signature: None, }],
+                input: serde_json::json!({"command": "ls"}),
+                thought_signature: None,
+            }],
             timestamp: None,
             tool_duration_ms: None,
         },
@@ -1210,7 +1335,9 @@ async fn test_sanitize_dangling_tool_ids_with_dots() {
             content: vec![ContentBlock::ToolUse {
                 id: "call.with.dots".to_string(),
                 name: "bash".to_string(),
-                input: serde_json::json!({"command": "crash"}), thought_signature: None, }],
+                input: serde_json::json!({"command": "crash"}),
+                thought_signature: None,
+            }],
             timestamp: None,
             tool_duration_ms: None,
         },

--- a/crates/jcode-base/src/provider/mod.rs
+++ b/crates/jcode-base/src/provider/mod.rs
@@ -232,13 +232,13 @@ pub fn set_model_with_auth_refresh(provider: &dyn Provider, model: &str) -> Resu
 use self::dispatch::CompletionMode;
 pub use self::models::{
     AccountModelAvailability, AccountModelAvailabilityState, AnthropicModelCatalog,
-    OpenAIModelCatalog, begin_anthropic_model_catalog_refresh, begin_openai_model_catalog_refresh,
-    cached_anthropic_model_ids, cached_openai_model_ids,
+    AnthropicModelCatalogAuth, OpenAIModelCatalog, begin_anthropic_model_catalog_refresh,
+    begin_openai_model_catalog_refresh, cached_anthropic_model_ids, cached_openai_model_ids,
     clear_all_model_unavailability_for_account, clear_all_provider_unavailability_for_account,
     clear_model_unavailable_for_account, clear_provider_unavailable_for_account,
     context_limit_for_model, context_limit_for_model_with_provider, fetch_anthropic_model_catalog,
-    fetch_anthropic_model_catalog_oauth, fetch_openai_api_key_model_catalog,
-    fetch_openai_context_limits, fetch_openai_model_catalog,
+    fetch_anthropic_model_catalog_oauth, fetch_anthropic_model_catalog_with_base,
+    fetch_openai_api_key_model_catalog, fetch_openai_context_limits, fetch_openai_model_catalog,
     finish_anthropic_model_catalog_refresh_for_scope, finish_openai_model_catalog_refresh,
     format_account_model_availability_detail, get_best_available_openai_model,
     is_model_available_for_account, known_anthropic_model_ids, known_openai_model_ids,

--- a/crates/jcode-base/src/provider/models.rs
+++ b/crates/jcode-base/src/provider/models.rs
@@ -10,8 +10,9 @@ use anyhow::Result;
 #[cfg(test)]
 pub(crate) use catalog::parse_anthropic_model_catalog;
 pub use catalog::{
-    AnthropicModelCatalog, OpenAIModelCatalog, fetch_anthropic_model_catalog,
-    fetch_anthropic_model_catalog_oauth, fetch_openai_api_key_model_catalog,
+    AnthropicModelCatalog, AnthropicModelCatalogAuth, OpenAIModelCatalog,
+    fetch_anthropic_model_catalog, fetch_anthropic_model_catalog_oauth,
+    fetch_anthropic_model_catalog_with_base, fetch_openai_api_key_model_catalog,
     fetch_openai_context_limits, fetch_openai_model_catalog,
 };
 use catalog_service::{ModelCatalogService, RuntimeModelUnavailability};

--- a/crates/jcode-base/src/provider/models_catalog.rs
+++ b/crates/jcode-base/src/provider/models_catalog.rs
@@ -12,6 +12,12 @@ pub struct AnthropicModelCatalog {
     pub context_limits: HashMap<String, usize>,
 }
 
+#[derive(Debug, Clone, Copy)]
+pub enum AnthropicModelCatalogAuth<'a> {
+    ApiKey(&'a str),
+    Bearer(&'a str),
+}
+
 pub(crate) fn parse_anthropic_model_catalog(data: &serde_json::Value) -> AnthropicModelCatalog {
     let models = data
         .get("data")
@@ -119,13 +125,44 @@ pub async fn fetch_openai_model_catalog(access_token: &str) -> Result<OpenAIMode
     Ok(parse_openai_model_catalog(&data))
 }
 
+const DEFAULT_ANTHROPIC_API_BASE: &str = "https://api.anthropic.com/v1";
+
+pub(crate) fn anthropic_model_catalog_url_from_base(api_base: &str) -> String {
+    let base = api_base.trim_end_matches('/');
+    if base.ends_with("/models") {
+        base.to_string()
+    } else if let Some(api_base) = base.strip_suffix("/messages") {
+        format!("{api_base}/models")
+    } else {
+        format!("{base}/models")
+    }
+}
+
 pub async fn fetch_anthropic_model_catalog(api_key: &str) -> Result<AnthropicModelCatalog> {
+    fetch_anthropic_model_catalog_with_base(
+        DEFAULT_ANTHROPIC_API_BASE,
+        AnthropicModelCatalogAuth::ApiKey(api_key),
+    )
+    .await
+}
+
+pub async fn fetch_anthropic_model_catalog_with_base(
+    api_base: &str,
+    auth: AnthropicModelCatalogAuth<'_>,
+) -> Result<AnthropicModelCatalog> {
+    let url = anthropic_model_catalog_url_from_base(api_base);
     fetch_anthropic_model_catalog_with_request(|client, after_id| {
         let mut req = client
-            .get("https://api.anthropic.com/v1/models")
-            .header("x-api-key", api_key)
+            .get(&url)
             .header("anthropic-version", "2023-06-01")
             .query(&[("limit", "1000")]);
+
+        req = match auth {
+            AnthropicModelCatalogAuth::ApiKey(api_key) => req.header("x-api-key", api_key),
+            AnthropicModelCatalogAuth::Bearer(token) => {
+                req.header("Authorization", format!("Bearer {}", token))
+            }
+        };
 
         if let Some(after) = after_id {
             req = req.query(&[("after_id", after)]);
@@ -213,6 +250,35 @@ where
         available_models,
         context_limits: limits,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn anthropic_model_catalog_url_appends_models_to_base_url() {
+        assert_eq!(
+            anthropic_model_catalog_url_from_base("http://127.0.0.1:15721/anthropic/v1/"),
+            "http://127.0.0.1:15721/anthropic/v1/models"
+        );
+    }
+
+    #[test]
+    fn anthropic_model_catalog_url_keeps_explicit_models_endpoint() {
+        assert_eq!(
+            anthropic_model_catalog_url_from_base("https://example.test/v1/models"),
+            "https://example.test/v1/models"
+        );
+    }
+
+    #[test]
+    fn anthropic_model_catalog_url_replaces_explicit_messages_endpoint() {
+        assert_eq!(
+            anthropic_model_catalog_url_from_base("https://example.test/v1/messages"),
+            "https://example.test/v1/models"
+        );
+    }
 }
 
 /// Fetch model availability from the OpenAI platform API using an API key.


### PR DESCRIPTION
Closes #325

## Summary

- Honor `ANTHROPIC_BASE_URL` for non-OAuth direct Anthropic Messages requests and model-catalog refreshes.
- Add `ANTHROPIC_AUTH_TOKEN` support for bearer-token Anthropic-compatible gateways/proxies.
- Preserve existing behavior for Claude OAuth and official Anthropic API keys: OAuth stays on the official OAuth endpoint, and API keys keep using `x-api-key`.
- Update Anthropic auth-status detection and test env isolation so bearer-token direct auth is visible without polluting unrelated tests.

## Validation

- `cargo test -p jcode-base provider::anthropic --lib`
- `cargo test -p jcode-base provider::models::catalog --lib`
- `cargo test -p jcode-base auth::active_method --lib`
- `cargo test -p jcode-base full_and_fast_auth_status_match_for_shared_probe_fields --lib`
- `cargo check -p jcode-base --all-targets`
- `rustfmt --edition 2024 --config skip_children=true --check <touched Rust files>`

## Local notes

- `cargo fmt --all -- --check` reports unrelated formatting churn in untouched modules with my local stable Rust 1.96 checkout.
- `cargo clippy -p jcode-base --lib -- -D warnings` currently stops on pre-existing warnings outside this patch (`jcode-core/src/stdin_detect.rs`, `jcode-render-core/src/markdown.rs`).
- `cargo check -p jcode-base --all-targets --all-features` is not a clean Windows local signal here: it stops in `tikv-jemalloc-sys` before checking this patch because the Windows/MSVC all-features path expects a Unix `sh`/jemalloc configure environment.