### PR TITLE
fix(browser): cap bridge CLI calls and allow reinstall after a stale marker (fixes #602)

### DIFF
--- a/crates/jcode-base/src/browser.rs
+++ b/crates/jcode-base/src/browser.rs
@@ -704,22 +704,50 @@ fn native_messaging_hosts_dir() -> Result<PathBuf> {
     }
 }
 
+/// How long to wait for the browser CLI before declaring the bridge dead.
+///
+/// The CLI round-trips to the Firefox extension over `ws://127.0.0.1:8766`. If
+/// the extension is missing, disabled, or Firefox is closed, nothing ever
+/// answers and an unbounded `.output().await` hangs `browser status` and
+/// `browser setup` for minutes. See #602.
+const BRIDGE_PING_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
+/// Run the browser CLI with a hard timeout, killing the child if it overruns.
+///
+/// `Ok(None)` means the call timed out, which callers treat as "not
+/// responding" so they fail fast instead of hanging.
+async fn run_browser_cli_capped(
+    bin: &std::path::Path,
+    args: &[&str],
+    timeout: std::time::Duration,
+) -> Result<Option<std::process::Output>> {
+    let mut cmd = tokio::process::Command::new(bin);
+    cmd.args(args).kill_on_drop(true);
+
+    match tokio::time::timeout(timeout, cmd.output()).await {
+        Ok(output) => Ok(Some(output?)),
+        Err(_) => {
+            crate::logging::warn(&format!(
+                "browser CLI '{}' timed out after {}s; treating the bridge as not responding",
+                args.first().copied().unwrap_or("(no action)"),
+                timeout.as_secs()
+            ));
+            Ok(None)
+        }
+    }
+}
+
 async fn check_browser_ping() -> Result<bool> {
     let bin = browser_binary_path();
     if !bin.exists() {
         return Ok(false);
     }
 
-    let output = tokio::process::Command::new(&bin)
-        .arg("ping")
-        .output()
-        .await?;
-
-    if output.status.success() {
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        Ok(stdout.contains("pong"))
-    } else {
-        Ok(false)
+    match run_browser_cli_capped(&bin, &["ping"], BRIDGE_PING_TIMEOUT).await? {
+        Some(output) if output.status.success() => {
+            Ok(String::from_utf8_lossy(&output.stdout).contains("pong"))
+        }
+        _ => Ok(false),
     }
 }
 
@@ -729,11 +757,13 @@ async fn probe_bridge_action_support(action: &str, params_json: &str) -> Result<
         return Ok(false);
     }
 
-    let output = tokio::process::Command::new(&bin)
-        .arg(action)
-        .arg(params_json)
-        .output()
-        .await?;
+    let Some(output) =
+        run_browser_cli_capped(&bin, &[action, params_json], BRIDGE_PING_TIMEOUT).await?
+    else {
+        // A dead bridge cannot tell us whether the action exists; report it as
+        // unsupported rather than hanging the caller (#602).
+        return Ok(false);
+    };
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);
@@ -825,8 +855,19 @@ async fn wait_for_ready(timeout_secs: u64) -> Result<bool> {
     Ok(false)
 }
 
+/// Whether `browser setup` should offer to (re)install the bridge extension.
+///
+/// Keying only off the persistent `.setup-complete` marker meant that once a
+/// past setup succeeded, setup could never recover if the extension later
+/// vanished from the live Firefox profile: it just printed "already completed".
+/// Also re-prompt when the binary is installed but the bridge is not
+/// responding, which is the only signal that a previously-working setup lost
+/// its extension. A healthy responding bridge stays inert. See #602.
 fn should_prompt_extension_install(status: &BrowserStatus) -> bool {
-    !status.setup_complete
+    if !status.setup_complete {
+        return true;
+    }
+    status.binary_installed && !status.responding
 }
 
 async fn install_extension() -> Result<String> {

--- a/crates/jcode-base/src/browser_tests.rs
+++ b/crates/jcode-base/src/browser_tests.rs
@@ -68,11 +68,23 @@ fn test_should_prompt_extension_install_only_before_setup_complete() {
     };
     assert!(should_prompt_extension_install(&incomplete));
 
-    let complete = BrowserStatus {
+    // A completed setup whose bridge is healthy stays inert.
+    let complete_and_healthy = BrowserStatus {
         setup_complete: true,
+        responding: true,
+        ..incomplete.clone()
+    };
+    assert!(!should_prompt_extension_install(&complete_and_healthy));
+
+    // But a completed setup whose extension has since vanished must be able to
+    // re-prompt; previously the stale .setup-complete marker suppressed the
+    // installer forever (#602).
+    let complete_but_dead = BrowserStatus {
+        setup_complete: true,
+        responding: false,
         ..incomplete
     };
-    assert!(!should_prompt_extension_install(&complete));
+    assert!(should_prompt_extension_install(&complete_but_dead));
 }
 
 #[test]
@@ -209,4 +221,105 @@ fn ensure_browser_session_does_not_pass_unsupported_bind_window_flag() {
     } else {
         crate::env::remove_var("JCODE_HOME");
     }
+}
+
+// Regression coverage for #602.
+//
+// Bug A: the bridge ping had no timeout. The browser CLI round-trips to the
+// Firefox extension over ws://127.0.0.1:8766, so when the extension is missing
+// the CLI never returns and `browser status` / `browser setup` hang for
+// minutes (measured: 2m14s and a full 3-minute cap).
+//
+// Bug B: once ~/.jcode/browser/.setup-complete existed, setup could never
+// reinstall a vanished extension.
+
+#[cfg(unix)]
+fn write_executable(path: &std::path::Path, script: &str) {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::write(path, script).expect("write script");
+    let mut perms = std::fs::metadata(path).expect("stat script").permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(path, perms).expect("chmod script");
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn hanging_browser_cli_times_out_instead_of_blocking_forever() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let bin = temp.path().join("browser");
+    // Stands in for a CLI waiting on a bridge that will never answer.
+    write_executable(&bin, "#!/bin/sh\nsleep 600\n");
+
+    let started = std::time::Instant::now();
+    let result = run_browser_cli_capped(&bin, &["ping"], std::time::Duration::from_millis(300))
+        .await
+        .expect("capped call should not error");
+    let elapsed = started.elapsed();
+
+    assert!(result.is_none(), "a hanging CLI must report a timeout");
+    assert!(
+        elapsed < std::time::Duration::from_secs(5),
+        "must fail fast, took {elapsed:?}"
+    );
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn responsive_browser_cli_still_returns_its_output() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let bin = temp.path().join("browser");
+    write_executable(&bin, "#!/bin/sh\necho pong\n");
+
+    let output = run_browser_cli_capped(&bin, &["ping"], std::time::Duration::from_secs(5))
+        .await
+        .expect("capped call should not error")
+        .expect("a responsive CLI must not report a timeout");
+
+    assert!(output.status.success());
+    assert!(String::from_utf8_lossy(&output.stdout).contains("pong"));
+}
+
+fn status_fixture(setup_complete: bool, binary_installed: bool, responding: bool) -> BrowserStatus {
+    BrowserStatus {
+        backend: "test",
+        browser: "firefox",
+        setup_complete,
+        binary_installed,
+        responding,
+        compatible: true,
+        missing_actions: Vec::new(),
+        ready: setup_complete && binary_installed && responding,
+    }
+}
+
+#[test]
+fn setup_prompts_on_a_first_run() {
+    assert!(should_prompt_extension_install(&status_fixture(
+        false, false, false
+    )));
+}
+
+#[test]
+fn stale_marker_no_longer_blocks_reinstall_when_the_bridge_is_dead() {
+    // The #602 shape: marker present from a past setup, binary installed, but
+    // the extension is gone from the live profile so nothing answers.
+    assert!(should_prompt_extension_install(&status_fixture(
+        true, true, false
+    )));
+}
+
+#[test]
+fn healthy_bridge_stays_inert() {
+    assert!(!should_prompt_extension_install(&status_fixture(
+        true, true, true
+    )));
+}
+
+#[test]
+fn completed_setup_without_the_binary_does_not_prompt() {
+    // Nothing to talk to yet; the binary install path handles this, so the
+    // extension prompt must not fire spuriously.
+    assert!(!should_prompt_extension_install(&status_fixture(
+        true, false, false
+    )));
 }


### PR DESCRIPTION
Fixes #602.

Two defects that together turn "the extension went missing" into an unbounded hang with no recovery path.

## Bug A: unbounded bridge ping

`check_browser_ping` and `probe_bridge_action_support` spawned the browser CLI with `.output().await` and no timeout. That CLI round-trips to the Firefox extension over `ws://127.0.0.1:8766`, so when the extension is not connected nothing answers and the await never returns. The reporter measured `browser status` at **2m14s** and `browser setup` hanging for its full 3-minute cap.

Both now route through a shared `run_browser_cli_capped` helper using `kill_on_drop(true)` + `tokio::time::timeout` (10s), mirroring the existing `hooks.rs` pattern. A timeout is treated as "not responding" so callers fail fast.

## Bug B: stale `.setup-complete` marker

`should_prompt_extension_install` returned `!status.setup_complete`, so once the marker existed setup never reopened the installer, even with the extension gone from the live profile. It just printed "already completed" and could never recover.

Setup now still prompts on a first run, and additionally re-prompts when the binary is installed but the bridge is not responding, which is the only signal that a previously-working setup lost its extension. A healthy responding bridge stays inert.

## Tests

6 new cases in `browser_tests.rs`:

- `hanging_browser_cli_times_out_instead_of_blocking_forever` — spawns a real `sleep 600` stand-in for a CLI waiting on a dead bridge, and asserts the call returns fast rather than hanging
- `responsive_browser_cli_still_returns_its_output` — the timeout wrapper does not change the healthy path
- the four `should_prompt_extension_install` states: first run, stale marker + dead bridge, healthy bridge, and completed-setup-without-binary

One existing test (`test_should_prompt_extension_install_only_before_setup_complete`) asserted the old behavior verbatim; it is updated to distinguish healthy from dead bridges rather than deleted.

`cargo test -p jcode-base --lib` → **1142 passed, 0 failed**.

Root cause analysis, measurements, and a fix branch contributed by @vietgs03.

--- *— Jcode agent (automated triage), on behalf of @1jehuang*