### PR TITLE
fix(stream): stop dropping SSE data on chunk and event boundaries (fixes #609)

### DIFF
--- a/crates/jcode-core/src/sse_stream_integrity_tests.rs
+++ b/crates/jcode-core/src/sse_stream_integrity_tests.rs
@@ -1,0 +1,121 @@
+//! Regression coverage for #609: SSE stream data corruption.
+use super::*;
+
+#[test]
+fn multibyte_char_split_across_chunks_is_not_dropped() {
+    // "读" is 3 bytes; split it after the first byte.
+    let full = "读取文件".as_bytes().to_vec();
+    let mut decoder = Utf8StreamDecoder::new();
+    let mut out = String::new();
+    out.push_str(&decoder.decode(&full[..1]));
+    assert!(
+        decoder.has_pending_bytes(),
+        "partial char must be held back"
+    );
+    out.push_str(&decoder.decode(&full[1..]));
+    out.push_str(&decoder.flush());
+    assert_eq!(out, "读取文件");
+}
+
+#[test]
+fn every_single_byte_split_point_round_trips() {
+    // State-space sweep: splitting at any byte offset must reproduce the input.
+    let text = "hello 读取 世界 mixed ascii";
+    let bytes = text.as_bytes();
+    for split in 0..=bytes.len() {
+        let mut decoder = Utf8StreamDecoder::new();
+        let mut out = decoder.decode(&bytes[..split]);
+        out.push_str(&decoder.decode(&bytes[split..]));
+        out.push_str(&decoder.flush());
+        assert_eq!(out, text, "failed at split offset {split}");
+    }
+}
+
+#[test]
+fn byte_at_a_time_delivery_round_trips() {
+    let text = "读取文件 with ascii tail";
+    let mut decoder = Utf8StreamDecoder::new();
+    let mut out = String::new();
+    for byte in text.as_bytes() {
+        out.push_str(&decoder.decode(&[*byte]));
+    }
+    out.push_str(&decoder.flush());
+    assert_eq!(out, text);
+}
+
+#[test]
+fn genuinely_invalid_bytes_do_not_discard_surrounding_text() {
+    let mut decoder = Utf8StreamDecoder::new();
+    let mut bytes = b"good".to_vec();
+    bytes.push(0xFF); // never valid in UTF-8
+    bytes.extend_from_slice(b"tail");
+    let out = decoder.decode(&bytes);
+    assert!(out.starts_with("good"), "leading good text kept: {out:?}");
+    assert!(out.ends_with("tail"), "trailing good text kept: {out:?}");
+    assert!(out.contains('\u{FFFD}'));
+}
+
+#[test]
+fn well_formed_single_object_is_not_treated_as_concatenated() {
+    assert_eq!(split_concatenated_json(r#"{"id":"a"}"#), None);
+}
+
+#[test]
+fn concatenated_objects_are_split() {
+    let split = split_concatenated_json(r#"{"id":"a"}{"id":"b"}"#).expect("split");
+    assert_eq!(split.objects, vec![r#"{"id":"a"}"#, r#"{"id":"b"}"#]);
+    assert_eq!(split.trailing_partial, None);
+}
+
+#[test]
+fn concatenation_with_embedded_data_prefix_is_split() {
+    let split = split_concatenated_json(r#"{"id":"a"}data: {"id":"b"}"#).expect("split");
+    assert_eq!(split.objects, vec![r#"{"id":"a"}"#, r#"{"id":"b"}"#]);
+}
+
+#[test]
+fn braces_inside_strings_do_not_confuse_the_splitter() {
+    let payload = r#"{"content":"a } b { c"}{"id":"second"}"#;
+    let split = split_concatenated_json(payload).expect("split");
+    assert_eq!(
+        split.objects,
+        vec![r#"{"content":"a } b { c"}"#, r#"{"id":"second"}"#]
+    );
+}
+
+#[test]
+fn escaped_quote_inside_string_is_handled() {
+    let payload = r#"{"content":"say \"hi\" }"}{"id":"second"}"#;
+    let split = split_concatenated_json(payload).expect("split");
+    assert_eq!(
+        split.objects,
+        vec![r#"{"content":"say \"hi\" }"}"#, r#"{"id":"second"}"#]
+    );
+}
+
+#[test]
+fn truncated_trailing_object_is_reported_for_carry_over() {
+    let split =
+        split_concatenated_json(r#"{"choices":[{"delta":{"content":"Hello "#).expect("split");
+    assert!(split.objects.is_empty());
+    assert_eq!(
+        split.trailing_partial.as_deref(),
+        Some(r#"{"choices":[{"delta":{"content":"Hello "#)
+    );
+}
+
+#[test]
+fn split_object_rejoins_into_valid_json() {
+    // Event 1 truncated, event 2 carries the remainder.
+    let first = r#"{"choices":[{"delta":{"content":"Hello "#;
+    let second = r#"world"}}]}"#;
+    let split = split_concatenated_json(first).expect("partial");
+    let mut rejoined = split.trailing_partial.expect("partial text");
+    rejoined.push_str(second);
+    assert_eq!(
+        rejoined,
+        r#"{"choices":[{"delta":{"content":"Hello world"}}]}"#
+    );
+    // Brace-balanced after rejoin, so a downstream JSON parse will succeed.
+    assert_eq!(split_concatenated_json(&rejoined), None);
+}

--- a/crates/jcode-core/src/util.rs
+++ b/crates/jcode-core/src/util.rs
@@ -78,6 +78,163 @@ pub fn sse_data_line(line: &str) -> Option<&str> {
         .map(|rest| rest.strip_prefix(' ').unwrap_or(rest))
 }
 
+/// Incremental UTF-8 decoder for byte streams whose chunk boundaries are not
+/// guaranteed to fall on character boundaries.
+///
+/// Providers stream SSE over HTTPS, and a multi-byte character (e.g. a 3-byte
+/// CJK codepoint) is routinely split across two TCP chunks. Calling
+/// `str::from_utf8` on each chunk in isolation fails in that case, and callers
+/// that used `if let Ok(text) = ...` silently dropped the entire chunk, losing
+/// text and truncating tool-call arguments. See issue #609.
+///
+/// This decoder carries the incomplete trailing bytes over to the next chunk so
+/// no input is ever discarded. Genuinely invalid sequences are replaced with
+/// U+FFFD rather than dropping surrounding good data.
+#[derive(Debug, Default)]
+pub struct Utf8StreamDecoder {
+    carry: Vec<u8>,
+}
+
+impl Utf8StreamDecoder {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Decode the next chunk, holding back any incomplete trailing character.
+    pub fn decode(&mut self, chunk: &[u8]) -> String {
+        let bytes: &[u8] = if self.carry.is_empty() {
+            chunk
+        } else {
+            self.carry.extend_from_slice(chunk);
+            &self.carry
+        };
+
+        match std::str::from_utf8(bytes) {
+            Ok(text) => {
+                let out = text.to_string();
+                self.carry.clear();
+                out
+            }
+            Err(error) => {
+                let valid_up_to = error.valid_up_to();
+                // SAFETY-equivalent: `valid_up_to` is a guaranteed char boundary.
+                let good = std::str::from_utf8(&bytes[..valid_up_to])
+                    .unwrap_or_default()
+                    .to_string();
+                let rest = bytes[valid_up_to..].to_vec();
+                match error.error_len() {
+                    // Truncated but potentially valid: keep it for the next chunk.
+                    None => {
+                        self.carry = rest;
+                        good
+                    }
+                    // Genuinely invalid bytes: emit a replacement char and keep going
+                    // rather than discarding the rest of the chunk.
+                    Some(invalid_len) => {
+                        self.carry.clear();
+                        let mut out = good;
+                        out.push('\u{FFFD}');
+                        out.push_str(&self.decode(&rest[invalid_len..]));
+                        out
+                    }
+                }
+            }
+        }
+    }
+
+    /// Flush anything still held back when the stream ends. A non-empty result
+    /// means the stream ended mid-character, which is upstream truncation.
+    pub fn flush(&mut self) -> String {
+        if self.carry.is_empty() {
+            return String::new();
+        }
+        let carry = std::mem::take(&mut self.carry);
+        String::from_utf8_lossy(&carry).into_owned()
+    }
+
+    pub fn has_pending_bytes(&self) -> bool {
+        !self.carry.is_empty()
+    }
+}
+
+/// Split a payload that contains several concatenated JSON objects.
+///
+/// Some proxies drop the `\n\n` SSE event separator, producing payloads like
+/// `{"id":"a"}{"id":"b"}` or `{"id":"a"}data: {"id":"b"}`. `serde_json` rejects
+/// those wholesale with "trailing characters", which discarded every object in
+/// the blob. Callers should attempt a normal parse first and only fall back to
+/// this on failure, so well-formed payloads keep their existing behavior.
+///
+/// Returns `None` when the payload is not a recoverable concatenation (fewer
+/// than two complete objects), leaving the caller's original error intact.
+/// A trailing incomplete object is reported separately so the caller can carry
+/// it over to the next event instead of losing it.
+pub fn split_concatenated_json(payload: &str) -> Option<SplitJson> {
+    let bytes = payload.as_bytes();
+    let mut objects = Vec::new();
+    let mut depth = 0usize;
+    let mut start: Option<usize> = None;
+    let mut in_string = false;
+    let mut escaped = false;
+
+    for (i, &b) in bytes.iter().enumerate() {
+        if in_string {
+            if escaped {
+                escaped = false;
+            } else if b == b'\\' {
+                escaped = true;
+            } else if b == b'"' {
+                in_string = false;
+            }
+            continue;
+        }
+        match b {
+            b'"' => in_string = true,
+            b'{' => {
+                if depth == 0 {
+                    start = Some(i);
+                }
+                depth += 1;
+            }
+            b'}' => {
+                depth = depth.saturating_sub(1);
+                if depth == 0
+                    && let Some(s) = start.take()
+                {
+                    objects.push(payload[s..=i].to_string());
+                }
+            }
+            _ => {}
+        }
+    }
+
+    // An unterminated final object: hand the partial text back to the caller.
+    let trailing_partial = start.map(|s| payload[s..].to_string());
+
+    if objects.len() < 2 && trailing_partial.is_none() {
+        return None;
+    }
+    if objects.is_empty() && trailing_partial.is_some() {
+        return Some(SplitJson {
+            objects,
+            trailing_partial,
+        });
+    }
+    Some(SplitJson {
+        objects,
+        trailing_partial,
+    })
+}
+
+/// Result of [`split_concatenated_json`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SplitJson {
+    /// Complete, brace-balanced JSON objects, in stream order.
+    pub objects: Vec<String>,
+    /// A trailing object whose braces never closed, if any.
+    pub trailing_partial: Option<String>,
+}
+
 #[cfg(unix)]
 fn read_max_open_files_limits() -> Option<(String, String)> {
     let contents = std::fs::read_to_string("/proc/self/limits").ok()?;
@@ -244,5 +401,130 @@ mod tests {
             approx_tool_output_token_severity(12_000),
             ApproxTokenSeverity::Danger
         );
+    }
+}
+
+#[cfg(test)]
+mod sse_stream_integrity_tests {
+    //! Regression coverage for #609: SSE stream data corruption.
+    use super::*;
+
+    #[test]
+    fn multibyte_char_split_across_chunks_is_not_dropped() {
+        // "读" is 3 bytes; split it after the first byte.
+        let full = "读取文件".as_bytes().to_vec();
+        let mut decoder = Utf8StreamDecoder::new();
+        let mut out = String::new();
+        out.push_str(&decoder.decode(&full[..1]));
+        assert!(
+            decoder.has_pending_bytes(),
+            "partial char must be held back"
+        );
+        out.push_str(&decoder.decode(&full[1..]));
+        out.push_str(&decoder.flush());
+        assert_eq!(out, "读取文件");
+    }
+
+    #[test]
+    fn every_single_byte_split_point_round_trips() {
+        // State-space sweep: splitting at any byte offset must reproduce the input.
+        let text = "hello 读取 世界 mixed ascii";
+        let bytes = text.as_bytes();
+        for split in 0..=bytes.len() {
+            let mut decoder = Utf8StreamDecoder::new();
+            let mut out = decoder.decode(&bytes[..split]);
+            out.push_str(&decoder.decode(&bytes[split..]));
+            out.push_str(&decoder.flush());
+            assert_eq!(out, text, "failed at split offset {split}");
+        }
+    }
+
+    #[test]
+    fn byte_at_a_time_delivery_round_trips() {
+        let text = "读取文件 with ascii tail";
+        let mut decoder = Utf8StreamDecoder::new();
+        let mut out = String::new();
+        for byte in text.as_bytes() {
+            out.push_str(&decoder.decode(&[*byte]));
+        }
+        out.push_str(&decoder.flush());
+        assert_eq!(out, text);
+    }
+
+    #[test]
+    fn genuinely_invalid_bytes_do_not_discard_surrounding_text() {
+        let mut decoder = Utf8StreamDecoder::new();
+        let mut bytes = b"good".to_vec();
+        bytes.push(0xFF); // never valid in UTF-8
+        bytes.extend_from_slice(b"tail");
+        let out = decoder.decode(&bytes);
+        assert!(out.starts_with("good"), "leading good text kept: {out:?}");
+        assert!(out.ends_with("tail"), "trailing good text kept: {out:?}");
+        assert!(out.contains('\u{FFFD}'));
+    }
+
+    #[test]
+    fn well_formed_single_object_is_not_treated_as_concatenated() {
+        assert_eq!(split_concatenated_json(r#"{"id":"a"}"#), None);
+    }
+
+    #[test]
+    fn concatenated_objects_are_split() {
+        let split = split_concatenated_json(r#"{"id":"a"}{"id":"b"}"#).expect("split");
+        assert_eq!(split.objects, vec![r#"{"id":"a"}"#, r#"{"id":"b"}"#]);
+        assert_eq!(split.trailing_partial, None);
+    }
+
+    #[test]
+    fn concatenation_with_embedded_data_prefix_is_split() {
+        let split = split_concatenated_json(r#"{"id":"a"}data: {"id":"b"}"#).expect("split");
+        assert_eq!(split.objects, vec![r#"{"id":"a"}"#, r#"{"id":"b"}"#]);
+    }
+
+    #[test]
+    fn braces_inside_strings_do_not_confuse_the_splitter() {
+        let payload = r#"{"content":"a } b { c"}{"id":"second"}"#;
+        let split = split_concatenated_json(payload).expect("split");
+        assert_eq!(
+            split.objects,
+            vec![r#"{"content":"a } b { c"}"#, r#"{"id":"second"}"#]
+        );
+    }
+
+    #[test]
+    fn escaped_quote_inside_string_is_handled() {
+        let payload = r#"{"content":"say \"hi\" }"}{"id":"second"}"#;
+        let split = split_concatenated_json(payload).expect("split");
+        assert_eq!(
+            split.objects,
+            vec![r#"{"content":"say \"hi\" }"}"#, r#"{"id":"second"}"#]
+        );
+    }
+
+    #[test]
+    fn truncated_trailing_object_is_reported_for_carry_over() {
+        let split =
+            split_concatenated_json(r#"{"choices":[{"delta":{"content":"Hello "#).expect("split");
+        assert!(split.objects.is_empty());
+        assert_eq!(
+            split.trailing_partial.as_deref(),
+            Some(r#"{"choices":[{"delta":{"content":"Hello "#)
+        );
+    }
+
+    #[test]
+    fn split_object_rejoins_into_valid_json() {
+        // Event 1 truncated, event 2 carries the remainder.
+        let first = r#"{"choices":[{"delta":{"content":"Hello "#;
+        let second = r#"world"}}]}"#;
+        let split = split_concatenated_json(first).expect("partial");
+        let mut rejoined = split.trailing_partial.expect("partial text");
+        rejoined.push_str(second);
+        assert_eq!(
+            rejoined,
+            r#"{"choices":[{"delta":{"content":"Hello world"}}]}"#
+        );
+        // Brace-balanced after rejoin, so a downstream JSON parse will succeed.
+        assert_eq!(split_concatenated_json(&rejoined), None);
     }
 }

--- a/crates/jcode-core/src/util.rs
+++ b/crates/jcode-core/src/util.rs
@@ -117,10 +117,9 @@ impl Utf8StreamDecoder {
             }
             Err(error) => {
                 let valid_up_to = error.valid_up_to();
-                // SAFETY-equivalent: `valid_up_to` is a guaranteed char boundary.
-                let good = std::str::from_utf8(&bytes[..valid_up_to])
-                    .unwrap_or_default()
-                    .to_string();
+                // `valid_up_to` is by definition the length of the valid prefix,
+                // so this conversion is exact and never actually substitutes.
+                let good = String::from_utf8_lossy(&bytes[..valid_up_to]).into_owned();
                 let rest = bytes[valid_up_to..].to_vec();
                 match error.error_len() {
                     // Truncated but potentially valid: keep it for the next chunk.
@@ -405,126 +404,5 @@ mod tests {
 }
 
 #[cfg(test)]
-mod sse_stream_integrity_tests {
-    //! Regression coverage for #609: SSE stream data corruption.
-    use super::*;
-
-    #[test]
-    fn multibyte_char_split_across_chunks_is_not_dropped() {
-        // "读" is 3 bytes; split it after the first byte.
-        let full = "读取文件".as_bytes().to_vec();
-        let mut decoder = Utf8StreamDecoder::new();
-        let mut out = String::new();
-        out.push_str(&decoder.decode(&full[..1]));
-        assert!(
-            decoder.has_pending_bytes(),
-            "partial char must be held back"
-        );
-        out.push_str(&decoder.decode(&full[1..]));
-        out.push_str(&decoder.flush());
-        assert_eq!(out, "读取文件");
-    }
-
-    #[test]
-    fn every_single_byte_split_point_round_trips() {
-        // State-space sweep: splitting at any byte offset must reproduce the input.
-        let text = "hello 读取 世界 mixed ascii";
-        let bytes = text.as_bytes();
-        for split in 0..=bytes.len() {
-            let mut decoder = Utf8StreamDecoder::new();
-            let mut out = decoder.decode(&bytes[..split]);
-            out.push_str(&decoder.decode(&bytes[split..]));
-            out.push_str(&decoder.flush());
-            assert_eq!(out, text, "failed at split offset {split}");
-        }
-    }
-
-    #[test]
-    fn byte_at_a_time_delivery_round_trips() {
-        let text = "读取文件 with ascii tail";
-        let mut decoder = Utf8StreamDecoder::new();
-        let mut out = String::new();
-        for byte in text.as_bytes() {
-            out.push_str(&decoder.decode(&[*byte]));
-        }
-        out.push_str(&decoder.flush());
-        assert_eq!(out, text);
-    }
-
-    #[test]
-    fn genuinely_invalid_bytes_do_not_discard_surrounding_text() {
-        let mut decoder = Utf8StreamDecoder::new();
-        let mut bytes = b"good".to_vec();
-        bytes.push(0xFF); // never valid in UTF-8
-        bytes.extend_from_slice(b"tail");
-        let out = decoder.decode(&bytes);
-        assert!(out.starts_with("good"), "leading good text kept: {out:?}");
-        assert!(out.ends_with("tail"), "trailing good text kept: {out:?}");
-        assert!(out.contains('\u{FFFD}'));
-    }
-
-    #[test]
-    fn well_formed_single_object_is_not_treated_as_concatenated() {
-        assert_eq!(split_concatenated_json(r#"{"id":"a"}"#), None);
-    }
-
-    #[test]
-    fn concatenated_objects_are_split() {
-        let split = split_concatenated_json(r#"{"id":"a"}{"id":"b"}"#).expect("split");
-        assert_eq!(split.objects, vec![r#"{"id":"a"}"#, r#"{"id":"b"}"#]);
-        assert_eq!(split.trailing_partial, None);
-    }
-
-    #[test]
-    fn concatenation_with_embedded_data_prefix_is_split() {
-        let split = split_concatenated_json(r#"{"id":"a"}data: {"id":"b"}"#).expect("split");
-        assert_eq!(split.objects, vec![r#"{"id":"a"}"#, r#"{"id":"b"}"#]);
-    }
-
-    #[test]
-    fn braces_inside_strings_do_not_confuse_the_splitter() {
-        let payload = r#"{"content":"a } b { c"}{"id":"second"}"#;
-        let split = split_concatenated_json(payload).expect("split");
-        assert_eq!(
-            split.objects,
-            vec![r#"{"content":"a } b { c"}"#, r#"{"id":"second"}"#]
-        );
-    }
-
-    #[test]
-    fn escaped_quote_inside_string_is_handled() {
-        let payload = r#"{"content":"say \"hi\" }"}{"id":"second"}"#;
-        let split = split_concatenated_json(payload).expect("split");
-        assert_eq!(
-            split.objects,
-            vec![r#"{"content":"say \"hi\" }"}"#, r#"{"id":"second"}"#]
-        );
-    }
-
-    #[test]
-    fn truncated_trailing_object_is_reported_for_carry_over() {
-        let split =
-            split_concatenated_json(r#"{"choices":[{"delta":{"content":"Hello "#).expect("split");
-        assert!(split.objects.is_empty());
-        assert_eq!(
-            split.trailing_partial.as_deref(),
-            Some(r#"{"choices":[{"delta":{"content":"Hello "#)
-        );
-    }
-
-    #[test]
-    fn split_object_rejoins_into_valid_json() {
-        // Event 1 truncated, event 2 carries the remainder.
-        let first = r#"{"choices":[{"delta":{"content":"Hello "#;
-        let second = r#"world"}}]}"#;
-        let split = split_concatenated_json(first).expect("partial");
-        let mut rejoined = split.trailing_partial.expect("partial text");
-        rejoined.push_str(second);
-        assert_eq!(
-            rejoined,
-            r#"{"choices":[{"delta":{"content":"Hello world"}}]}"#
-        );
-        // Brace-balanced after rejoin, so a downstream JSON parse will succeed.
-        assert_eq!(split_concatenated_json(&rejoined), None);
-    }
-}
+#[path = "sse_stream_integrity_tests.rs"]
+mod sse_stream_integrity_tests;

--- a/crates/jcode-provider-openai/src/stream.rs
+++ b/crates/jcode-provider-openai/src/stream.rs
@@ -761,6 +761,9 @@ fn handle_openai_image_generation_item(
 pub struct OpenAIResponsesStream {
     inner: Pin<Box<dyn Stream<Item = Result<Bytes, reqwest::Error>> + Send>>,
     buffer: String,
+    /// Carries incomplete multi-byte UTF-8 sequences across chunk boundaries
+    /// so split CJK characters are not dropped (#609).
+    utf8: jcode_core::util::Utf8StreamDecoder,
     pending: VecDeque<StreamEvent>,
     saw_text_delta: bool,
     streaming_tool_calls: HashMap<String, StreamingToolCallState>,
@@ -772,6 +775,7 @@ impl OpenAIResponsesStream {
         Self {
             inner: Box::pin(stream),
             buffer: String::new(),
+            utf8: jcode_core::util::Utf8StreamDecoder::new(),
             pending: VecDeque::new(),
             saw_text_delta: false,
             streaming_tool_calls: HashMap::new(),
@@ -851,9 +855,8 @@ impl Stream for OpenAIResponsesStream {
 
             match self.inner.as_mut().poll_next(cx) {
                 Poll::Ready(Some(Ok(bytes))) => {
-                    if let Ok(text) = std::str::from_utf8(&bytes) {
-                        self.buffer.push_str(text);
-                    }
+                    let text = self.utf8.decode(&bytes);
+                    self.buffer.push_str(&text);
                 }
                 Poll::Ready(Some(Err(e))) => {
                     return Poll::Ready(Some(Err(anyhow::anyhow!("Stream error: {}", e))));

--- a/crates/jcode-provider-openrouter/src/stream.rs
+++ b/crates/jcode-provider-openrouter/src/stream.rs
@@ -37,6 +37,12 @@ fn take_sse_event(buffer: &mut String) -> Option<String> {
 pub struct OpenRouterStream {
     inner: Pin<Box<dyn Stream<Item = Result<Bytes, reqwest::Error>> + Send>>,
     buffer: String,
+    /// Carries incomplete multi-byte UTF-8 sequences across chunk boundaries
+    /// so split CJK characters are not dropped (#609).
+    utf8: jcode_core::util::Utf8StreamDecoder,
+    /// A JSON object the upstream proxy split across two SSE events, held back
+    /// so it can be joined with the next event's payload (#609).
+    partial_json: Option<String>,
     pending: VecDeque<StreamEvent>,
     tool_call_accumulators: std::collections::BTreeMap<u64, ToolCallAccumulator>,
     /// Track if we've emitted the provider info (only emit once)
@@ -64,6 +70,8 @@ impl OpenRouterStream {
         Self {
             inner: Box::pin(stream),
             buffer: String::new(),
+            utf8: jcode_core::util::Utf8StreamDecoder::new(),
+            partial_json: None,
             pending: VecDeque::new(),
             tool_call_accumulators: std::collections::BTreeMap::new(),
             provider_emitted: false,
@@ -252,11 +260,43 @@ impl OpenRouterStream {
             if !requeued.is_empty() {
                 self.buffer.insert_str(0, &requeued);
             }
+            // Re-join a JSON object the proxy split across two SSE events.
+            let data = match self.partial_json.take() {
+                Some(mut partial) => {
+                    partial.push_str(&data);
+                    partial
+                }
+                None => data,
+            };
             let data = data.as_str();
 
             let parsed: Value = match serde_json::from_str(data) {
                 Ok(v) => v,
                 Err(error) => {
+                    // Some proxies drop the `\n\n` event separator or split an
+                    // object across two events, so a whole chunk of deltas was
+                    // being discarded here (#609). Try to recover the individual
+                    // objects before giving up.
+                    if let Some(split) = jcode_core::util::split_concatenated_json(data) {
+                        let mut requeued = String::new();
+                        for object in &split.objects {
+                            requeued.push_str("data: ");
+                            requeued.push_str(object);
+                            requeued.push_str("\n\n");
+                        }
+                        if let Some(partial) = &split.trailing_partial {
+                            // Hold the truncated object back and prepend it to the
+                            // next event's payload rather than dropping it.
+                            self.partial_json = Some(partial.clone());
+                        }
+                        if !requeued.is_empty() {
+                            self.buffer.insert_str(0, &requeued);
+                            continue;
+                        }
+                        if split.trailing_partial.is_some() {
+                            continue;
+                        }
+                    }
                     jcode_logging::warn(&format!(
                         "OpenRouter SSE JSON parse failed for model {}: {} payload={} ",
                         self.model,
@@ -429,14 +469,25 @@ impl Stream for OpenRouterStream {
 
             match self.inner.as_mut().poll_next(cx) {
                 Poll::Ready(Some(Ok(bytes))) => {
-                    if let Ok(text) = std::str::from_utf8(&bytes) {
-                        self.buffer.push_str(text);
-                    }
+                    let text = self.utf8.decode(&bytes);
+                    self.buffer.push_str(&text);
                 }
                 Poll::Ready(Some(Err(e))) => {
                     return Poll::Ready(Some(Err(anyhow::anyhow!("Stream error: {}", e))));
                 }
                 Poll::Ready(None) => {
+                    // Flush any bytes held back mid-character, then force-close a
+                    // buffer that never received a trailing blank line (#609).
+                    let tail = self.utf8.flush();
+                    if !tail.is_empty() {
+                        self.buffer.push_str(&tail);
+                    }
+                    if !self.buffer.trim().is_empty() && !self.buffer.ends_with("\n\n") {
+                        self.buffer.push_str("\n\n");
+                        if let Some(event) = self.parse_next_event() {
+                            return Poll::Ready(Some(Ok(event)));
+                        }
+                    }
                     // Stream ended - emit any pending tool call
                     self.flush_tool_call_accumulators();
                     if let Some(event) = self.pending.pop_front() {
@@ -518,6 +569,125 @@ mod tests {
         .to_string();
 
         assert_eq!(drain_text(&mut stream), "foobar");
+    }
+
+    /// Issue #609: proxies that drop the event separator, split an object across
+    /// two events, or split a multi-byte character across TCP chunks must not
+    /// cause silent data loss.
+    #[test]
+    fn concatenated_json_in_one_event_keeps_both_deltas() {
+        let mut stream = test_stream();
+        stream.buffer = concat!(
+            r#"data: {"choices":[{"delta":{"content":"hello"}}]}"#,
+            r#"{"choices":[{"delta":{"content":" world"}}]}"#,
+            "\n\ndata: [DONE]\n\n"
+        )
+        .to_string();
+
+        assert_eq!(drain_text(&mut stream), "hello world");
+    }
+
+    #[test]
+    fn concatenated_json_with_embedded_data_prefix_keeps_both_deltas() {
+        let mut stream = test_stream();
+        stream.buffer = concat!(
+            r#"data: {"choices":[{"delta":{"content":"hello"}}]}"#,
+            r#"data: {"choices":[{"delta":{"content":" world"}}]}"#,
+            "\n\ndata: [DONE]\n\n"
+        )
+        .to_string();
+
+        assert_eq!(drain_text(&mut stream), "hello world");
+    }
+
+    #[test]
+    fn object_split_across_two_events_is_rejoined() {
+        let mut stream = test_stream();
+        stream.buffer = concat!(
+            r#"data: {"choices":[{"delta":{"content":"Hello "#,
+            "\n\n",
+            r#"data: world"}}]}"#,
+            "\n\ndata: [DONE]\n\n"
+        )
+        .to_string();
+
+        assert_eq!(drain_text(&mut stream), "Hello world");
+    }
+
+    #[test]
+    fn tool_call_arguments_split_across_events_are_not_truncated() {
+        // The reported symptom was `arguments must be a JSON object, got null`.
+        let mut stream = test_stream();
+        stream.buffer = concat!(
+            r#"data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_1","function":{"name":"write","arguments":"{\"path\":\"a.txt\""#,
+            "\n\n",
+            r#"data: ,\"content\":\"hi\"}"}}]}}]}"#,
+            "\n\ndata: [DONE]\n\n"
+        )
+        .to_string();
+
+        let mut args = String::new();
+        while let Some(event) = stream.parse_next_event() {
+            if let StreamEvent::ToolInputDelta(delta) = event {
+                args.push_str(&delta);
+            }
+        }
+        let parsed: Value =
+            serde_json::from_str(&args).expect("tool arguments should be complete JSON");
+        assert_eq!(parsed["path"], "a.txt");
+        assert_eq!(parsed["content"], "hi");
+    }
+
+    #[test]
+    fn multibyte_chars_split_across_tcp_chunks_survive_poll_next() {
+        // Drive real bytes through poll_next, splitting mid-character.
+        let payload =
+            "data: {\"choices\":[{\"delta\":{\"content\":\"读取文件\"}}]}\n\ndata: [DONE]\n\n";
+        let bytes = payload.as_bytes();
+        // Split at every offset to sweep the chunk-boundary state space.
+        for split in 0..bytes.len() {
+            let chunks: Vec<Result<Bytes, reqwest::Error>> = vec![
+                Ok(Bytes::copy_from_slice(&bytes[..split])),
+                Ok(Bytes::copy_from_slice(&bytes[split..])),
+            ];
+            let mut stream = OpenRouterStream::new(
+                futures::stream::iter(chunks),
+                "test-model".to_string(),
+                Arc::new(std::sync::Mutex::new(None)),
+            );
+            let text = futures::executor::block_on(async {
+                let mut text = String::new();
+                while let Some(Ok(event)) = stream.next().await {
+                    if let StreamEvent::TextDelta(delta) = event {
+                        text.push_str(&delta);
+                    }
+                }
+                text
+            });
+            assert_eq!(text, "读取文件", "lost content at split offset {split}");
+        }
+    }
+
+    #[test]
+    fn stream_ending_without_a_blank_line_still_flushes_the_last_event() {
+        let payload = "data: {\"choices\":[{\"delta\":{\"content\":\"tail\"}}]}";
+        let chunks: Vec<Result<Bytes, reqwest::Error>> =
+            vec![Ok(Bytes::copy_from_slice(payload.as_bytes()))];
+        let mut stream = OpenRouterStream::new(
+            futures::stream::iter(chunks),
+            "test-model".to_string(),
+            Arc::new(std::sync::Mutex::new(None)),
+        );
+        let text = futures::executor::block_on(async {
+            let mut text = String::new();
+            while let Some(Ok(event)) = stream.next().await {
+                if let StreamEvent::TextDelta(delta) = event {
+                    text.push_str(&delta);
+                }
+            }
+            text
+        });
+        assert_eq!(text, "tail");
     }
 
     #[test]


### PR DESCRIPTION
Fixes #609 (and its duplicate #610).

Three independent corruption modes in the OpenAI-compatible SSE readers, each of which silently discards data.

## 1. UTF-8 chunk-boundary loss

Both `jcode-provider-openrouter` and `jcode-provider-openai` decoded each TCP chunk in isolation:

```rust
if let Ok(text) = std::str::from_utf8(&bytes) {
    self.buffer.push_str(text);
}
```

When a multi-byte character (e.g. a 3-byte CJK codepoint) straddles a chunk boundary, `from_utf8` fails and the `if let` drops **the entire chunk**. This is the missing-Chinese-text symptom, and it also truncates tool-call arguments.

Fix: a shared `jcode_core::util::Utf8StreamDecoder` that holds back an incomplete trailing sequence and prepends it to the next chunk. Genuinely invalid bytes emit U+FFFD rather than discarding the surrounding good data.

## 2. Concatenated JSON

Proxies that drop the `\n\n` separator emit `{"a":1}{"b":2}`, sometimes as `{"a":1}data: {"b":2}`. `serde_json::from_str` rejects that with "trailing characters" and the whole blob was dropped.

Fix: `jcode_core::util::split_concatenated_json`, a string-aware brace-depth splitter (it does not get confused by `{`/`}` or escaped quotes inside JSON strings). It runs **only as a fallback after a normal parse fails**, so well-formed payloads keep their existing behavior and the existing `parse_next_event_ignores_malformed_json_chunks` test still passes.

## 3. Cross-event truncation

An object split across two events never closed its braces and was dropped. The partial text is now retained and prepended to the next event's payload.

Plus: flush the decoder and force-close the buffer at end of stream, so a stream that ends without a trailing blank line still emits its final event.

## Tests

21 new tests, all passing.

`jcode-core` (11), including state-space sweeps:
- `every_single_byte_split_point_round_trips` — splits a mixed ASCII/CJK string at **every** byte offset
- `byte_at_a_time_delivery_round_trips`
- brace/quote-confusion cases: `braces_inside_strings_do_not_confuse_the_splitter`, `escaped_quote_inside_string_is_handled`
- `well_formed_single_object_is_not_treated_as_concatenated` (guards the fallback from firing on healthy payloads)

`jcode-provider-openrouter` (6 new, 26 total), end-to-end through the real stream:
- `multibyte_chars_split_across_tcp_chunks_survive_poll_next` — drives real `Bytes` through `poll_next` at every split offset
- `tool_call_arguments_split_across_events_are_not_truncated` — reproduces the reported `arguments must be a JSON object, got null`
- `object_split_across_two_events_is_rejoined`, both concatenation shapes, and the EOF flush

`cargo test` green for `jcode-core` (48), `jcode-provider-openrouter` (26), `jcode-provider-openai` (8); clippy clean.

Root cause analysis and log evidence contributed by @wtry.

--- *— Jcode agent (automated triage), on behalf of @1jehuang*