### PR TITLE
Triage fixes: install.sh, /config edit, FreeBSD, .agents skills, MCP compat, retry fail-fast, terminal config

### DIFF
--- a/.github/workflows/freebsd-smoke.yml
+++ b/.github/workflows/freebsd-smoke.yml
@@ -1,0 +1,88 @@
+name: FreeBSD Smoke
+
+# Builds and smoke-tests jcode inside a real FreeBSD VM.
+#
+# GitHub does not offer native FreeBSD runners, so we boot a FreeBSD guest
+# (via QEMU) on a standard Ubuntu runner using vmactions/freebsd-vm. This runs
+# the actual FreeBSD kernel and userland, giving a true build + run check
+# instead of a cross-compile that can never link platform C dependencies
+# (e.g. aws-lc-sys). See issue #416.
+
+on:
+  workflow_dispatch:
+    inputs:
+      release:
+        description: Build in release mode (slower, matches shipping binary)
+        required: false
+        default: false
+        type: boolean
+  push:
+    paths:
+      - '.github/workflows/freebsd-smoke.yml'
+  schedule:
+    # Weekly drift check so FreeBSD breakage is caught even without a push.
+    - cron: '0 7 * * 1'
+
+concurrency:
+  group: freebsd-smoke-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  smoke:
+    name: FreeBSD Smoke (x86_64)
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Build and test in FreeBSD VM
+        uses: vmactions/freebsd-vm@v1
+        with:
+          release: "14.2"
+          usesh: true
+          # Give the build VM enough room: aws-lc-sys + tract pull in heavy C/Rust.
+          mem: 6144
+          cpu: 4
+          # Install the toolchain jcode needs. The project is OpenSSL-free
+          # (rustls + aws-lc-rs), so we only need a C/C++ toolchain, cmake, and
+          # rust. pkgconf is handy for any transitive pkg-config probes.
+          prepare: |
+            pkg install -y rust cmake gmake pkgconf bash git
+          # CARGO_BUILD_JOBS keeps memory in check; aws-lc-sys is memory hungry.
+          run: |
+            set -e
+            echo "::group::Toolchain versions"
+            uname -a
+            cc --version | head -1
+            cargo --version
+            rustc --version
+            echo "::endgroup::"
+
+            export CARGO_TERM_COLOR=always
+            export CARGO_BUILD_JOBS=3
+
+            if [ "${{ inputs.release }}" = "true" ]; then
+              PROFILE_FLAG="--release"
+              TARGET_DIR="release"
+            else
+              PROFILE_FLAG=""
+              TARGET_DIR="debug"
+            fi
+
+            echo "::group::cargo build (jcode binary)"
+            cargo build --locked $PROFILE_FLAG -p jcode --bin jcode
+            echo "::endgroup::"
+
+            echo "::group::Verify binary launches"
+            ./target/$TARGET_DIR/jcode --version
+            echo "::endgroup::"
+
+            echo "::group::Compile platform unit tests"
+            cargo test --locked $PROFILE_FLAG -p jcode-base --lib --no-run
+            echo "::endgroup::"
+
+            echo "::group::Run platform unit tests"
+            cargo test --locked $PROFILE_FLAG -p jcode-base --lib -- --nocapture platform
+            echo "::endgroup::"

--- a/README.md
+++ b/README.md
@@ -501,15 +501,19 @@ Primary config files:
 - `~/.jcode/mcp.json` for global MCP servers
 - `.jcode/mcp.json` for project-local MCP servers
 
-Compatibility fallback:
+Claude Code compatibility:
 
-- `.claude/mcp.json`
+- `~/.claude.json` (Claude Code's user config): top-level `mcpServers`, plus per-project servers under `projects.<abs_path>.mcpServers` for the current directory
+- `.mcp.json` at the repo root (Claude Code's project config)
+- `.claude/mcp.json` (legacy fallback)
+
+Both the canonical `mcpServers` key and jcode's historical `servers` key are accepted. jcode currently supports stdio (command-based) servers only; HTTP/SSE entries (`"type": "http"`/`"sse"`) are recognized and skipped with a log line.
 
 Example MCP config:
 
 ```json
 {
-  "servers": {
+  "mcpServers": {
     "filesystem": {
       "command": "/path/to/mcp-server",
       "args": ["--root", "/workspace"],
@@ -520,7 +524,7 @@ Example MCP config:
 }
 ```
 
-On first run, jcode also tries to import MCP servers from `~/.claude/mcp.json` and `~/.codex/config.toml` if `~/.jcode/mcp.json` does not exist yet.
+On first run, jcode also tries to import MCP servers from `~/.claude.json` (falling back to the legacy `~/.claude/mcp.json`) and `~/.codex/config.toml` if `~/.jcode/mcp.json` does not exist yet.
 
 For headless or SSH sessions, OAuth-style providers support `jcode login --provider <provider> --no-browser` (alias: `--headless`) so jcode prints the auth URL/QR and falls back to manual code or callback paste instead of trying to launch a local browser.
 

--- a/crates/jcode-app-core/src/tool/mcp.rs
+++ b/crates/jcode-app-core/src/tool/mcp.rs
@@ -205,6 +205,8 @@ impl McpManagementTool {
             args: params.args.unwrap_or_default(),
             env: params.env.unwrap_or_default(),
             shared: true,
+            transport: None,
+            url: None,
         };
 
         let manager = self.manager.read().await;

--- a/crates/jcode-base/src/auth/cursor.rs
+++ b/crates/jcode-base/src/auth/cursor.rs
@@ -249,6 +249,12 @@ fn cursor_vscdb_paths() -> Vec<PathBuf> {
         "AppData/Roaming/Cursor/User/globalStorage/state.vscdb",
         "AppData/Roaming/cursor/User/globalStorage/state.vscdb",
     ];
+    // Other Unix platforms (e.g. FreeBSD) follow the XDG-style layout like Linux.
+    #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
+    let relatives = [
+        ".config/Cursor/User/globalStorage/state.vscdb",
+        ".config/cursor/User/globalStorage/state.vscdb",
+    ];
 
     relatives
         .into_iter()

--- a/crates/jcode-base/src/config/default_file.rs
+++ b/crates/jcode-base/src/config/default_file.rs
@@ -383,6 +383,13 @@ swarm_spawn_mode = "visible"
 # Example:
 #   focus_hook = "~/bin/jcode-focus-router"
 # focus_hook = ""
+#
+# macOS only: terminal that the Cmd+; launch hotkey and in-app session spawns
+# open jcode into. One of: ghostty, iterm2, wezterm, warp, alacritty, vscode,
+# terminal (Apple Terminal). Preferred over the legacy
+# ~/.jcode/preferred_terminal.json file. After changing this, re-run
+# `jcode setup-hotkey` so the generated launcher script (Cmd+;) picks it up.
+# preferred = "ghostty"
 
 [notifications]
 # Desktop notifications for interactive sessions (macOS Notification Center /

--- a/crates/jcode-base/src/config_tests.rs
+++ b/crates/jcode-base/src/config_tests.rs
@@ -120,6 +120,15 @@ fn spawn_hook_defaults_to_none_and_parses_from_toml() {
 }
 
 #[test]
+fn terminal_preferred_defaults_to_none_and_parses_from_toml() {
+    assert_eq!(Config::default().terminal.preferred, None);
+
+    let cfg: Config = toml::from_str("[terminal]\npreferred = \"ghostty\"\n")
+        .expect("preferred should parse");
+    assert_eq!(cfg.terminal.preferred.as_deref(), Some("ghostty"));
+}
+
+#[test]
 fn hooks_config_defaults_and_parses_from_toml() {
     let defaults = Config::default().hooks;
     assert_eq!(defaults.turn_start, None);

--- a/crates/jcode-base/src/config_tests.rs
+++ b/crates/jcode-base/src/config_tests.rs
@@ -123,8 +123,8 @@ fn spawn_hook_defaults_to_none_and_parses_from_toml() {
 fn terminal_preferred_defaults_to_none_and_parses_from_toml() {
     assert_eq!(Config::default().terminal.preferred, None);
 
-    let cfg: Config = toml::from_str("[terminal]\npreferred = \"ghostty\"\n")
-        .expect("preferred should parse");
+    let cfg: Config =
+        toml::from_str("[terminal]\npreferred = \"ghostty\"\n").expect("preferred should parse");
     assert_eq!(cfg.terminal.preferred.as_deref(), Some("ghostty"));
 }
 

--- a/crates/jcode-base/src/mcp/manager.rs
+++ b/crates/jcode-base/src/mcp/manager.rs
@@ -492,6 +492,8 @@ mod tests {
                 args: vec![],
                 env: HashMap::new(),
                 shared: false,
+                transport: None,
+                url: None,
             },
         );
         let manager = McpManager::with_config(config);

--- a/crates/jcode-base/src/mcp/protocol.rs
+++ b/crates/jcode-base/src/mcp/protocol.rs
@@ -383,10 +383,9 @@ impl McpConfig {
 
         // Global servers under top-level `mcpServers`.
         if let Some(map) = value.get("mcpServers")
-            && let Ok(servers) =
-                serde_json::from_value::<std::collections::HashMap<String, McpServerConfig>>(
-                    map.clone(),
-                )
+            && let Ok(servers) = serde_json::from_value::<
+                std::collections::HashMap<String, McpServerConfig>,
+            >(map.clone())
         {
             config.servers.extend(servers);
         }
@@ -398,10 +397,9 @@ impl McpConfig {
             let cwd_str = cwd.to_string_lossy();
             if let Some(project) = projects.get(cwd_str.as_ref())
                 && let Some(map) = project.get("mcpServers")
-                && let Ok(servers) =
-                    serde_json::from_value::<std::collections::HashMap<String, McpServerConfig>>(
-                        map.clone(),
-                    )
+                && let Ok(servers) = serde_json::from_value::<
+                    std::collections::HashMap<String, McpServerConfig>,
+                >(map.clone())
             {
                 config.servers.extend(servers);
             }

--- a/crates/jcode-base/src/mcp/protocol.rs
+++ b/crates/jcode-base/src/mcp/protocol.rs
@@ -169,6 +169,9 @@ pub struct ResourceContent {
 /// MCP server configuration
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct McpServerConfig {
+    /// Command for stdio servers. Empty for HTTP/SSE servers, which jcode does
+    /// not yet support (such entries are skipped at load time).
+    #[serde(default)]
     pub command: String,
     #[serde(default)]
     pub args: Vec<String>,
@@ -179,6 +182,28 @@ pub struct McpServerConfig {
     /// Stateful servers (Playwright browser) should not be shared.
     #[serde(default = "default_shared")]
     pub shared: bool,
+    /// Transport type from Claude Code configs ("stdio", "http", "sse"). Used
+    /// only to recognize and skip non-stdio servers; defaults to stdio.
+    #[serde(rename = "type", default, skip_serializing_if = "Option::is_none")]
+    pub transport: Option<String>,
+    /// URL for HTTP/SSE servers (Claude Code compat). Unused by jcode today.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+}
+
+impl McpServerConfig {
+    /// jcode currently only supports stdio (command-based) MCP servers. A config
+    /// entry is stdio when it has a command and is not explicitly an http/sse
+    /// transport.
+    pub fn is_stdio(&self) -> bool {
+        if let Some(t) = &self.transport {
+            let t = t.to_ascii_lowercase();
+            if t == "http" || t == "sse" || t == "streamable-http" {
+                return false;
+            }
+        }
+        !self.command.trim().is_empty()
+    }
 }
 
 fn default_shared() -> bool {
@@ -188,7 +213,9 @@ fn default_shared() -> bool {
 /// Full MCP configuration file
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct McpConfig {
-    #[serde(default)]
+    /// Server map. Accepts the canonical Claude Code key `mcpServers` as well as
+    /// jcode's historical `servers` key.
+    #[serde(default, alias = "mcpServers")]
     pub servers: std::collections::HashMap<String, McpServerConfig>,
 }
 
@@ -228,13 +255,26 @@ impl McpConfig {
         let mut imported = Self::default();
         let mut sources = Vec::new();
 
-        // Import from Claude Code (~/.claude/mcp.json)
+        // Import from Claude Code. The canonical user config is `~/.claude.json`
+        // (top-level `mcpServers` + per-project entries); fall back to the older
+        // `~/.claude/mcp.json` layout for users who still have it.
+        if let Ok(claude_json) = crate::storage::user_home_path(".claude.json") {
+            if claude_json.exists() {
+                let cwd = std::env::current_dir().ok();
+                let config = Self::load_claude_json(&claude_json, cwd.as_deref());
+                let count = config.servers.len();
+                if count > 0 {
+                    sources.push(format!("{} from Claude Code", count));
+                    imported.servers.extend(config.servers);
+                }
+            }
+        }
         if let Ok(claude_mcp) = crate::storage::user_home_path(".claude/mcp.json") {
             if claude_mcp.exists() {
                 if let Ok(config) = Self::load_from_file(&claude_mcp) {
                     let count = config.servers.len();
                     if count > 0 {
-                        sources.push(format!("{} from Claude Code", count));
+                        sources.push(format!("{} from Claude Code (legacy)", count));
                         imported.servers.extend(config.servers);
                     }
                 }
@@ -316,12 +356,58 @@ impl McpConfig {
                             args,
                             env,
                             shared,
+                            transport: None,
+                            url: None,
                         },
                     );
                 }
             }
         }
         Ok(config)
+    }
+
+    /// Parse MCP servers from Claude Code's `~/.claude.json`.
+    ///
+    /// Claude Code stores a global set under the top-level `mcpServers` key, and
+    /// per-project sets under `projects.<abs_path>.mcpServers`. We merge the
+    /// global set first, then overlay the entry for `cwd` (if any) so a
+    /// project-specific server wins for the active directory.
+    fn load_claude_json(path: &std::path::Path, cwd: Option<&std::path::Path>) -> Self {
+        let mut config = Self::default();
+        let Ok(content) = std::fs::read_to_string(path) else {
+            return config;
+        };
+        let Ok(value) = serde_json::from_str::<serde_json::Value>(&content) else {
+            return config;
+        };
+
+        // Global servers under top-level `mcpServers`.
+        if let Some(map) = value.get("mcpServers")
+            && let Ok(servers) =
+                serde_json::from_value::<std::collections::HashMap<String, McpServerConfig>>(
+                    map.clone(),
+                )
+        {
+            config.servers.extend(servers);
+        }
+
+        // Per-project servers under `projects.<abs_path>.mcpServers`.
+        if let (Some(cwd), Some(projects)) =
+            (cwd, value.get("projects").and_then(|p| p.as_object()))
+        {
+            let cwd_str = cwd.to_string_lossy();
+            if let Some(project) = projects.get(cwd_str.as_ref())
+                && let Some(map) = project.get("mcpServers")
+                && let Ok(servers) =
+                    serde_json::from_value::<std::collections::HashMap<String, McpServerConfig>>(
+                        map.clone(),
+                    )
+            {
+                config.servers.extend(servers);
+            }
+        }
+
+        config
     }
 
     /// Load from default locations (merges jcode global + local, local overrides)
@@ -345,10 +431,28 @@ impl McpConfig {
             }
         }
 
+        // Claude Code user/global config (~/.claude.json): top-level mcpServers
+        // plus per-project entries for the current working directory.
+        if let Ok(claude_json) = crate::storage::user_home_path(".claude.json") {
+            if claude_json.exists() {
+                let cwd = std::env::current_dir().ok();
+                let config = Self::load_claude_json(&claude_json, cwd.as_deref());
+                merged.servers.extend(config.servers);
+            }
+        }
+
         // Load project-local jcode config (.jcode/mcp.json)
         let local_jcode = std::path::Path::new(".jcode/mcp.json");
         if local_jcode.exists() {
             if let Ok(config) = Self::load_from_file(local_jcode) {
+                merged.servers.extend(config.servers);
+            }
+        }
+
+        // Claude Code project config: `.mcp.json` at the repo root.
+        let local_mcp = std::path::Path::new(".mcp.json");
+        if local_mcp.exists() {
+            if let Ok(config) = Self::load_from_file(local_mcp) {
                 merged.servers.extend(config.servers);
             }
         }
@@ -360,6 +464,21 @@ impl McpConfig {
                 merged.servers.extend(config.servers);
             }
         }
+
+        // jcode only supports stdio servers today. Drop HTTP/SSE entries (common
+        // in Claude Code configs) so they don't fail to spawn, but log them so
+        // the omission is visible.
+        merged.servers.retain(|name, cfg| {
+            let keep = cfg.is_stdio();
+            if !keep {
+                crate::logging::info(&format!(
+                    "MCP: Skipping non-stdio server '{}' ({}); HTTP/SSE transports are not yet supported",
+                    name,
+                    cfg.transport.as_deref().unwrap_or("http")
+                ));
+            }
+            keep
+        });
 
         merged
     }

--- a/crates/jcode-base/src/mcp/protocol_tests.rs
+++ b/crates/jcode-base/src/mcp/protocol_tests.rs
@@ -111,7 +111,10 @@ fn test_load_claude_json_global_and_project_servers() {
 
     let config = McpConfig::load_claude_json(&claude_json, Some(&cwd));
     assert_eq!(config.servers.len(), 2);
-    assert_eq!(config.servers.get("global-srv").unwrap().command, "global-bin");
+    assert_eq!(
+        config.servers.get("global-srv").unwrap().command,
+        "global-bin"
+    );
     assert_eq!(
         config.servers.get("project-srv").unwrap().command,
         "project-bin"

--- a/crates/jcode-base/src/mcp/protocol_tests.rs
+++ b/crates/jcode-base/src/mcp/protocol_tests.rs
@@ -55,6 +55,70 @@ fn test_mcp_config_empty() {
 }
 
 #[test]
+fn test_mcp_config_accepts_claude_mcp_servers_key() {
+    // Claude Code uses `mcpServers`, not `servers`.
+    let json = r#"{
+            "mcpServers": {
+                "claude-server": {
+                    "command": "npx",
+                    "args": ["-y", "some-mcp"]
+                }
+            }
+        }"#;
+    let config: McpConfig = serde_json::from_str(json).unwrap();
+    assert_eq!(config.servers.len(), 1);
+    let server = config.servers.get("claude-server").unwrap();
+    assert_eq!(server.command, "npx");
+    assert!(server.is_stdio());
+}
+
+#[test]
+fn test_mcp_http_server_is_not_stdio() {
+    let json = r#"{
+            "mcpServers": {
+                "remote": {
+                    "type": "http",
+                    "url": "https://example.com/mcp"
+                }
+            }
+        }"#;
+    let config: McpConfig = serde_json::from_str(json).unwrap();
+    let server = config.servers.get("remote").unwrap();
+    assert!(!server.is_stdio());
+    assert_eq!(server.url.as_deref(), Some("https://example.com/mcp"));
+}
+
+#[test]
+fn test_load_claude_json_global_and_project_servers() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let cwd = temp.path().join("myproject");
+    std::fs::create_dir_all(&cwd).unwrap();
+    let claude_json = temp.path().join(".claude.json");
+
+    let body = serde_json::json!({
+        "mcpServers": {
+            "global-srv": { "command": "global-bin" }
+        },
+        "projects": {
+            cwd.to_string_lossy(): {
+                "mcpServers": {
+                    "project-srv": { "command": "project-bin", "args": ["--flag"] }
+                }
+            }
+        }
+    });
+    std::fs::write(&claude_json, serde_json::to_string_pretty(&body).unwrap()).unwrap();
+
+    let config = McpConfig::load_claude_json(&claude_json, Some(&cwd));
+    assert_eq!(config.servers.len(), 2);
+    assert_eq!(config.servers.get("global-srv").unwrap().command, "global-bin");
+    assert_eq!(
+        config.servers.get("project-srv").unwrap().command,
+        "project-bin"
+    );
+}
+
+#[test]
 fn test_tool_def_deserialization() {
     let json = r#"{
             "name": "read_file",

--- a/crates/jcode-base/src/mcp/schema_cache_tests.rs
+++ b/crates/jcode-base/src/mcp/schema_cache_tests.rs
@@ -11,6 +11,8 @@ fn cfg(command: &str, args: &[&str]) -> McpServerConfig {
         args: args.iter().map(|s| s.to_string()).collect(),
         env: HashMap::new(),
         shared: true,
+        transport: None,
+        url: None,
     }
 }
 

--- a/crates/jcode-base/src/platform.rs
+++ b/crates/jcode-base/src/platform.rs
@@ -203,8 +203,14 @@ pub fn raise_nofile_limit_best_effort(minimum_soft_limit: u64) {
             return;
         }
 
-        let current: u64 = limit.rlim_cur;
-        let hard: u64 = limit.rlim_max;
+        // `rlim_cur`/`rlim_max` are `u64` on Linux/macOS but `i64` on some
+        // platforms (e.g. FreeBSD), so cast explicitly to keep builds portable.
+        // The cast is a no-op (and clippy-flagged) where the field is already
+        // `u64`, hence the allow.
+        #[allow(clippy::unnecessary_cast)]
+        let current: u64 = limit.rlim_cur as u64;
+        #[allow(clippy::unnecessary_cast)]
+        let hard: u64 = limit.rlim_max as u64;
         let Some(desired) = desired_nofile_soft_limit(current, hard, minimum_soft_limit) else {
             return;
         };

--- a/crates/jcode-base/src/skill.rs
+++ b/crates/jcode-base/src/skill.rs
@@ -219,6 +219,13 @@ impl SkillRegistry {
             }
         }
 
+        // Load from ~/.agents/skills/ (shared cross-tool `.agents` convention)
+        if let Ok(agents_skills) = crate::storage::user_home_path(".agents/skills")
+            && agents_skills.exists()
+        {
+            registry.load_from_dir(&agents_skills)?;
+        }
+
         registry.load_project_local_dirs(working_dir)?;
 
         Ok(registry)
@@ -234,6 +241,12 @@ impl SkillRegistry {
         let local_jcode = Self::project_local_dir(working_dir, ".jcode");
         if local_jcode.exists() {
             self.load_from_dir(&local_jcode)?;
+        }
+
+        // Load from ./.agents/skills/ (shared cross-tool `.agents` convention)
+        let local_agents = Self::project_local_dir(working_dir, ".agents");
+        if local_agents.exists() {
+            self.load_from_dir(&local_agents)?;
         }
 
         // Fallback: ./.claude/skills/ (project-local Claude skills for compatibility)
@@ -376,10 +389,23 @@ impl SkillRegistry {
             }
         }
 
+        // Load from ~/.agents/skills/ (shared cross-tool `.agents` convention)
+        if let Ok(agents_skills) = crate::storage::user_home_path(".agents/skills")
+            && agents_skills.exists()
+        {
+            count += self.load_from_dir_count(&agents_skills)?;
+        }
+
         // Load from ./.jcode/skills/ (project-local jcode skills)
         let local_jcode = Self::project_local_dir(working_dir, ".jcode");
         if local_jcode.exists() {
             count += self.load_from_dir_count(&local_jcode)?;
+        }
+
+        // Load from ./.agents/skills/ (shared cross-tool `.agents` convention)
+        let local_agents = Self::project_local_dir(working_dir, ".agents");
+        if local_agents.exists() {
+            count += self.load_from_dir_count(&local_agents)?;
         }
 
         // Fallback: ./.claude/skills/ (project-local Claude skills for compatibility)
@@ -783,6 +809,20 @@ mod tests {
             .get("wd-only")
             .expect("working-dir local skill should load");
         assert_eq!(skill.description, "Test skill wd-only");
+        assert!(skill.path.starts_with(temp.path()));
+    }
+
+    #[test]
+    fn load_for_working_dir_reads_project_local_agents_skills() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        write_test_skill(temp.path(), ".agents", "agents-only");
+
+        let registry = SkillRegistry::load_for_working_dir(Some(temp.path())).expect("load skills");
+
+        let skill = registry
+            .get("agents-only")
+            .expect("project-local .agents skill should load");
+        assert_eq!(skill.description, "Test skill agents-only");
         assert!(skill.path.starts_with(temp.path()));
     }
 

--- a/crates/jcode-config-types/src/lib.rs
+++ b/crates/jcode-config-types/src/lib.rs
@@ -635,6 +635,16 @@ pub struct TerminalConfig {
     ///
     /// Env override: `JCODE_FOCUS_HOOK` (set empty to disable a config hook).
     pub focus_hook: Option<String>,
+    /// Terminal used by the macOS Cmd+; launch hotkey and in-app session spawns.
+    ///
+    /// One of: `ghostty`, `iterm2`, `wezterm`, `warp`, `alacritty`, `vscode`,
+    /// `terminal` (Apple Terminal). When set, this is the source of truth for
+    /// which terminal jcode launches into and is preferred over the legacy
+    /// `~/.jcode/preferred_terminal.json` file. Re-run `jcode setup-hotkey`
+    /// after changing it so the generated launcher script picks up the change.
+    ///
+    /// macOS only; ignored on other platforms.
+    pub preferred: Option<String>,
 }
 
 /// Lifecycle hooks: external commands jcode runs at well-defined points.

--- a/crates/jcode-setup-hints/src/macos_terminal.rs
+++ b/crates/jcode-setup-hints/src/macos_terminal.rs
@@ -98,7 +98,25 @@ pub(super) fn save_preferred_macos_terminal(terminal: MacTerminalKind) -> Result
 }
 
 pub(super) fn effective_macos_terminal() -> MacTerminalKind {
-    load_preferred_macos_terminal().unwrap_or_else(detect_macos_terminal)
+    // Precedence: config.toml `[terminal] preferred` (discoverable, documented)
+    // > legacy `~/.jcode/preferred_terminal.json` > runtime detection.
+    config_preferred_macos_terminal()
+        .or_else(load_preferred_macos_terminal)
+        .unwrap_or_else(detect_macos_terminal)
+}
+
+/// Read `[terminal] preferred` from `~/.jcode/config.toml`, if present and valid.
+fn config_preferred_macos_terminal() -> Option<MacTerminalKind> {
+    #[derive(Deserialize, Default)]
+    struct Wrapper {
+        #[serde(default)]
+        terminal: jcode_config_types::TerminalConfig,
+    }
+    let dir = storage::jcode_dir().ok()?;
+    let text = std::fs::read_to_string(dir.join("config.toml")).ok()?;
+    let wrapper = toml::from_str::<Wrapper>(&text).ok()?;
+    let preferred = wrapper.terminal.preferred?;
+    MacTerminalKind::from_cli_value(&preferred)
 }
 
 fn detect_macos_terminal() -> MacTerminalKind {
@@ -265,6 +283,32 @@ mod tests {
         MacTerminalKind, applescript_command_for_iterm, applescript_command_for_terminal,
         launch_command_for_macos_terminal, open_command_for_terminal,
     };
+
+    #[test]
+    fn from_cli_value_maps_documented_config_values() {
+        // These are the values documented for `[terminal] preferred` in
+        // config.toml; they must round-trip to a known terminal kind (#401).
+        let cases = [
+            ("ghostty", MacTerminalKind::Ghostty),
+            ("iterm2", MacTerminalKind::Iterm2),
+            ("iterm", MacTerminalKind::Iterm2),
+            ("terminal", MacTerminalKind::AppleTerminal),
+            ("wezterm", MacTerminalKind::WezTerm),
+            ("warp", MacTerminalKind::Warp),
+            ("alacritty", MacTerminalKind::Alacritty),
+            ("vscode", MacTerminalKind::Vscode),
+            ("code", MacTerminalKind::Vscode),
+            ("  Ghostty  ", MacTerminalKind::Ghostty),
+        ];
+        for (value, expected) in cases {
+            assert_eq!(
+                MacTerminalKind::from_cli_value(value),
+                Some(expected),
+                "config value {value:?} should map to {expected:?}"
+            );
+        }
+        assert_eq!(MacTerminalKind::from_cli_value("nope"), None);
+    }
 
     #[test]
     fn open_command_terminals_use_open_with_expected_args() {

--- a/crates/jcode-tui/src/tui/app/commands.rs
+++ b/crates/jcode-tui/src/tui/app/commands.rs
@@ -3138,7 +3138,31 @@ pub(super) fn handle_config_command(app: &mut App, trimmed: &str) -> bool {
                 tool_data: None,
             });
 
-            let _ = std::process::Command::new(&editor).arg(&path).spawn();
+            // $EDITOR may contain arguments (e.g. "zed --wait" or "code -w"), so
+            // split on whitespace and use the first token as the binary, passing
+            // the rest as leading args before the file path. Report spawn errors
+            // instead of swallowing them so the user is not left confused.
+            let mut parts = editor.split_whitespace();
+            match parts.next() {
+                Some(bin) => {
+                    let extra: Vec<&str> = parts.collect();
+                    if let Err(e) = std::process::Command::new(bin)
+                        .args(&extra)
+                        .arg(&path)
+                        .spawn()
+                    {
+                        app.push_display_message(DisplayMessage::error(format!(
+                            "Failed to launch editor '{}': {}",
+                            editor, e
+                        )));
+                    }
+                }
+                None => {
+                    app.push_display_message(DisplayMessage::error(
+                        "$EDITOR is set to an empty value; cannot open config.".to_string(),
+                    ));
+                }
+            }
         }
         return true;
     }

--- a/crates/jcode-tui/src/tui/app/commands.rs
+++ b/crates/jcode-tui/src/tui/app/commands.rs
@@ -128,6 +128,10 @@ pub(super) fn is_non_retryable_auto_poke_error(error: &str) -> bool {
         "invalid model",
         "model_not_found",
         "model_not_supported",
+        "unsupportedmodel",
+        "unsupported model",
+        "does not support the coding plan",
+        "coding plan feature",
         "unsupported parameter",
         "unsupported_value",
         "invalid parameter",
@@ -184,6 +188,35 @@ pub(super) fn is_auto_poke_connectivity_error(error: &str) -> bool {
     ];
 
     connectivity_markers
+        .iter()
+        .any(|marker| lower.contains(marker))
+}
+
+/// Whether `error` is a deterministic model/endpoint-capability failure that can
+/// never succeed by resending the identical request: the configured model is not
+/// valid for the configured endpoint (e.g. Volcengine Ark's coding-plan endpoint
+/// returning `404 UnsupportedModel` for a model that lacks the coding plan
+/// feature, or a plain model-not-found). Unlike the broader
+/// [`is_non_retryable_auto_poke_error`] set (which also covers billing, payload
+/// size, auth, etc.), this is narrow enough that we can fail fast *regardless of
+/// auto-poke* during reconnect/recovery continuation instead of burning the
+/// retry budget on a request that is structurally guaranteed to 4xx. See #387.
+pub(super) fn is_fatal_model_endpoint_error(error: &str) -> bool {
+    let lower = error.to_ascii_lowercase();
+
+    let model_endpoint_markers = [
+        "unsupportedmodel",
+        "unsupported model",
+        "does not support the coding plan",
+        "coding plan feature",
+        "model_not_found",
+        "model_not_supported",
+        "invalid model",
+        "the model does not exist",
+        "model does not exist",
+    ];
+
+    model_endpoint_markers
         .iter()
         .any(|marker| lower.contains(marker))
 }

--- a/crates/jcode-tui/src/tui/app/commands_tests.rs
+++ b/crates/jcode-tui/src/tui/app/commands_tests.rs
@@ -75,3 +75,31 @@ fn transient_server_error_remains_retryable_for_auto_poke() {
     let err = "OpenAI-compatible chat request failed\n  status: 503 Service Unavailable";
     assert!(!is_non_retryable_auto_poke_error(err));
 }
+
+#[test]
+fn volcengine_ark_unsupported_model_is_fatal_model_endpoint_error() {
+    use super::{is_fatal_model_endpoint_error, is_non_retryable_auto_poke_error};
+    let err = "OpenAI-compatible chat request failed\n  endpoint: \
+        https://ark.cn-beijing.volces.com/api/coding/v3/chat/completions\n  model: \
+        volcengine:ark-code-latest\n  auth: ARK_API_KEY\n  status: 404 Not Found\n  response: \
+        {\"error\":{\"code\":\"UnsupportedModel\",\"message\":\"The requested model does not \
+        support the coding plan feature.\"}}";
+    // It is both a fatal model/endpoint error (fail fast, no retries) and a
+    // non-retryable auto-poke error (don't keep poking).
+    assert!(is_fatal_model_endpoint_error(err));
+    assert!(is_non_retryable_auto_poke_error(err));
+}
+
+#[test]
+fn transient_5xx_is_not_a_fatal_model_endpoint_error() {
+    use super::is_fatal_model_endpoint_error;
+    let err = "OpenAI-compatible chat request failed\n  status: 503 Service Unavailable";
+    assert!(!is_fatal_model_endpoint_error(err));
+}
+
+#[test]
+fn model_not_found_is_fatal_model_endpoint_error() {
+    use super::is_fatal_model_endpoint_error;
+    let err = "chat request failed: 404 model_not_found: The model `gpt-foo` does not exist";
+    assert!(is_fatal_model_endpoint_error(err));
+}

--- a/crates/jcode-tui/src/tui/app/remote/server_events.rs
+++ b/crates/jcode-tui/src/tui/app/remote/server_events.rs
@@ -920,7 +920,9 @@ pub(in crate::tui::app) fn handle_server_event(
             if crate::tui::app::commands::is_fatal_model_endpoint_error(&message) {
                 app.clear_pending_remote_retry();
                 if app.auto_poke_incomplete_todos {
-                    crate::tui::app::commands::stop_auto_poke_for_non_retryable_error(app, &message);
+                    crate::tui::app::commands::stop_auto_poke_for_non_retryable_error(
+                        app, &message,
+                    );
                 }
                 app.push_display_message(DisplayMessage::system(
                     "🛑 Not retrying: the model is not valid for the configured endpoint (e.g. an Ark coding-plan endpoint rejecting a model without the coding plan feature, or a model-not-found). Check the model name and base URL (the coding endpoint `/api/coding/v3` only accepts coding-plan models; use `/api/v3` otherwise), then send again.".to_string(),

--- a/crates/jcode-tui/src/tui/app/remote/server_events.rs
+++ b/crates/jcode-tui/src/tui/app/remote/server_events.rs
@@ -912,6 +912,23 @@ pub(in crate::tui::app) fn handle_server_event(
             {
                 return false;
             }
+            // Deterministic model/endpoint-capability failures (e.g. Volcengine
+            // Ark's coding-plan endpoint returning 404 UnsupportedModel, or a
+            // model-not-found) can never succeed by resending the identical
+            // request. Fail fast with an actionable hint instead of burning the
+            // auto-retry budget on guaranteed 4xx responses (#387).
+            if crate::tui::app::commands::is_fatal_model_endpoint_error(&message) {
+                app.clear_pending_remote_retry();
+                if app.auto_poke_incomplete_todos {
+                    crate::tui::app::commands::stop_auto_poke_for_non_retryable_error(app, &message);
+                }
+                app.push_display_message(DisplayMessage::system(
+                    "🛑 Not retrying: the model is not valid for the configured endpoint (e.g. an Ark coding-plan endpoint rejecting a model without the coding plan feature, or a model-not-found). Check the model name and base URL (the coding endpoint `/api/coding/v3` only accepts coding-plan models; use `/api/v3` otherwise), then send again.".to_string(),
+                ));
+                app.set_status_notice("Stopped: model/endpoint mismatch");
+                app.restore_failed_input_to_box();
+                return false;
+            }
             if app.auto_poke_incomplete_todos
                 && crate::tui::app::commands::is_non_retryable_auto_poke_error(&message)
             {

--- a/crates/jcode-tui/src/tui/app/tests/remote_events_reload_04.rs
+++ b/crates/jcode-tui/src/tui/app/tests/remote_events_reload_04.rs
@@ -1050,8 +1050,7 @@ fn test_remote_anthropic_api_key_accrues_cost_from_token_usage() {
     oauth_app.is_remote = true;
     oauth_app.remote_provider_name = Some("Claude".to_string());
     oauth_app.remote_provider_model = Some("claude-sonnet-4-6".to_string());
-    oauth_app.remote_resolved_credential =
-        Some(jcode_provider_core::ResolvedCredential::Oauth);
+    oauth_app.remote_resolved_credential = Some(jcode_provider_core::ResolvedCredential::Oauth);
     oauth_app.handle_server_event(
         crate::protocol::ServerEvent::TokenUsage {
             input: 1_000,
@@ -1111,8 +1110,7 @@ fn test_resumed_session_seeds_cost_from_history_token_totals() {
     oauth_app.is_remote = true;
     oauth_app.remote_provider_name = Some("Claude".to_string());
     oauth_app.remote_provider_model = Some("claude-sonnet-4-6".to_string());
-    oauth_app.remote_resolved_credential =
-        Some(jcode_provider_core::ResolvedCredential::Oauth);
+    oauth_app.remote_resolved_credential = Some(jcode_provider_core::ResolvedCredential::Oauth);
     oauth_app.seed_cost_from_history_totals(&totals);
     assert_eq!(oauth_app.cost.total_cost, 0.0);
 }

--- a/crates/jcode-tui/src/tui/app/tests/remote_events_reload_04.rs
+++ b/crates/jcode-tui/src/tui/app/tests/remote_events_reload_04.rs
@@ -219,6 +219,63 @@ fn test_remote_non_retryable_error_stops_auto_poke_after_short_retry_budget() {
 }
 
 #[test]
+fn test_remote_fatal_model_endpoint_error_fails_fast_without_retry_budget() {
+    // Volcengine Ark coding-plan endpoint returning 404 UnsupportedModel can
+    // never succeed on resend, so the recovery/reconnect continuation must NOT
+    // burn the auto-retry budget on it (#387).
+    let mut app = create_test_app();
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let _guard = rt.enter();
+    let mut remote = crate::tui::backend::RemoteConnection::dummy();
+
+    app.auto_poke_incomplete_todos = true;
+    app.queued_messages
+        .push("You have 1 incomplete todo. Continue working, or update the todo tool.".to_string());
+    app.rate_limit_pending_message = Some(PendingRemoteMessage {
+        content: "continue".to_string(),
+        images: vec![],
+        is_system: true,
+        system_reminder: None,
+        auto_retry: true,
+        retry_attempts: 0,
+        retry_at: None,
+    });
+    app.is_processing = true;
+    app.status = ProcessingStatus::Streaming;
+
+    app.handle_server_event(
+        crate::protocol::ServerEvent::Error {
+            id: 21,
+            message: "OpenAI-compatible chat request failed\n  endpoint: https://ark.cn-beijing.volces.com/api/coding/v3/chat/completions\n  model: volcengine:ark-code-latest\n  auth: ARK_API_KEY\n  status: 404 Not Found\n  response: {\"error\":{\"code\":\"UnsupportedModel\",\"message\":\"The requested model does not support the coding plan feature.\"}}".to_string(),
+            retry_after_secs: None,
+        },
+        &mut remote,
+    );
+
+    // No retry scheduled: pending cleared immediately, no backoff timer set.
+    assert!(app.rate_limit_pending_message.is_none());
+    assert!(app.rate_limit_reset.is_none());
+    // Auto-poke is stopped, and an actionable hint is shown.
+    assert!(!app.auto_poke_incomplete_todos);
+    assert!(
+        app.display_messages()
+            .iter()
+            .any(|m| m.role == "system" && m.content.contains("Not retrying")),
+        "expected a fail-fast model/endpoint hint, got: {:?}",
+        app.display_messages()
+            .iter()
+            .map(|m| m.content.clone())
+            .collect::<Vec<_>>()
+    );
+    // It must not have produced a "retrying (attempt N/M)" message.
+    assert!(
+        !app.display_messages()
+            .iter()
+            .any(|m| m.content.contains("attempt 1/"))
+    );
+}
+
+#[test]
 fn test_remote_connectivity_error_waits_for_network_without_retry_budget() {
     let mut app = create_test_app();
     let rt = tokio::runtime::Runtime::new().unwrap();

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -49,7 +49,10 @@ else
   INSTALL_DIR="${JCODE_INSTALL_DIR:-$HOME/.local/bin}"
 fi
 
-VERSION=$(curl -fsSL "https://api.github.com/repos/$REPO/releases/latest" | grep '"tag_name"' | cut -d'"' -f4)
+# Extract the tag_name value, working for both pretty-printed (multi-line) and
+# compact (single-line) GitHub API JSON. `grep -o` isolates just the tag_name
+# field so `cut` no longer matches an unrelated string like the release url.
+VERSION=$(curl -fsSL "https://api.github.com/repos/$REPO/releases/latest" | grep -o '"tag_name" *: *"[^"]*"' | head -1 | cut -d'"' -f4)
 [ -n "$VERSION" ] || err "Failed to determine latest version"
 
 URL_TGZ="https://github.com/$REPO/releases/download/$VERSION/$ARTIFACT.tar.gz"


### PR DESCRIPTION
Autonomous triage of newly filed issues. Each fix is a focused commit.

## Fixes

- Closes #411 - install.sh tag_name parsing: GitHub's `/releases/latest` now returns compact single-line JSON, so the old `grep | cut` returned a URL instead of the tag. Use `grep -o` to isolate the `tag_name` field (works for compact and pretty JSON).
- Closes #412 - `/config edit` now shell-splits `$EDITOR` so values with args (e.g. `zed --wait`, `code -w`) launch correctly, and surfaces spawn errors instead of failing silently.
- Closes #416 - FreeBSD support: cast `rlim_cur`/`rlim_max` to `u64` (they're `i64` on FreeBSD), add an XDG-style Cursor `state.vscdb` fallback for other Unix, and add a `freebsd-smoke` CI workflow that boots a real FreeBSD VM (`vmactions/freebsd-vm`) to build + run + test. Verified green: https://github.com/1jehuang/jcode/actions/runs/28342275452 (build, `--version`, platform unit tests all pass on FreeBSD 14.2).
- Closes #413 - Load skills from the shared `.agents` convention: `~/.agents/skills/` and `./.agents/skills/`, alongside existing `.jcode`/`.claude` paths (load + reload paths).
- Closes #414 - MCP Claude Code compatibility: accept the canonical `mcpServers` key (alias of `servers`), load `./.mcp.json` and `~/.claude.json` (top-level + `projects.<cwd>.mcpServers`), recognize and skip HTTP/SSE (`type`/`url`) entries with a log line, and update first-run import + README.
- Closes #387 - Fail fast on non-retryable model/endpoint errors: reconnect/recovery continuation no longer burns the auto-retry budget on deterministic 4xx model-capability errors (e.g. Volcengine Ark coding-plan endpoint `404 UnsupportedModel`, model-not-found). Shows an actionable model/base-URL hint instead.
- Closes #401 - Add a discoverable, documented `[terminal] preferred` config.toml key for the macOS Cmd+; launch terminal, preferred over the legacy `~/.jcode/preferred_terminal.json`.

## Validation

- `cargo build -p jcode --bin jcode` (selfdev) succeeds.
- FreeBSD VM CI run is green (build + run + tests).
- New/updated unit + integration tests pass: MCP, skills, platform nofile, retry fail-fast classifier (`is_fatal_model_endpoint_error`), and `[terminal] preferred` parsing.