### PR TITLE
fix(mcp): run owned servers in session cwd and keep them out of shared pool

### DIFF
--- a/crates/jcode-base/src/mcp/client.rs
+++ b/crates/jcode-base/src/mcp/client.rs
@@ -123,22 +123,40 @@ pub struct McpClient {
 }
 
 impl McpClient {
-    /// Connect to an MCP server
+    /// Connect to an MCP server, inheriting the current process working directory
     pub async fn connect(name: String, config: &McpServerConfig) -> Result<Self> {
+        Self::connect_in_dir(name, config, None).await
+    }
+
+    /// Connect to an MCP server, optionally running it in `working_dir`.
+    ///
+    /// The working directory is only applied when it exists; otherwise the
+    /// subprocess falls back to inheriting the current process cwd (issue #557).
+    pub async fn connect_in_dir(
+        name: String,
+        config: &McpServerConfig,
+        working_dir: Option<&std::path::Path>,
+    ) -> Result<Self> {
+        let working_dir = working_dir.filter(|dir| dir.is_dir());
         crate::logging::info(&format!(
-            "MCP: Connecting to '{}' ({} {:?})",
-            name, config.command, config.args
+            "MCP: Connecting to '{}' ({} {:?}) cwd={:?}",
+            name, config.command, config.args, working_dir
         ));
 
         let mut env: HashMap<String, String> = std::env::vars().collect();
         env.extend(config.env.clone());
 
-        let mut child = Command::new(&config.command)
+        let mut command = Command::new(&config.command);
+        command
             .args(&config.args)
             .envs(&env)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
+            .stderr(Stdio::piped());
+        if let Some(dir) = working_dir {
+            command.current_dir(dir);
+        }
+        let mut child = command
             .spawn()
             .with_context(|| format!("Failed to spawn MCP server: {}", config.command))?;
 
@@ -349,5 +367,75 @@ impl McpClient {
 impl Drop for McpClient {
     fn drop(&mut self) {
         let _ = self.child.start_kill();
+    }
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::McpClient;
+    use crate::mcp::protocol::McpServerConfig;
+
+    /// A minimal fake stdio MCP server (shell script) that reports its own
+    /// process cwd as the serverInfo name.
+    fn fake_server_config() -> McpServerConfig {
+        let script = r#"
+while IFS= read -r line; do
+  case "$line" in
+    *'"initialize"'*)
+      printf '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2024-11-05","capabilities":{},"serverInfo":{"name":"%s","version":"0"}}}\n' "$PWD"
+      ;;
+    *'"tools/list"'*)
+      printf '{"jsonrpc":"2.0","id":2,"result":{"tools":[]}}\n'
+      ;;
+  esac
+done
+"#;
+        McpServerConfig {
+            command: "/bin/sh".to_string(),
+            args: vec!["-c".to_string(), script.to_string()],
+            env: Default::default(),
+            shared: false,
+            transport: None,
+            url: None,
+            enabled: None,
+            disabled: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn connect_in_dir_sets_subprocess_cwd() {
+        // Issue #557: owned MCP servers must run in the session project dir.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let expected = dir.path().canonicalize().expect("canonicalize");
+
+        let client = McpClient::connect_in_dir(
+            "cwd-test".to_string(),
+            &fake_server_config(),
+            Some(dir.path()),
+        )
+        .await
+        .expect("connect");
+
+        let reported = client.server_info().expect("server info").name;
+        assert_eq!(
+            std::path::Path::new(&reported)
+                .canonicalize()
+                .expect("canonicalize reported"),
+            expected
+        );
+    }
+
+    #[tokio::test]
+    async fn connect_in_dir_missing_dir_falls_back_to_inherited_cwd() {
+        let client = McpClient::connect_in_dir(
+            "cwd-fallback-test".to_string(),
+            &fake_server_config(),
+            Some(std::path::Path::new("/nonexistent/jcode-557")),
+        )
+        .await
+        .expect("connect should fall back to inherited cwd");
+
+        let reported = client.server_info().expect("server info").name;
+        assert!(!reported.is_empty());
     }
 }

--- a/crates/jcode-base/src/mcp/manager.rs
+++ b/crates/jcode-base/src/mcp/manager.rs
@@ -163,8 +163,11 @@ impl McpManager {
             for (name, config) in owned_servers {
                 let name = name.clone();
                 let config = config.clone();
+                let project_dir = self.project_dir.clone();
                 let handle = tokio::spawn(async move {
-                    let result = McpClient::connect(name.clone(), &config).await;
+                    let result =
+                        McpClient::connect_in_dir(name.clone(), &config, project_dir.as_deref())
+                            .await;
                     (name, result)
                 });
                 spawn_handles.push(handle);
@@ -226,9 +229,10 @@ impl McpManager {
         }
 
         // Owned (non-shared or no pool available)
-        let client = McpClient::connect(name.to_string(), config)
-            .await
-            .with_context(|| format!("Failed to connect to MCP server '{}'", name))?;
+        let client =
+            McpClient::connect_in_dir(name.to_string(), config, self.project_dir.as_deref())
+                .await
+                .with_context(|| format!("Failed to connect to MCP server '{}'", name))?;
 
         self.owned_clients
             .write()

--- a/crates/jcode-base/src/mcp/pool.rs
+++ b/crates/jcode-base/src/mcp/pool.rs
@@ -74,6 +74,11 @@ impl SharedMcpPool {
             if !server_config.is_enabled() {
                 continue;
             }
+            // Non-shared servers are owned per-session (with the session cwd)
+            // and must never be spawned in the daemon-global pool (issue #557).
+            if !server_config.shared {
+                continue;
+            }
             let name = name.clone();
             let server_config = server_config.clone();
             connect_futures.push(async move {
@@ -430,5 +435,34 @@ mod tests {
         };
 
         assert!(Arc::ptr_eq(&first_notify, &second_notify));
+    }
+
+    #[tokio::test]
+    async fn connect_all_skips_non_shared_servers() {
+        // Issue #557: shared:false servers are owned per-session and must not
+        // be spawned in the daemon-global pool. If the pool tried to connect
+        // this nonexistent command it would show up as a failure.
+        let mut config = McpConfig::default();
+        config.servers.insert(
+            "owned-only".to_string(),
+            crate::mcp::protocol::McpServerConfig {
+                command: "/nonexistent/jcode-test-mcp-557".to_string(),
+                args: vec![],
+                env: Default::default(),
+                shared: false,
+                transport: None,
+                url: None,
+                enabled: None,
+                disabled: None,
+            },
+        );
+        let pool = SharedMcpPool::new(config);
+
+        let (successes, failures) = pool.connect_all().await;
+        assert_eq!(successes, 0);
+        assert!(
+            failures.is_empty(),
+            "non-shared server must be skipped, got failures: {failures:?}"
+        );
     }
 }


### PR DESCRIPTION
Fixes #557.

## Problem
- Owned (`shared: false`) MCP servers were spawned via `McpClient::connect`, which never set `Command::current_dir`, so in daemon mode they inherited the daemon cwd instead of the session workspace.
- `SharedMcpPool::connect_all` only filtered on `is_enabled()`, so `shared: false` servers were also spawned once globally in the pool.

## Fix
- Added `McpClient::connect_in_dir(name, config, working_dir)`; applies `Command::current_dir` only when the directory exists, otherwise falls back to the inherited cwd. `connect` delegates to it with `None`.
- `McpManager` now passes its `project_dir` to owned connections in both `connect_all` and the on-demand `connect` path (which also backs connect-on-first-call).
- `SharedMcpPool::connect_all` skips `shared: false` servers.

## Tests
- `mcp::client::tests::connect_in_dir_sets_subprocess_cwd`: fake stdio MCP server reports its `$PWD`; asserts it matches the requested dir.
- `mcp::client::tests::connect_in_dir_missing_dir_falls_back_to_inherited_cwd`
- `mcp::pool::tests::connect_all_skips_non_shared_servers`
- `cargo check -p jcode-base` and `cargo test -p jcode-base mcp` (35 passed) are green.

---
*— Jcode agent (automated triage), on behalf of @1jehuang*