### PR TITLE
fix(tui): stop a dead terminal from mislabeling a live session as Crashed (fixes #599)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3581,6 +3581,7 @@ dependencies = [
  "jcode-selfdev-types",
  "jcode-tui",
  "jcode-tui-session-picker",
+ "jcode-tui-style",
  "libc",
  "objc2 0.6.4",
  "objc2-app-kit 0.3.2",
@@ -4660,6 +4661,7 @@ dependencies = [
 name = "jcode-tui-style"
 version = "0.1.0"
 dependencies = [
+ "jcode-logging",
  "ratatui",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -161,6 +161,7 @@ chrono = { version = "0.4", features = ["serde"] }
 sha2 = "0.10"
 hex = "0.4"
 open = "5"               # Open URLs in browser
+jcode-tui-style = { path = "crates/jcode-tui-style" }
 jcode-tui-session-picker = { path = "crates/jcode-tui-session-picker", features = ["serde"] }
 
 # Streaming

--- a/crates/jcode-tui-permissions/src/lib.rs
+++ b/crates/jcode-tui-permissions/src/lib.rs
@@ -583,11 +583,7 @@ impl PermissionsApp {
             }
         };
 
-        // See #599: ratatui::restore() reports failures with eprintln!, which
-        // itself panics when the terminal (and therefore stderr) is already
-        // dead. This crate has no logger, and a failed restore during teardown
-        // is not actionable, so drop the error rather than risk the panic.
-        let _ = ratatui::try_restore();
+        jcode_tui_style::restore_terminal_quietly();
         result
     }
 }

--- a/crates/jcode-tui-permissions/src/lib.rs
+++ b/crates/jcode-tui-permissions/src/lib.rs
@@ -583,7 +583,11 @@ impl PermissionsApp {
             }
         };
 
-        ratatui::restore();
+        // See #599: ratatui::restore() reports failures with eprintln!, which
+        // itself panics when the terminal (and therefore stderr) is already
+        // dead. This crate has no logger, and a failed restore during teardown
+        // is not actionable, so drop the error rather than risk the panic.
+        let _ = ratatui::try_restore();
         result
     }
 }

--- a/crates/jcode-tui-style/Cargo.toml
+++ b/crates/jcode-tui-style/Cargo.toml
@@ -5,4 +5,5 @@ edition = "2024"
 publish = false
 
 [dependencies]
+jcode-logging = { path = "../jcode-logging" }
 ratatui = "0.30"

--- a/crates/jcode-tui-style/src/lib.rs
+++ b/crates/jcode-tui-style/src/lib.rs
@@ -7,3 +7,19 @@ pub use theme_mode::{
     ThemeMode, adapt_buffer, adapt_buffer_for_theme, adapt_color_for_theme, is_light_theme,
     set_theme_mode, theme_mode,
 };
+
+/// Restore the terminal, logging any failure instead of printing it.
+///
+/// `ratatui::restore()` reports failures with `eprintln!`. On a dead terminal
+/// (closed window, dropped SSH) the restore fails with EIO and stderr is
+/// equally dead, so that `eprintln!` itself panics inside
+/// `std::io::stdio::print_to`. The panic hook can then record a live session as
+/// crashed and clobber its snapshot.
+///
+/// Always prefer this over `ratatui::restore()` on cleanup and orphan-exit
+/// paths. See issue #599 (and #129, the same class via another path).
+pub fn restore_terminal_quietly() {
+    if let Err(error) = ratatui::try_restore() {
+        jcode_logging::warn(&format!("failed to restore terminal: {error}"));
+    }
+}

--- a/crates/jcode-tui/src/tui/session_picker.rs
+++ b/crates/jcode-tui/src/tui/session_picker.rs
@@ -2396,11 +2396,7 @@ impl SessionPicker {
         if keyboard_enhanced {
             super::disable_keyboard_enhancement();
         }
-        // See #599: ratatui::restore() reports failures with eprintln!, which
-        // panics on a dead terminal.
-        if let Err(error) = ratatui::try_restore() {
-            jcode_logging::warn(&format!("failed to restore terminal: {error}"));
-        }
+        jcode_tui_style::restore_terminal_quietly();
         super::mermaid::clear_image_state();
 
         result

--- a/crates/jcode-tui/src/tui/session_picker.rs
+++ b/crates/jcode-tui/src/tui/session_picker.rs
@@ -2396,7 +2396,11 @@ impl SessionPicker {
         if keyboard_enhanced {
             super::disable_keyboard_enhancement();
         }
-        ratatui::restore();
+        // See #599: ratatui::restore() reports failures with eprintln!, which
+        // panics on a dead terminal.
+        if let Err(error) = ratatui::try_restore() {
+            jcode_logging::warn(&format!("failed to restore terminal: {error}"));
+        }
         super::mermaid::clear_image_state();
 
         result

--- a/src/cli/terminal.rs
+++ b/src/cli/terminal.rs
@@ -171,6 +171,16 @@ pub fn get_current_session() -> Option<String> {
     crate::get_current_session()
 }
 
+/// Whether a panic in this process should relabel the on-disk session as crashed.
+///
+/// Only an `Active` session can legitimately make that transition. A dying
+/// client (closed terminal window, dropped SSH) must not relabel a session that
+/// the shared server still owns, nor write its stale snapshot over the server's
+/// newer one. See #599; `mark_current_session_crashed` already had this guard.
+fn should_record_panic_as_crash(status: &session::SessionStatus) -> bool {
+    matches!(status, session::SessionStatus::Active)
+}
+
 pub fn install_panic_hook() {
     let default_hook = panic::take_hook();
     panic::set_hook(Box::new(move |info| {
@@ -183,7 +193,9 @@ pub fn install_panic_hook() {
                 telemetry::record_crash(&provider, &model, telemetry::SessionEndReason::Panic);
             }
 
-            if let Ok(mut session) = session::Session::load(&session_id) {
+            if let Ok(mut session) = session::Session::load(&session_id)
+                && should_record_panic_as_crash(&session.status)
+            {
                 session.mark_crashed(Some(format!("Panic: {}", info)));
                 let _ = session.save();
             }
@@ -409,7 +421,12 @@ fn cleanup_tui_runtime(state: &TuiRuntimeState, restore_terminal: bool) {
         if state.keyboard_enhanced {
             tui::disable_keyboard_enhancement();
         }
-        ratatui::restore();
+        // A dead terminal makes ratatui::restore()'s internal eprintln! panic
+        // with EIO, which the panic hook then records as a session crash
+        // (#599). Route the failure to the log file instead.
+        if let Err(error) = ratatui::try_restore() {
+            crate::logging::warn(&format!("failed to restore terminal: {error}"));
+        }
     }
 }
 
@@ -732,5 +749,52 @@ mod tests {
         let error = write_session_resume_hint(ClosedWriter, "session_closed_pipe")
             .expect_err("closed stderr should be reported as an I/O error");
         assert_eq!(error.kind(), io::ErrorKind::BrokenPipe);
+    }
+}
+
+#[cfg(test)]
+mod panic_crash_labeling_tests {
+    //! Regression coverage for #599.
+    //!
+    //! Closing a terminal (or dropping SSH) makes `ratatui::restore()`'s
+    //! internal `eprintln!` panic with EIO. The panic hook then relabeled the
+    //! session as `Crashed` and saved the dying client's stale snapshot over the
+    //! server's newer one. Only an `Active` session may be relabeled.
+    use super::*;
+
+    #[test]
+    fn active_session_is_still_labeled_crashed_on_panic() {
+        assert!(should_record_panic_as_crash(
+            &session::SessionStatus::Active
+        ));
+    }
+
+    #[test]
+    fn already_crashed_session_is_not_relabeled() {
+        assert!(!should_record_panic_as_crash(
+            &session::SessionStatus::Crashed {
+                message: Some("earlier crash".to_string())
+            }
+        ));
+    }
+
+    #[test]
+    fn completed_session_is_not_relabeled_by_a_dying_client() {
+        // The exact #599 shape: the session lives on in the shared server and is
+        // no longer Active locally, so a dead-terminal panic must leave it alone.
+        for status in [
+            session::SessionStatus::Closed,
+            session::SessionStatus::Reloaded,
+            session::SessionStatus::Compacted,
+            session::SessionStatus::RateLimited,
+            session::SessionStatus::Error {
+                message: "unrelated".to_string(),
+            },
+        ] {
+            assert!(
+                !should_record_panic_as_crash(&status),
+                "non-active status {status:?} must not be relabeled as crashed"
+            );
+        }
     }
 }

--- a/src/cli/terminal.rs
+++ b/src/cli/terminal.rs
@@ -421,12 +421,7 @@ fn cleanup_tui_runtime(state: &TuiRuntimeState, restore_terminal: bool) {
         if state.keyboard_enhanced {
             tui::disable_keyboard_enhancement();
         }
-        // A dead terminal makes ratatui::restore()'s internal eprintln! panic
-        // with EIO, which the panic hook then records as a session crash
-        // (#599). Route the failure to the log file instead.
-        if let Err(error) = ratatui::try_restore() {
-            crate::logging::warn(&format!("failed to restore terminal: {error}"));
-        }
+        jcode_tui_style::restore_terminal_quietly();
     }
 }
 


### PR DESCRIPTION
Fixes #599. Same class as the already-closed #129, resurfacing on Linux through a different path.

## Problem

Closing a terminal window (or dropping an SSH session) can mark a **live, healthy** session as `Crashed`, and let the dying client's stale on-disk snapshot overwrite the server's newer one.

## Root cause

Verified against ratatui 0.30 (`src/init.rs:457`):

```rust
pub fn restore() {
    if let Err(err) = try_restore() {
        std::eprintln!("Failed to restore terminal: {err}");
    }
}
```

On a dead terminal the restore fails with EIO and stderr is equally dead, so the `eprintln!` itself panics in `std::io::stdio::print_to`. The panic hook then **unconditionally** loaded the session and marked it `Crashed`, producing both a bogus crash label and a snapshot clobber (the reported `maple` session saved 548 messages over the server's 551).

## Fix

1. Replace `ratatui::restore()` with `try_restore()` at all three cleanup/orphan sites (`src/cli/terminal.rs`, `crates/jcode-tui-permissions/src/lib.rs`, `crates/jcode-tui/src/tui/session_picker.rs`) and route the failure to the log file. No `ratatui::restore()` call sites remain in the tree.
2. Guard the panic hook so only an `Active` session may transition to `Crashed`. This mirrors the guard `mark_current_session_crashed` already had, and is the part that prevents the snapshot clobber.

The guard is extracted as `should_record_panic_as_crash` so it is directly testable.

## Tests

New `panic_crash_labeling_tests`, 3 cases covering the full `SessionStatus` space: `Active` still labels, `Crashed` is not relabeled, and `Closed`/`Reloaded`/`Compacted`/`RateLimited`/`Error` are all left alone (the exact #599 shape, where the session lives on in the shared server).

All 3 pass; the 13 existing `cli::terminal` tests still pass; `cargo check --bin jcode` clean.

Root cause analysis and production logs contributed by @vietgs03.

--- *— Jcode agent (automated triage), on behalf of @1jehuang*