### PR TITLE
fix(copilot): send Sonnet 5 reasoning effort

### DIFF
--- a/crates/jcode-base/src/provider/mod.rs
+++ b/crates/jcode-base/src/provider/mod.rs
@@ -2215,7 +2215,7 @@ impl Provider for MultiProvider {
                 }
             }
             ActiveProvider::OpenAI => self.openai_provider().and_then(|o| o.reasoning_effort()),
-            ActiveProvider::Copilot => None,
+            ActiveProvider::Copilot => self.copilot_provider().and_then(|o| o.reasoning_effort()),
             ActiveProvider::Antigravity => None,
             ActiveProvider::Gemini => None,
             ActiveProvider::Cursor => None,
@@ -2235,6 +2235,10 @@ impl Provider for MultiProvider {
             ActiveProvider::OpenAI => self
                 .openai_provider()
                 .ok_or_else(|| anyhow::anyhow!("OpenAI provider not available"))?
+                .set_reasoning_effort(effort),
+            ActiveProvider::Copilot => self
+                .copilot_provider()
+                .ok_or_else(|| anyhow::anyhow!("Copilot provider not available"))?
                 .set_reasoning_effort(effort),
             ActiveProvider::OpenRouter => self
                 .active_openrouter_execution_provider()
@@ -2260,7 +2264,10 @@ impl Provider for MultiProvider {
                 .active_openrouter_execution_provider()
                 .map(|o| o.available_efforts())
                 .unwrap_or_default(),
-            ActiveProvider::Copilot => vec![],
+            ActiveProvider::Copilot => self
+                .copilot_provider()
+                .map(|o| o.available_efforts())
+                .unwrap_or_default(),
             ActiveProvider::Antigravity => vec![],
             ActiveProvider::Gemini => vec![],
             ActiveProvider::Cursor => vec![],

--- a/crates/jcode-base/src/provider/mod.rs
+++ b/crates/jcode-base/src/provider/mod.rs
@@ -2256,10 +2256,10 @@ impl Provider for MultiProvider {
                 .active_openrouter_execution_provider()
                 .map(|o| o.available_efforts())
                 .unwrap_or_default(),
-            ActiveProvider::Copilot => self
-                .copilot_provider()
-                .map(|o| o.available_efforts())
-                .unwrap_or_default(),
+            ActiveProvider::Copilot => match self.copilot_provider() {
+                Some(provider) => provider.available_efforts(),
+                None => vec![],
+            },
             _ => vec![],
         }
     }

--- a/crates/jcode-base/src/provider/mod.rs
+++ b/crates/jcode-base/src/provider/mod.rs
@@ -2206,23 +2206,15 @@ impl Provider for MultiProvider {
 
     fn reasoning_effort(&self) -> Option<String> {
         match self.active_provider() {
-            ActiveProvider::Claude => {
-                if self.use_claude_cli {
-                    None
-                } else {
-                    self.anthropic_provider()
-                        .and_then(|provider| provider.reasoning_effort())
-                }
-            }
+            ActiveProvider::Claude if !self.use_claude_cli => self
+                .anthropic_provider()
+                .and_then(|provider| provider.reasoning_effort()),
             ActiveProvider::OpenAI => self.openai_provider().and_then(|o| o.reasoning_effort()),
             ActiveProvider::Copilot => self.copilot_provider().and_then(|o| o.reasoning_effort()),
-            ActiveProvider::Antigravity => None,
-            ActiveProvider::Gemini => None,
-            ActiveProvider::Cursor => None,
-            ActiveProvider::Bedrock => None,
             ActiveProvider::OpenRouter => self
                 .active_openrouter_execution_provider()
                 .and_then(|o| o.reasoning_effort()),
+            _ => None,
         }
     }
 
@@ -2268,9 +2260,6 @@ impl Provider for MultiProvider {
                 .copilot_provider()
                 .map(|o| o.available_efforts())
                 .unwrap_or_default(),
-            ActiveProvider::Antigravity => vec![],
-            ActiveProvider::Gemini => vec![],
-            ActiveProvider::Cursor => vec![],
             _ => vec![],
         }
     }

--- a/crates/jcode-provider-copilot-runtime/src/copilot_tests.rs
+++ b/crates/jcode-provider-copilot-runtime/src/copilot_tests.rs
@@ -14,6 +14,7 @@ fn make_test_provider(fetched: Vec<String>) -> CopilotApiProvider {
         init_done: Arc::new(std::sync::atomic::AtomicBool::new(true)),
         premium_mode: Arc::new(std::sync::atomic::AtomicU8::new(0)),
         user_turn_count: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+        reasoning_effort: Arc::new(RwLock::new(None)),
         created_at: std::time::Instant::now(),
     }
 }
@@ -659,4 +660,92 @@ fn build_messages_sanitizes_missing_tool_output_ids() {
 
     assert_eq!(built[1]["tool_calls"][0]["id"], "call_with_dots_orphan");
     assert_eq!(built[2]["tool_call_id"], "call_with_dots_orphan");
+}
+
+fn sonnet5_provider() -> CopilotApiProvider {
+    let provider = make_test_provider(vec![]);
+    provider.set_model("claude-sonnet-5").unwrap();
+    provider
+}
+
+#[test]
+fn sonnet5_reasoning_effort_serialized_when_set() {
+    let provider = sonnet5_provider();
+    Provider::set_reasoning_effort(&provider, "high").unwrap();
+    let mut body = serde_json::json!({"model": "claude-sonnet-5"});
+    provider.add_reasoning_effort_parameter(&mut body, "claude-sonnet-5");
+    assert_eq!(body["reasoning_effort"], "high");
+    assert_eq!(
+        Provider::reasoning_effort(&provider).as_deref(),
+        Some("high")
+    );
+}
+
+#[test]
+fn sonnet5_reasoning_effort_absent_when_unset() {
+    let provider = sonnet5_provider();
+    let mut body = serde_json::json!({"model": "claude-sonnet-5"});
+    provider.add_reasoning_effort_parameter(&mut body, "claude-sonnet-5");
+    assert!(body.get("reasoning_effort").is_none());
+    assert_eq!(Provider::reasoning_effort(&provider), None);
+}
+
+#[test]
+fn sonnet5_rejects_invalid_efforts() {
+    let provider = sonnet5_provider();
+    for bad in ["none", "minimal", "banana", ""] {
+        let err = Provider::set_reasoning_effort(&provider, bad).unwrap_err();
+        assert!(
+            err.to_string().contains("Unsupported reasoning effort"),
+            "{bad}: {err}"
+        );
+    }
+    assert_eq!(Provider::reasoning_effort(&provider), None);
+}
+
+#[test]
+fn sonnet5_accepts_all_supported_efforts() {
+    let provider = sonnet5_provider();
+    for effort in ["low", "medium", "high", "xhigh", "max"] {
+        Provider::set_reasoning_effort(&provider, effort).unwrap();
+        assert_eq!(
+            Provider::reasoning_effort(&provider).as_deref(),
+            Some(effort)
+        );
+    }
+    assert_eq!(
+        Provider::available_efforts(&provider),
+        vec!["low", "medium", "high", "xhigh", "max"]
+    );
+}
+
+#[test]
+fn non_sonnet_models_have_no_reasoning_effort() {
+    let provider = make_test_provider(vec![]);
+    provider.set_model("gpt-5.1-codex").unwrap();
+    assert!(Provider::available_efforts(&provider).is_empty());
+    let err = Provider::set_reasoning_effort(&provider, "high").unwrap_err();
+    assert!(err.to_string().contains("not supported"));
+    let mut body = serde_json::json!({"model": "gpt-5.1-codex"});
+    provider.add_reasoning_effort_parameter(&mut body, "gpt-5.1-codex");
+    assert!(body.get("reasoning_effort").is_none());
+}
+
+#[test]
+fn effort_not_serialized_after_switching_away_from_sonnet5() {
+    let provider = sonnet5_provider();
+    Provider::set_reasoning_effort(&provider, "max").unwrap();
+    provider.set_model("gpt-5.1-codex").unwrap();
+    let mut body = serde_json::json!({"model": "gpt-5.1-codex"});
+    provider.add_reasoning_effort_parameter(&mut body, "gpt-5.1-codex");
+    assert!(body.get("reasoning_effort").is_none());
+    assert_eq!(Provider::reasoning_effort(&provider), None);
+}
+
+#[test]
+fn fork_preserves_reasoning_effort() {
+    let provider = sonnet5_provider();
+    Provider::set_reasoning_effort(&provider, "xhigh").unwrap();
+    let forked = Provider::fork(&provider);
+    assert_eq!(forked.reasoning_effort().as_deref(), Some("xhigh"));
 }

--- a/crates/jcode-provider-copilot-runtime/src/lib.rs
+++ b/crates/jcode-provider-copilot-runtime/src/lib.rs
@@ -51,7 +51,16 @@ pub struct CopilotApiProvider {
     init_done: Arc<std::sync::atomic::AtomicBool>,
     premium_mode: Arc<std::sync::atomic::AtomicU8>,
     user_turn_count: Arc<std::sync::atomic::AtomicU64>,
+    reasoning_effort: Arc<RwLock<Option<String>>>,
     created_at: std::time::Instant,
+}
+
+/// Reasoning efforts supported by Copilot's claude-sonnet-5 route,
+/// per live `/models` capabilities (issue #558).
+const SONNET5_EFFORTS: [&str; 5] = ["low", "medium", "high", "xhigh", "max"];
+
+fn copilot_model_supports_reasoning_effort(model: &str) -> bool {
+    model == "claude-sonnet-5"
 }
 
 impl CopilotApiProvider {
@@ -62,6 +71,23 @@ impl CopilotApiProvider {
 
     fn add_max_token_parameter(body: &mut Value, model: &str, max_tokens: u32) {
         add_copilot_max_token_parameter(body, model, max_tokens);
+    }
+
+    fn current_reasoning_effort(&self) -> Option<String> {
+        self.reasoning_effort
+            .try_read()
+            .ok()
+            .and_then(|guard| guard.clone())
+    }
+
+    /// Add top-level `reasoning_effort` when set and the model supports it.
+    fn add_reasoning_effort_parameter(&self, body: &mut Value, model: &str) {
+        if !copilot_model_supports_reasoning_effort(model) {
+            return;
+        }
+        if let Some(effort) = self.current_reasoning_effort() {
+            body["reasoning_effort"] = json!(effort);
+        }
     }
 
     fn persisted_catalog_path() -> Result<std::path::PathBuf> {
@@ -137,6 +163,7 @@ impl CopilotApiProvider {
             init_done: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             premium_mode: Arc::new(std::sync::atomic::AtomicU8::new(Self::env_premium_mode())),
             user_turn_count: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+            reasoning_effort: Arc::new(RwLock::new(None)),
             created_at: std::time::Instant::now(),
         };
         provider.seed_cached_catalog();
@@ -172,6 +199,7 @@ impl CopilotApiProvider {
             init_done: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             premium_mode: Arc::new(std::sync::atomic::AtomicU8::new(Self::env_premium_mode())),
             user_turn_count: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+            reasoning_effort: Arc::new(RwLock::new(None)),
             created_at: std::time::Instant::now(),
         };
         provider.seed_cached_catalog();
@@ -475,6 +503,7 @@ impl CopilotApiProvider {
                 "stream": true,
             });
             Self::add_max_token_parameter(&mut body, &model, max_tokens);
+            self.add_reasoning_effort_parameter(&mut body, &model);
 
             if !tools.is_empty() {
                 body["tools"] = json!(tools);
@@ -885,6 +914,7 @@ impl Provider for CopilotApiProvider {
             "tools": &built_tools,
         });
         Self::add_max_token_parameter(&mut canonical_payload, &model_for_fingerprint, 32_768u32);
+        self.add_reasoning_effort_parameter(&mut canonical_payload, &model_for_fingerprint);
         let system_value = built_messages
             .first()
             .filter(|message| message.get("role").and_then(|role| role.as_str()) == Some("system"))
@@ -921,6 +951,7 @@ impl Provider for CopilotApiProvider {
             init_done: self.init_done.clone(),
             premium_mode: self.premium_mode.clone(),
             user_turn_count: self.user_turn_count.clone(),
+            reasoning_effort: self.reasoning_effort.clone(),
             created_at: self.created_at,
         };
 
@@ -1032,8 +1063,48 @@ impl Provider for CopilotApiProvider {
             init_done: self.init_done.clone(),
             premium_mode: self.premium_mode.clone(),
             user_turn_count: self.user_turn_count.clone(),
+            reasoning_effort: self.reasoning_effort.clone(),
             created_at: self.created_at,
         })
+    }
+
+    fn reasoning_effort(&self) -> Option<String> {
+        if !copilot_model_supports_reasoning_effort(&self.model()) {
+            return None;
+        }
+        self.current_reasoning_effort()
+    }
+
+    fn set_reasoning_effort(&self, effort: &str) -> Result<()> {
+        let model = self.model();
+        if !copilot_model_supports_reasoning_effort(&model) {
+            anyhow::bail!(
+                "Reasoning effort is not supported for Copilot model '{}' (only claude-sonnet-5)",
+                model
+            );
+        }
+        let normalized = effort.trim().to_lowercase();
+        if !SONNET5_EFFORTS.contains(&normalized.as_str()) {
+            anyhow::bail!(
+                "Unsupported reasoning effort '{}' for Copilot claude-sonnet-5. Supported: {}",
+                effort,
+                SONNET5_EFFORTS.join(", ")
+            );
+        }
+        let mut guard = self
+            .reasoning_effort
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        *guard = Some(normalized);
+        Ok(())
+    }
+
+    fn available_efforts(&self) -> Vec<&'static str> {
+        if copilot_model_supports_reasoning_effort(&self.model()) {
+            SONNET5_EFFORTS.to_vec()
+        } else {
+            vec![]
+        }
     }
 }
 

--- a/crates/jcode-provider-copilot-runtime/src/lib.rs
+++ b/crates/jcode-provider-copilot-runtime/src/lib.rs
@@ -75,9 +75,9 @@ impl CopilotApiProvider {
 
     fn current_reasoning_effort(&self) -> Option<String> {
         self.reasoning_effort
-            .try_read()
-            .ok()
-            .and_then(|guard| guard.clone())
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone()
     }
 
     /// Add top-level `reasoning_effort` when set and the model supports it.


### PR DESCRIPTION
Fixes #558.

The GitHub Copilot runtime silently dropped configured reasoning effort for `copilot:claude-sonnet-5`, letting the backend pick its default.

## Changes

- **Copilot runtime** (`jcode-provider-copilot-runtime`):
  - `available_efforts()` returns `low, medium, high, xhigh, max` when the active model is `claude-sonnet-5` (empty otherwise), matching the live `/models` capabilities.
  - `set_reasoning_effort()` / `reasoning_effort()` store and report the value; `none`, `minimal`, and unknown values are rejected locally with a clear error (the API returns 400 for them).
  - Top-level `"reasoning_effort"` is serialized in `/chat/completions` request bodies and the canonical fingerprint payload, only when set and the model is `claude-sonnet-5`.
  - `fork()` and per-request clones preserve the value.
- **jcode-base**: `ActiveProvider::Copilot` now delegates the three effort methods to the Copilot provider instead of hardcoding `None` / `vec![]` / an error.

Other Copilot models are untouched until their API contracts are independently verified.

## Testing

- `cargo check -p jcode-provider-copilot-runtime -p jcode-base`
- `cargo test -p jcode-provider-copilot-runtime`: 31 passed, including new tests for serialization present/absent, invalid-value rejection, all supported values, non-Sonnet gating, model-switch behavior, and fork preservation.

---
*— Jcode agent (automated triage), on behalf of @1jehuang*