### PR TITLE
Support custom base URL for OpenAI Responses API

### DIFF
--- a/crates/jcode-base/src/provider/openai.rs
+++ b/crates/jcode-base/src/provider/openai.rs
@@ -29,6 +29,10 @@ const CHATGPT_API_BASE: &str = "https://chatgpt.com/backend-api/codex";
 const RESPONSES_PATH: &str = "responses";
 const DEFAULT_MODEL: &str = "gpt-5.5";
 const ORIGINATOR: &str = "codex_cli_rs";
+const OPENAI_API_BASE_ENV: &str = "OPENAI_API_BASE";
+const OPENAI_BASE_URL_ENV: &str = "OPENAI_BASE_URL";
+const JCODE_OPENAI_API_BASE_ENV: &str = "JCODE_OPENAI_API_BASE";
+const OPENAI_ENV_FILE: &str = "openai.env";
 
 /// Maximum number of retries for transient errors
 const MAX_RETRIES: u32 = 3;
@@ -836,11 +840,42 @@ impl OpenAIProvider {
         parsed
     }
 
+    fn configured_openai_api_base() -> &'static str {
+        static CONFIGURED_BASE: LazyLock<String> = LazyLock::new(|| {
+            for env_key in [
+                JCODE_OPENAI_API_BASE_ENV,
+                OPENAI_API_BASE_ENV,
+                OPENAI_BASE_URL_ENV,
+            ] {
+                if let Some(raw) = crate::provider_catalog::load_env_value_from_env_or_config(
+                    env_key,
+                    OPENAI_ENV_FILE,
+                ) {
+                    if let Some(normalized) = crate::provider_catalog::normalize_api_base(&raw) {
+                        crate::logging::info(&format!(
+                            "OpenAI API base configured via {}: {}",
+                            env_key, normalized
+                        ));
+                        return normalized;
+                    }
+                    crate::logging::warn(&format!(
+                        "Ignoring invalid {}='{}'; use https://... or http://localhost/private-lan.",
+                        env_key, raw
+                    ));
+                }
+            }
+
+            OPENAI_API_BASE.to_string()
+        });
+
+        CONFIGURED_BASE.as_str()
+    }
+
     fn responses_url(credentials: &CodexCredentials) -> String {
         let base = if Self::is_chatgpt_mode(credentials) {
             CHATGPT_API_BASE
         } else {
-            OPENAI_API_BASE
+            Self::configured_openai_api_base()
         };
         format!("{}/{}", base.trim_end_matches('/'), RESPONSES_PATH)
     }

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -190,11 +190,11 @@ pub(crate) enum Command {
         #[arg(long, value_enum)]
         google_access_tier: Option<GoogleAccessTierArg>,
 
-        /// OpenAI-compatible API base URL. Used with --provider openai-compatible/custom profiles.
+        /// API base URL. Used with --provider openai-api for native Responses API or --provider openai-compatible/custom profiles.
         #[arg(long)]
         api_base: Option<String>,
 
-        /// OpenAI-compatible API key. If omitted, jcode prompts securely when needed.
+        /// API key. Used with --provider openai-api or OpenAI-compatible providers. If omitted, jcode prompts securely when needed.
         #[arg(long)]
         api_key: Option<String>,
 

--- a/src/cli/login.rs
+++ b/src/cli/login.rs
@@ -282,7 +282,7 @@ pub async fn run_login_provider(
                 .await
                 .map(|_| LoginFlowOutcome::Completed),
             LoginProviderTarget::OpenAiApiKey => {
-                login_openai_api_key_flow().map(|_| LoginFlowOutcome::Completed)
+                login_openai_api_key_flow(&options).map(|_| LoginFlowOutcome::Completed)
             }
             LoginProviderTarget::OpenRouter => {
                 login_openrouter_flow().map(|_| LoginFlowOutcome::Completed)
@@ -512,13 +512,16 @@ fn login_jcode_flow() -> Result<()> {
     Ok(())
 }
 
-fn login_openai_api_key_flow() -> Result<()> {
+fn login_openai_api_key_flow(options: &LoginOptions) -> Result<()> {
     eprintln!("Setting up OpenAI API key...");
     eprintln!("Get your API key from: https://platform.openai.com/api-keys\n");
-    eprint!("Paste your OpenAI API key: ");
-    io::stdout().flush()?;
-
-    let key = read_secret_line()?;
+    let key = if let Some(key) = options.openai_compatible_api_key.as_deref() {
+        key.trim().to_string()
+    } else {
+        eprint!("Paste your OpenAI API key: ");
+        io::stdout().flush()?;
+        read_secret_line()?
+    };
     if key.is_empty() {
         anyhow::bail!("No API key provided.");
     }
@@ -527,6 +530,15 @@ fn login_openai_api_key_flow() -> Result<()> {
     }
 
     save_named_api_key("openai.env", "OPENAI_API_KEY", &key)?;
+    if let Some(api_base) = options.openai_compatible_api_base.as_deref() {
+        let api_base = crate::provider_catalog::normalize_api_base(api_base).ok_or_else(|| {
+            anyhow::anyhow!(
+                "Invalid OpenAI API base URL '{}'. Use https://... or http://localhost/private-lan.",
+                api_base
+            )
+        })?;
+        save_named_api_key("openai.env", "JCODE_OPENAI_API_BASE", &api_base)?;
+    }
     eprintln!("\nSuccessfully saved OpenAI API key!");
     eprintln!(
         "Stored at {}",
@@ -535,6 +547,9 @@ fn login_openai_api_key_flow() -> Result<()> {
             .display()
     );
     eprintln!("Provider: openai-api (native OpenAI Responses API)");
+    if options.openai_compatible_api_base.is_some() {
+        eprintln!("Base URL: custom native Responses API endpoint");
+    }
     crate::telemetry::record_auth_success("openai-api", "api_key");
     Ok(())
 }


### PR DESCRIPTION
Closes #343

## Problem

The native `openai-api` provider uses the OpenAI Responses API, but its base URL was hardcoded to `https://api.openai.com/v1`. Users with a local or proxied Responses API endpoint could only configure `openai-compatible`, which is the wrong protocol path because it targets OpenAI-compatible chat/completions rather than native `/responses`.

## Summary

- Allow native `openai-api` Responses API requests to use a custom API base URL.
- Read the custom base URL from `JCODE_OPENAI_API_BASE`, `OPENAI_API_BASE`, or `OPENAI_BASE_URL`, including values saved in `openai.env`.
- Support non-interactive setup via:

```bash
jcode login openai-api \
  --api-base http://127.0.0.1:8317/v1 \
  --api-key '<key>' \
  --model gpt-5.5
```

- Keep `openai-compatible` separate and unchanged.
- Keep ChatGPT/OAuth mode on the existing ChatGPT backend URL.

## Edge cases and tradeoffs

- The custom base URL only affects non-ChatGPT native OpenAI API-key mode. ChatGPT OAuth/subscription mode still uses `https://chatgpt.com/backend-api/codex`.
- URL validation reuses the existing `normalize_api_base` policy, so HTTPS is accepted and private/local HTTP endpoints are allowed, while unsafe public HTTP endpoints are rejected.
- Env precedence is `JCODE_OPENAI_API_BASE`, then `OPENAI_API_BASE`, then `OPENAI_BASE_URL`.

## Validation

- `cargo check -p jcode-base -p jcode --bin jcode`
- Built local debug binary and verified native `openai-api` against a local Responses endpoint:

```bash
/Users/xd/.jcode/source/jcode/target/debug/jcode \
  --socket /tmp/jcode-openai-base-test.sock \
  -p openai-api -m gpt-5.5 \
  run 'Reply exactly JCODE_RESPONSES_BASE_OK'
```

Result:

```text
JCODE_RESPONSES_BASE_OK
```
