### PR TITLE
feat(install): add verified metadata and mirror fallbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,12 @@ Built for multi-session workflows, infinite customizability, and performance.
 
 ```bash
 # macOS & Linux
-curl -fsSL https://raw.githubusercontent.com/1jehuang/jcode/master/scripts/install.sh | bash
+curl -fsSL https://jcode.sh/install | bash
 ```
 
 ```powershell
 # Windows 11 (PowerShell 5.1+)
-irm https://raw.githubusercontent.com/1jehuang/jcode/master/scripts/install.ps1 | iex
+irm https://jcode.sh/install.ps1 | iex
 ```
 
 Need Homebrew, source builds, provider setup, or want an agent to set it up for you?
@@ -733,10 +733,10 @@ Set up jcode on this machine for me.
      brew install jcode
 
    - macOS or Linux via install script:
-     curl -fsSL https://raw.githubusercontent.com/1jehuang/jcode/master/scripts/install.sh | bash
+     curl -fsSL https://jcode.sh/install | bash
 
    - Windows PowerShell:
-     irm https://raw.githubusercontent.com/1jehuang/jcode/master/scripts/install.ps1 | iex
+     irm https://jcode.sh/install.ps1 | iex
 
    - From source if the above paths are not appropriate:
      git clone https://github.com/1jehuang/jcode.git
@@ -786,7 +786,7 @@ This is intended to be a copy-paste bootstrap prompt for jcode itself or any oth
 
 ```bash
 # macOS & Linux
-curl -fsSL https://raw.githubusercontent.com/1jehuang/jcode/master/scripts/install.sh | bash
+curl -fsSL https://jcode.sh/install | bash
 ```
 
 On Termux, install the glibc runtime and `patchelf` first so the installer can
@@ -795,12 +795,12 @@ launcher that avoids Termux's `LD_PRELOAD` shim:
 
 ```bash
 pkg install glibc patchelf
-curl -fsSL https://raw.githubusercontent.com/1jehuang/jcode/master/scripts/install.sh | bash
+curl -fsSL https://jcode.sh/install | bash
 ```
 
 ```powershell
 # Windows 11 x64 or ARM64 (PowerShell 5.1+)
-irm https://raw.githubusercontent.com/1jehuang/jcode/master/scripts/install.ps1 | iex
+irm https://jcode.sh/install.ps1 | iex
 ```
 
 The Windows installer selects the correct architecture and verifies the download

--- a/docs/WINDOWS.md
+++ b/docs/WINDOWS.md
@@ -21,7 +21,7 @@ PowerShell 5.1 or later is required by the installer. The x64 build is the defau
 Open PowerShell and run:
 
 ```powershell
-irm https://raw.githubusercontent.com/1jehuang/jcode/master/scripts/install.ps1 | iex
+irm https://jcode.sh/install.ps1 | iex
 ```
 
 The installer:
@@ -35,7 +35,7 @@ The installer:
 Alacritty installation and the global launch hotkey are optional and are no longer installed automatically. To request both explicitly:
 
 ```powershell
-$script = [scriptblock]::Create((irm https://raw.githubusercontent.com/1jehuang/jcode/master/scripts/install.ps1))
+$script = [scriptblock]::Create((irm https://jcode.sh/install.ps1))
 & $script -ConfigureAlacritty -ConfigureHotkey
 ```
 
@@ -46,7 +46,7 @@ fails with an actionable message rather than silently starting a long build.
 To explicitly allow a source build:
 
 ```powershell
-$script = [scriptblock]::Create((irm https://raw.githubusercontent.com/1jehuang/jcode/master/scripts/install.ps1))
+$script = [scriptblock]::Create((irm https://jcode.sh/install.ps1))
 & $script -BuildFromSource
 ```
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -5,10 +5,10 @@
     Downloads the latest jcode release and installs it to %LOCALAPPDATA%\jcode\bin.
 
     One-liner install:
-      irm https://raw.githubusercontent.com/1jehuang/jcode/master/scripts/install.ps1 | iex
+      irm https://jcode.sh/install.ps1 | iex
 
     Or download and run (allows parameters):
-      & ([scriptblock]::Create((irm https://raw.githubusercontent.com/1jehuang/jcode/master/scripts/install.ps1)))
+      & ([scriptblock]::Create((irm https://jcode.sh/install.ps1)))
 .PARAMETER InstallDir
     Override the installation directory (default: $env:LOCALAPPDATA\jcode\bin)
 .PARAMETER Version
@@ -49,6 +49,11 @@ if ($PSVersionTable.PSVersion.Major -lt 5) {
 }
 
 $Repo = "1jehuang/jcode"
+$ReleaseMetadataBase = if ($env:JCODE_RELEASE_METADATA_BASE) {
+    $env:JCODE_RELEASE_METADATA_BASE.TrimEnd('/')
+} else {
+    "https://jcode.sh/releases"
+}
 
 if (-not $InstallDir) {
     $localAppData = if ($env:LOCALAPPDATA) { $env:LOCALAPPDATA } else { [Environment]::GetFolderPath([Environment+SpecialFolder]::LocalApplicationData) }
@@ -71,6 +76,10 @@ function Write-Info($msg) { Write-Host $msg -ForegroundColor Blue }
 function Write-Err($msg) { throw "error: $msg" }
 function Write-Warn($msg) { Write-Host "warning: $msg" -ForegroundColor Yellow }
 
+function Test-JcodeReleaseTag([string]$Tag) {
+    return [bool]($Tag -match '^v[0-9]+\.[0-9]+\.[0-9]+(?:[+.-][A-Za-z0-9.-]+)?$')
+}
+
 function Resolve-JcodeReleaseTagFromUri([string]$Uri) {
     if (-not $Uri) { return $null }
     if ($Uri -match '/releases/tag/([^/?#]+)') {
@@ -82,6 +91,13 @@ function Resolve-JcodeReleaseTagFromUri([string]$Uri) {
 function Get-LatestJcodeReleaseTag {
     # Avoid api.github.com here. Its unauthenticated limit is only 60 requests
     # per public IP per hour, so installs are unreliable behind shared NAT/VPNs.
+    $metadataTag = $null
+    try {
+        $metadataResponse = Invoke-WebRequest -UseBasicParsing -Uri "$ReleaseMetadataBase/latest/version"
+        $candidate = ([string]$metadataResponse.Content).Trim()
+        if (Test-JcodeReleaseTag $candidate) { $metadataTag = $candidate }
+    } catch {}
+
     try {
         $response = Invoke-WebRequest -UseBasicParsing -Method Head -Uri "https://github.com/$Repo/releases/latest"
         $baseResponse = $response.BaseResponse
@@ -103,10 +119,34 @@ function Get-LatestJcodeReleaseTag {
 
         $tag = Resolve-JcodeReleaseTagFromUri $resolvedUri
         if ($tag) { return $tag }
-        Write-Err "GitHub did not redirect releases/latest to a version tag"
     } catch {
-        Write-Err "Failed to determine latest version: $_"
+        if (-not $metadataTag) {
+            Write-Err "Failed to determine latest version: $_"
+        }
     }
+
+    if ($metadataTag) {
+        Write-Warn "GitHub release lookup unavailable; using cached jcode.sh metadata ($metadataTag)."
+        return $metadataTag
+    }
+    Write-Err "Failed to determine latest version"
+}
+
+function Get-JcodeReleaseDownloadBases([string]$ReleaseTag) {
+    $bases = New-Object System.Collections.Generic.List[string]
+    try {
+        $response = Invoke-WebRequest -UseBasicParsing -Uri "$ReleaseMetadataBase/$ReleaseTag/download-bases"
+        foreach ($line in ([string]$response.Content -split "`r?`n")) {
+            $candidate = $line.Trim().TrimEnd('/')
+            if ($candidate -match '^https://\S+$' -and -not $bases.Contains($candidate)) {
+                $bases.Add($candidate)
+            }
+        }
+    } catch {}
+
+    $githubBase = "https://github.com/$Repo/releases/download/$ReleaseTag"
+    if (-not $bases.Contains($githubBase)) { $bases.Add($githubBase) }
+    return $bases.ToArray()
 }
 
 function Get-JcodeSha256FromManifest {
@@ -128,17 +168,23 @@ function Get-JcodeSha256FromManifest {
 }
 
 function Get-ReleaseChecksum([string]$ReleaseTag, [string]$AssetName) {
-    $checksumUrl = "https://github.com/$Repo/releases/download/$ReleaseTag/SHA256SUMS"
-    try {
-        $response = Invoke-WebRequest -UseBasicParsing -Uri $checksumUrl
-        $contents = [string]$response.Content
-    } catch {
-        Write-Err "Could not download SHA256SUMS for $ReleaseTag. Refusing to install an unverified download: $_"
+    $lastError = $null
+    foreach ($checksumUrl in @(
+        "$ReleaseMetadataBase/$ReleaseTag/SHA256SUMS",
+        "https://github.com/$Repo/releases/download/$ReleaseTag/SHA256SUMS"
+    )) {
+        try {
+            $response = Invoke-WebRequest -UseBasicParsing -Uri $checksumUrl
+            $expected = Get-JcodeSha256FromManifest -ManifestText ([string]$response.Content) -AssetName $AssetName
+            if ($expected) { return $expected }
+        } catch {
+            $lastError = $_
+        }
     }
 
-    $expected = Get-JcodeSha256FromManifest -ManifestText $contents -AssetName $AssetName
-    if ($expected) { return $expected }
-
+    if ($lastError) {
+        Write-Err "Could not download SHA256SUMS for $ReleaseTag. Refusing to install an unverified download: $lastError"
+    }
     Write-Err "SHA256SUMS for $ReleaseTag does not list $AssetName"
 }
 
@@ -853,8 +899,7 @@ if (-not $Version) {
 if (-not $Version) { Write-Err "Failed to determine latest version" }
 
 $VersionNum = $Version.TrimStart('v')
-$TgzUrl = "https://github.com/$Repo/releases/download/$Version/$Artifact.tar.gz"
-$ExeUrl = "https://github.com/$Repo/releases/download/$Version/$Artifact.exe"
+$DownloadBases = Get-JcodeReleaseDownloadBases $Version
 
 $BuildsDir = Join-Path (Get-JcodeLocalAppDataDir) "jcode\builds"
 $StableDir = Join-Path $BuildsDir "stable"
@@ -898,20 +943,20 @@ if ($ResolvedArtifactExePath) {
     Copy-Item -Path $ResolvedArtifactTgzPath -Destination $DownloadPath -Force
     $DownloadMode = "tar"
 } else {
-    try {
-        Write-Info "Downloading $Artifact.exe..."
-        Invoke-WebRequest -UseBasicParsing -Uri $ExeUrl -OutFile $DownloadPath
-        $DownloadMode = "bin"
-        $DownloadedAssetName = "$Artifact.exe"
-    } catch {
-        try {
-            Write-Info "Trying archive download..."
-            Invoke-WebRequest -UseBasicParsing -Uri $TgzUrl -OutFile $DownloadPath
-            $DownloadMode = "tar"
-            $DownloadedAssetName = "$Artifact.tar.gz"
-        } catch {
-            $DownloadMode = ""
+    foreach ($candidate in @(
+        @{ Name = "$Artifact.exe"; Mode = "bin" },
+        @{ Name = "$Artifact.tar.gz"; Mode = "tar" }
+    )) {
+        foreach ($base in $DownloadBases) {
+            try {
+                Write-Info "Downloading $($candidate.Name) from $base..."
+                Invoke-WebRequest -UseBasicParsing -Uri "$base/$($candidate.Name)" -OutFile $DownloadPath
+                $DownloadMode = $candidate.Mode
+                $DownloadedAssetName = $candidate.Name
+                break
+            } catch {}
         }
+        if ($DownloadMode) { break }
     }
 }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 REPO="1jehuang/jcode"
+RELEASE_METADATA_BASE="${JCODE_RELEASE_METADATA_BASE:-https://jcode.sh/releases}"
 IS_WINDOWS=false
 IS_TERMUX=false
 INSTALL_STAGE="startup"
@@ -13,6 +14,23 @@ tmpdir=""
 
 info() { printf '\033[1;34m%s\033[0m\n' "$*"; }
 err()  { printf '\033[1;31merror: %s\033[0m\n' "$*" >&2; exit 1; }
+
+valid_release_tag() {
+  printf '%s' "$1" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+([+.-][[:alnum:].-]+)?$'
+}
+
+sha256_file() {
+  file="$1"
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$file" | awk '{print tolower($1)}'
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$file" | awk '{print tolower($1)}'
+  elif command -v openssl >/dev/null 2>&1; then
+    openssl dgst -sha256 "$file" | awk '{print tolower($NF)}'
+  else
+    return 1
+  fi
+}
 
 valid_conversion_id() {
   printf '%s' "${JCODE_INSTALL_CONVERSION_ID:-}" |
@@ -130,20 +148,32 @@ else
   INSTALL_DIR="${JCODE_INSTALL_DIR:-$HOME/.local/bin}"
 fi
 
-# Resolve GitHub's stable `releases/latest` redirect instead of using the
-# unauthenticated GitHub API. The API only permits 60 requests per public IP
-# per hour, which makes installs fail with HTTP 403 on shared networks/VPNs.
+# Prefer GitHub's stable redirect when it is reachable so publication changes
+# are visible immediately. jcode.sh keeps a static copy of the latest published
+# tag as an independent fallback for GitHub outages, blocks, and shared-network
+# throttling. Neither path uses the rate-limited unauthenticated GitHub API.
 INSTALL_STAGE="release_lookup"
-LATEST_RELEASE_URL=$(curl -fsSIL -o /dev/null -w '%{url_effective}' "https://github.com/$REPO/releases/latest")
-case "$LATEST_RELEASE_URL" in
-  */releases/tag/*) VERSION="${LATEST_RELEASE_URL##*/}" ;;
-  *) VERSION="" ;;
-esac
-[ -n "$VERSION" ] || err "Failed to determine latest version"
+VERSION="${JCODE_VERSION:-}"
+if [ -z "$VERSION" ]; then
+  METADATA_VERSION=$(curl -fsSL --retry 2 --connect-timeout 10 \
+    "$RELEASE_METADATA_BASE/latest/version" 2>/dev/null | tr -d '\r\n' || true)
+  LATEST_RELEASE_URL=$(curl -fsSIL --retry 2 --connect-timeout 10 \
+    -o /dev/null -w '%{url_effective}' "https://github.com/$REPO/releases/latest" 2>/dev/null || true)
+  case "$LATEST_RELEASE_URL" in
+    */releases/tag/*) GITHUB_VERSION="${LATEST_RELEASE_URL##*/}" ;;
+    *) GITHUB_VERSION="" ;;
+  esac
+  if valid_release_tag "$GITHUB_VERSION"; then
+    VERSION="$GITHUB_VERSION"
+  elif valid_release_tag "$METADATA_VERSION"; then
+    VERSION="$METADATA_VERSION"
+    info "GitHub release lookup unavailable; using cached jcode.sh metadata ($VERSION)."
+  fi
+fi
+valid_release_tag "$VERSION" || err "Failed to determine latest version"
 INSTALL_VERSION="${VERSION#v}"
 
-URL_TGZ="https://github.com/$REPO/releases/download/$VERSION/$ARTIFACT.tar.gz"
-URL_BIN="https://github.com/$REPO/releases/download/$VERSION/$ARTIFACT"
+GITHUB_RELEASE_BASE="https://github.com/$REPO/releases/download/$VERSION"
 
 if [ "$IS_WINDOWS" = true ]; then
   EXE=".exe"
@@ -177,10 +207,51 @@ tmpdir=$(mktemp -d)
 
 INSTALL_STAGE="artifact_download"
 download_mode=""
-if curl -fsSL "$URL_TGZ" -o "$tmpdir/jcode.download" 2>/dev/null; then
-  download_mode="tar"
-elif curl -fsSL "$URL_BIN" -o "$tmpdir/jcode.download" 2>/dev/null; then
-  download_mode="bin"
+downloaded_asset=""
+DOWNLOAD_BASES=$(curl -fsSL --retry 2 --connect-timeout 10 \
+  "$RELEASE_METADATA_BASE/$VERSION/download-bases" 2>/dev/null || true)
+DOWNLOAD_BASES=$(printf '%s\n%s\n' "$DOWNLOAD_BASES" "$GITHUB_RELEASE_BASE" |
+  awk '/^https:\/\/[^[:space:]]+$/ && !seen[$0]++')
+
+for candidate in "$ARTIFACT.tar.gz" "$ARTIFACT$EXE"; do
+  while IFS= read -r base; do
+    [ -n "$base" ] || continue
+    if curl -fsSL --retry 2 --connect-timeout 10 \
+      "${base%/}/$candidate" -o "$tmpdir/jcode.download" 2>/dev/null; then
+      downloaded_asset="$candidate"
+      case "$candidate" in
+        *.tar.gz) download_mode="tar" ;;
+        *) download_mode="bin" ;;
+      esac
+      break 2
+    fi
+  done <<EOF
+$DOWNLOAD_BASES
+EOF
+done
+
+if [ -n "$download_mode" ]; then
+  INSTALL_STAGE="artifact_verification"
+  EXPECTED_SHA256=""
+  for checksum_url in \
+    "$RELEASE_METADATA_BASE/$VERSION/SHA256SUMS" \
+    "$GITHUB_RELEASE_BASE/SHA256SUMS"; do
+    CHECKSUMS=$(curl -fsSL --retry 2 --connect-timeout 10 \
+      "$checksum_url" 2>/dev/null || true)
+    EXPECTED_SHA256=$(printf '%s\n' "$CHECKSUMS" |
+      awk -v asset="$downloaded_asset" '$2 == asset || $2 == "*" asset { print tolower($1); exit }')
+    if printf '%s' "$EXPECTED_SHA256" | grep -Eq '^[0-9a-f]{64}$'; then
+      break
+    fi
+    EXPECTED_SHA256=""
+  done
+  printf '%s' "$EXPECTED_SHA256" | grep -Eq '^[0-9a-f]{64}$' \
+    || err "Could not find a trusted SHA-256 checksum for $downloaded_asset in $VERSION"
+  ACTUAL_SHA256=$(sha256_file "$tmpdir/jcode.download") \
+    || err "sha256sum, shasum, or openssl is required to verify the download"
+  [ "$ACTUAL_SHA256" = "$EXPECTED_SHA256" ] \
+    || err "SHA-256 verification failed for $downloaded_asset"
+  info "Verified SHA-256: $downloaded_asset"
 fi
 
 INSTALL_STAGE="binary_install"

--- a/scripts/test_install_conversion.sh
+++ b/scripts/test_install_conversion.sh
@@ -31,10 +31,35 @@ done
 [ -z "${DOWNLOAD_URL_LOG:-}" ] || printf '%s\n' "$url" >> "$DOWNLOAD_URL_LOG"
 case "$url" in
   *telemetry.jcode.sh*) printf '%s\n' "$payload" >> "$INSTALL_TELEMETRY_LOG" ;;
+  *jcode.sh/releases/latest/version)
+    [ "${FAIL_RELEASE:-0}" != "1" ] || exit 22
+    [ "${FAIL_METADATA_RELEASE:-0}" != "1" ] || exit 22
+    printf 'v1.2.3\n'
+    ;;
+  *jcode.sh/releases/v1.2.3/download-bases)
+    printf 'https://mirror.invalid/releases/v1.2.3\n'
+    printf 'https://github.com/1jehuang/jcode/releases/download/v1.2.3\n'
+    ;;
+  *jcode.sh/releases/v1.2.3/SHA256SUMS)
+    if [ "${METADATA_CHECKSUM_HTML:-0}" = "1" ]; then
+      printf '<!doctype html><title>fallback page</title>\n'
+      exit 0
+    fi
+    checksum='8d57abb57a0dae3ff23c8f0df1f51951b7772822e0d560e860d6f68c24ef6d3d'
+    [ "${BAD_CHECKSUM:-0}" != "1" ] || checksum='aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+    printf '%s  %s\n' "$checksum" "${TEST_CHECKSUM_ASSET:-jcode-linux-x86_64.tar.gz}"
+    ;;
+  *github.com*/releases/download/v1.2.3/SHA256SUMS)
+    checksum='8d57abb57a0dae3ff23c8f0df1f51951b7772822e0d560e860d6f68c24ef6d3d'
+    [ "${BAD_CHECKSUM:-0}" != "1" ] || checksum='aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+    printf '%s  %s\n' "$checksum" "${TEST_CHECKSUM_ASSET:-jcode-linux-x86_64.tar.gz}"
+    ;;
   *github.com*/releases/latest)
     [ "${FAIL_RELEASE:-0}" != "1" ] || exit 22
+    [ "${FAIL_GITHUB_RELEASE:-0}" != "1" ] || exit 22
     printf 'https://github.com/1jehuang/jcode/releases/tag/v1.2.3'
     ;;
+  *mirror.invalid*) exit 22 ;;
   *github.com*/releases/download/*)
     [ -n "$output" ] || exit 2
     printf 'fake archive' > "$output"
@@ -82,6 +107,30 @@ grep -q '"stage":"installer_start".*"outcome":"success"' "$telemetry_log"
 grep -q '"stage":"installer_finish".*"outcome":"success"' "$telemetry_log"
 test "$(cat "$hotkey_setup_log")" = "setup-hotkey"
 
+# If GitHub's release page is blocked, the static jcode.sh version endpoint
+# must keep the complete install path working.
+PATH="$tmp/bin:$PATH" \
+HOME="$tmp/home-metadata-fallback" \
+JCODE_HOME="$tmp/home-metadata-fallback/.jcode" \
+JCODE_INSTALL_DIR="$tmp/install-metadata-fallback" \
+JCODE_SKIP_SERVER_RELOAD=1 \
+JCODE_NO_TELEMETRY=1 \
+FAIL_GITHUB_RELEASE=1 \
+bash "$repo_dir/scripts/install.sh" >/dev/null
+test -x "$tmp/install-metadata-fallback/jcode"
+
+# A static host may return its HTML fallback with HTTP 200 for a missing path.
+# Treat that as invalid metadata and continue to GitHub's checksum file.
+PATH="$tmp/bin:$PATH" \
+HOME="$tmp/home-checksum-fallback" \
+JCODE_HOME="$tmp/home-checksum-fallback/.jcode" \
+JCODE_INSTALL_DIR="$tmp/install-checksum-fallback" \
+JCODE_SKIP_SERVER_RELOAD=1 \
+JCODE_NO_TELEMETRY=1 \
+METADATA_CHECKSUM_HTML=1 \
+bash "$repo_dir/scripts/install.sh" >/dev/null
+test -x "$tmp/install-checksum-fallback/jcode"
+
 # Git for Windows can be x64-emulated on Windows ARM64. In that case uname -m
 # reports x86_64 while PROCESSOR_ARCHITEW6432 exposes the native ARM64 OS.
 windows_url_log="$tmp/windows-arm64-urls.log"
@@ -97,6 +146,7 @@ TEST_UNAME_M=x86_64 \
 PROCESSOR_ARCHITECTURE=AMD64 \
 PROCESSOR_ARCHITEW6432=ARM64 \
 TEST_ARCHIVE_ARTIFACT=jcode-windows-aarch64.exe \
+TEST_CHECKSUM_ASSET=jcode-windows-aarch64.tar.gz \
 DOWNLOAD_URL_LOG="$windows_url_log" \
 bash "$repo_dir/scripts/install.sh" >/dev/null
 grep -q '/jcode-windows-aarch64.tar.gz$' "$windows_url_log"
@@ -116,6 +166,21 @@ if PATH="$tmp/bin:$PATH" \
   exit 1
 fi
 grep -q '"stage":"installer_finish".*"outcome":"failure".*"failure_stage":"release_lookup"' "$failure_log"
+
+checksum_failure_log="$tmp/checksum-failure.jsonl"
+if PATH="$tmp/bin:$PATH" \
+  HOME="$tmp/home-checksum-failure" \
+  JCODE_HOME="$tmp/home-checksum-failure/.jcode" \
+  JCODE_INSTALL_DIR="$tmp/install-checksum-failure" \
+  JCODE_INSTALL_CONVERSION_ID="$conversion_id" \
+  JCODE_SKIP_SERVER_RELOAD=1 \
+  INSTALL_TELEMETRY_LOG="$checksum_failure_log" \
+  BAD_CHECKSUM=1 \
+  bash "$repo_dir/scripts/install.sh" >/dev/null 2>&1; then
+  echo "expected checksum verification failure" >&2
+  exit 1
+fi
+grep -q '"stage":"installer_finish".*"outcome":"failure".*"failure_stage":"artifact_verification"' "$checksum_failure_log"
 
 if grep -q 'api.github.com' "$windows_url_log"; then
   echo "installer must not depend on the rate-limited unauthenticated GitHub API" >&2

--- a/scripts/test_windows_setup_evaluation.ps1
+++ b/scripts/test_windows_setup_evaluation.ps1
@@ -154,8 +154,40 @@ try {
     Invoke-Case 'release_lookup_avoids_unauthenticated_github_api' {
         Assert-Equal 'v1.2.3' (Resolve-JcodeReleaseTagFromUri 'https://github.com/1jehuang/jcode/releases/tag/v1.2.3') 'release redirect parser should extract the stable tag'
         Assert-Equal 'v1.2.3-rc.1' (Resolve-JcodeReleaseTagFromUri 'https://github.com/1jehuang/jcode/releases/tag/v1.2.3-rc.1?source=latest') 'release redirect parser should stop before query parameters'
+        Assert-Equal $true (Test-JcodeReleaseTag 'v1.2.3') 'stable release tags should validate'
+        Assert-Equal $false (Test-JcodeReleaseTag 'latest') 'unversioned release labels should not validate'
         $scriptText = Get-Content -LiteralPath $installScript -Raw
         Assert-NotContains $scriptText 'api.github.com/repos/$Repo/releases/latest' 'installer should not use the rate-limited unauthenticated GitHub API'
+        Assert-Contains $scriptText 'jcode.sh/releases' 'installer should include independent static release metadata'
+
+        $script:releaseLookupRequests = @()
+        function Invoke-WebRequest {
+            param(
+                [switch]$UseBasicParsing,
+                [string]$Method,
+                [Parameter(Mandatory = $true)][string]$Uri,
+                [string]$OutFile
+            )
+            $script:releaseLookupRequests += $Uri
+            if ($Uri -eq 'https://jcode.sh/releases/latest/version') {
+                return [pscustomobject]@{ Content = "v1.2.3`n" }
+            }
+            if ($Uri -eq 'https://jcode.sh/releases/v1.2.3/download-bases') {
+                return [pscustomobject]@{ Content = "https://mirror.example/releases/v1.2.3`n" }
+            }
+            if ($Uri -eq 'https://github.com/1jehuang/jcode/releases/latest') {
+                throw 'simulated GitHub block'
+            }
+            throw "unexpected URI: $Uri"
+        }
+        try {
+            Assert-Equal 'v1.2.3' (Get-LatestJcodeReleaseTag) 'static metadata should cover a blocked GitHub release lookup'
+            $bases = @(Get-JcodeReleaseDownloadBases 'v1.2.3')
+            Assert-Equal 'https://mirror.example/releases/v1.2.3' $bases[0] 'configured mirror should be preferred'
+            Assert-Equal 'https://github.com/1jehuang/jcode/releases/download/v1.2.3' $bases[1] 'GitHub should remain the final fallback'
+        } finally {
+            Remove-Item Function:\Invoke-WebRequest -ErrorAction SilentlyContinue
+        }
     }
 
     Invoke-Case 'path_persistence_and_deduplication' {

--- a/scripts/uninstall.ps1
+++ b/scripts/uninstall.ps1
@@ -373,7 +373,7 @@ if ($pathUpdate.Changed) {
 }
 
 Write-Info "jcode uninstalled."
-Write-Info "Reinstall with: irm https://raw.githubusercontent.com/1jehuang/jcode/master/scripts/install.ps1 | iex"
+Write-Info "Reinstall with: irm https://jcode.sh/install.ps1 | iex"
 
 
     return 0

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -126,7 +126,7 @@ fi
 
 info "jcode uninstalled."
 if [ "$PURGE" = false ]; then
-  info "Reinstall with: curl -fsSL https://raw.githubusercontent.com/1jehuang/jcode/master/scripts/install.sh | bash"
+  info "Reinstall with: curl -fsSL https://jcode.sh/install | bash"
 else
-  info "All jcode data wiped. Reinstall with: curl -fsSL https://raw.githubusercontent.com/1jehuang/jcode/master/scripts/install.sh | bash"
+  info "All jcode data wiped. Reinstall with: curl -fsSL https://jcode.sh/install | bash"
 fi


### PR DESCRIPTION
## Summary
- use jcode.sh metadata as an independent fallback while keeping GitHub latest authoritative when reachable
- consume ordered download bases so an R2 mirror can be enabled without changing installer commands
- verify Unix downloads against SHA-256 and retain Windows checksum verification with metadata fallback
- point public documentation at direct jcode.sh installers

## Validation
- `bash scripts/test_install_conversion.sh`
- PowerShell parser and deterministic fallback case
- isolated live install of v0.49.0 with SHA-256 verification
- exact public `curl -fsSL https://jcode.sh/install | bash` isolated install
