### PR TITLE
fix(model-list): give each named provider its own model cache namespace (fixes #607)

### DIFF
--- a/crates/jcode-provider-openrouter-runtime/src/lib.rs
+++ b/crates/jcode-provider-openrouter-runtime/src/lib.rs
@@ -1823,20 +1823,6 @@ impl OpenRouterProvider {
         source_api_base == self.api_base
     }
 
-    pub(crate) fn load_usable_model_disk_cache_entry(
-        &self,
-    ) -> Option<jcode_provider_openrouter::DiskCache> {
-        // Read from this profile's own namespace rather than whichever profile
-        // last won the process-global env var (#607).
-        let entry = match self.foreground_cache_namespace() {
-            Some(namespace) => {
-                jcode_provider_openrouter::load_disk_cache_entry_for_namespace(&namespace)
-            }
-            None => load_disk_cache_entry(),
-        };
-        entry.filter(|entry| self.model_disk_cache_source_matches(entry))
-    }
-
     fn begin_background_model_catalog_refresh(&self) -> bool {
         let Some(now) = current_unix_secs() else {
             return false;
@@ -2035,11 +2021,9 @@ impl OpenRouterProvider {
         let models_cache = Arc::clone(&self.models_cache);
         let refresh_state = Arc::clone(&self.model_catalog_refresh);
         let previous_fingerprint = self.cached_model_catalog_fingerprint();
-        let cache_namespace = self.foreground_cache_namespace();
-
+        let ns = self.foreground_cache_namespace();
         handle.spawn(async move {
-            match fetch_models_from_api(client, api_base, auth, models_cache, cache_namespace).await
-            {
+            match fetch_models_from_api(client, api_base, auth, models_cache, ns).await {
                 Ok(models) => {
                     let updated = models_fingerprint(&models) != previous_fingerprint;
                     if updated {

--- a/crates/jcode-provider-openrouter-runtime/src/lib.rs
+++ b/crates/jcode-provider-openrouter-runtime/src/lib.rs
@@ -1826,7 +1826,15 @@ impl OpenRouterProvider {
     pub(crate) fn load_usable_model_disk_cache_entry(
         &self,
     ) -> Option<jcode_provider_openrouter::DiskCache> {
-        load_disk_cache_entry().filter(|entry| self.model_disk_cache_source_matches(entry))
+        // Read from this profile's own namespace rather than whichever profile
+        // last won the process-global env var (#607).
+        let entry = match self.foreground_cache_namespace() {
+            Some(namespace) => {
+                jcode_provider_openrouter::load_disk_cache_entry_for_namespace(&namespace)
+            }
+            None => load_disk_cache_entry(),
+        };
+        entry.filter(|entry| self.model_disk_cache_source_matches(entry))
     }
 
     fn begin_background_model_catalog_refresh(&self) -> bool {
@@ -2027,9 +2035,11 @@ impl OpenRouterProvider {
         let models_cache = Arc::clone(&self.models_cache);
         let refresh_state = Arc::clone(&self.model_catalog_refresh);
         let previous_fingerprint = self.cached_model_catalog_fingerprint();
+        let cache_namespace = self.foreground_cache_namespace();
 
         handle.spawn(async move {
-            match fetch_models_from_api(client, api_base, auth, models_cache, None).await {
+            match fetch_models_from_api(client, api_base, auth, models_cache, cache_namespace).await
+            {
                 Ok(models) => {
                     let updated = models_fingerprint(&models) != previous_fingerprint;
                     if updated {
@@ -2508,7 +2518,7 @@ impl OpenRouterProvider {
             self.api_base.clone(),
             self.auth.clone(),
             Arc::clone(&self.models_cache),
-            None,
+            self.foreground_cache_namespace(),
         )
         .await
     }
@@ -2520,7 +2530,7 @@ impl OpenRouterProvider {
             self.api_base.clone(),
             self.auth.clone(),
             Arc::clone(&self.models_cache),
-            None,
+            self.foreground_cache_namespace(),
         )
         .await
     }

--- a/crates/jcode-provider-openrouter-runtime/src/lib.rs
+++ b/crates/jcode-provider-openrouter-runtime/src/lib.rs
@@ -35,9 +35,9 @@ pub use jcode_provider_openrouter::{
 };
 use jcode_provider_openrouter::{
     KIMI_FALLBACK_PROVIDERS, ModelCatalogRefreshState, ModelsCache, ParsedProvider, PinSource,
-    ProviderPin, current_unix_secs, known_providers, load_disk_cache_entry,
-    load_endpoints_disk_cache, parse_model_spec, save_disk_cache_with_source,
-    save_disk_cache_with_source_for_namespace, save_endpoints_disk_cache,
+    ProviderPin, current_unix_secs, known_providers, load_endpoints_disk_cache, parse_model_spec,
+    save_disk_cache_with_source, save_disk_cache_with_source_for_namespace,
+    save_endpoints_disk_cache,
 };
 use reqwest::Client;
 use reqwest::header::HeaderName;

--- a/crates/jcode-provider-openrouter-runtime/src/openrouter_catalog_merge_tests.rs
+++ b/crates/jcode-provider-openrouter-runtime/src/openrouter_catalog_merge_tests.rs
@@ -175,3 +175,91 @@ context_window = 128000
         "live catalog models must still be offered: {models:?}"
     );
 }
+
+/// Regression test for issue #607.
+///
+/// Every `new_named_openai_compatible()` constructor sets the process-global
+/// `JCODE_OPENROUTER_CACHE_NAMESPACE` env var, so with several named profiles
+/// in one process the last one constructed wins and every profile's foreground
+/// cache read/write collides on a single `<last-profile>_models.json`. The
+/// picker then shows another provider's catalog, or refetches and clobbers it,
+/// which is why the model list did not survive a relaunch.
+#[test]
+fn named_profiles_keep_distinct_disk_cache_namespaces() {
+    let _lock = ENV_LOCK.lock();
+    let temp = tempfile::tempdir().expect("temp jcode home");
+    let _home = EnvVarGuard::set("JCODE_HOME", temp.path().to_str().expect("utf8 temp path"));
+    let _namespace = EnvVarGuard::remove("JCODE_OPENROUTER_CACHE_NAMESPACE");
+    let _key = EnvVarGuard::set("TEST_NS_KEY", "test-key");
+
+    let make_profile = |base_url: &str| jcode_base::config::NamedProviderConfig {
+        base_url: base_url.to_string(),
+        api_key_env: Some("TEST_NS_KEY".to_string()),
+        model_catalog: true,
+        ..Default::default()
+    };
+
+    // Construct "first" then "second"; the env var now points at "second".
+    let first = OpenRouterProvider::new_named_openai_compatible(
+        "first",
+        &make_profile("https://first.models.test/v1"),
+    )
+    .expect("first profile");
+    let second = OpenRouterProvider::new_named_openai_compatible(
+        "second",
+        &make_profile("https://second.models.test/v1"),
+    )
+    .expect("second profile");
+
+    assert!(first.is_user_named_profile());
+    assert!(second.is_user_named_profile());
+    assert_eq!(
+        first.foreground_cache_namespace().as_deref(),
+        Some("first"),
+        "each named profile must use its own namespace, not the env var winner"
+    );
+    assert_eq!(
+        second.foreground_cache_namespace().as_deref(),
+        Some("second")
+    );
+
+    // Write a distinct on-disk cache for each namespace.
+    let cache_dir = temp.path().join("cache");
+    std::fs::create_dir_all(&cache_dir).expect("create cache dir");
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("clock")
+        .as_secs();
+    for (namespace, api_base, model_id) in [
+        ("first", "https://first.models.test/v1", "first-only-model"),
+        (
+            "second",
+            "https://second.models.test/v1",
+            "second-only-model",
+        ),
+    ] {
+        let cache = serde_json::json!({
+            "cached_at": now,
+            "source_api_base": api_base,
+            "models": [{ "id": model_id }],
+        });
+        std::fs::write(
+            cache_dir.join(format!("{namespace}_models.json")),
+            serde_json::to_string(&cache).expect("serialize cache"),
+        )
+        .expect("write cache");
+    }
+
+    // Each provider must read only its own cache, even though the env var
+    // points at "second".
+    let first_entry = first
+        .load_usable_model_disk_cache_entry()
+        .expect("first profile should find its own cache");
+    assert_eq!(first_entry.models.len(), 1);
+    assert_eq!(first_entry.models[0].id, "first-only-model");
+
+    let second_entry = second
+        .load_usable_model_disk_cache_entry()
+        .expect("second profile should find its own cache");
+    assert_eq!(second_entry.models[0].id, "second-only-model");
+}

--- a/crates/jcode-provider-openrouter-runtime/src/openrouter_provider_impl.rs
+++ b/crates/jcode-provider-openrouter-runtime/src/openrouter_provider_impl.rs
@@ -772,6 +772,24 @@ impl Provider for OpenRouterProvider {
 }
 
 impl OpenRouterProvider {
+    /// The disk-cache namespace this provider's *foreground* catalog reads and
+    /// writes should use.
+    ///
+    /// Every `new_named_openai_compatible()` constructor sets the process-global
+    /// `JCODE_OPENROUTER_CACHE_NAMESPACE` env var, so with several named
+    /// profiles in one process the last one constructed wins and all profiles
+    /// collide on a single `<last-profile>_models.json`. The background refresh
+    /// path already passes an explicit namespace; the foreground paths did not.
+    /// See issue #607.
+    ///
+    /// Standard/direct OpenRouter and built-in profiles keep the existing
+    /// env-var-driven `cache_path()` semantics.
+    pub(crate) fn foreground_cache_namespace(&self) -> Option<String> {
+        self.is_user_named_profile()
+            .then(|| self.profile_id.clone())
+            .flatten()
+    }
+
     /// True when this instance was built from a user-declared
     /// `[providers.<name>]` profile in config.toml rather than a built-in
     /// OpenAI-compatible profile (Cerebras, NVIDIA NIM, ...).

--- a/crates/jcode-provider-openrouter-runtime/src/openrouter_provider_impl.rs
+++ b/crates/jcode-provider-openrouter-runtime/src/openrouter_provider_impl.rs
@@ -790,6 +790,28 @@ impl OpenRouterProvider {
             .flatten()
     }
 
+    /// The disk cache entry usable for this provider, i.e. its own namespace
+    /// (#607) and a `source_api_base` that matches this endpoint.
+    pub(crate) fn load_usable_model_disk_cache_entry(
+        &self,
+    ) -> Option<jcode_provider_openrouter::DiskCache> {
+        self.load_disk_cache_entry_for_this_profile()
+            .filter(|entry| self.model_disk_cache_source_matches(entry))
+    }
+
+    /// Load this provider's own model disk cache, ignoring the process-global
+    /// namespace env var for user-named profiles (#607).
+    pub(crate) fn load_disk_cache_entry_for_this_profile(
+        &self,
+    ) -> Option<jcode_provider_openrouter::DiskCache> {
+        match self.foreground_cache_namespace() {
+            Some(namespace) => {
+                jcode_provider_openrouter::load_disk_cache_entry_for_namespace(&namespace)
+            }
+            None => jcode_provider_openrouter::load_disk_cache_entry(),
+        }
+    }
+
     /// True when this instance was built from a user-declared
     /// `[providers.<name>]` profile in config.toml rather than a built-in
     /// OpenAI-compatible profile (Cerebras, NVIDIA NIM, ...).


### PR DESCRIPTION
Fixes #607.

## Problem

After setting a model in `/model`, the model list does not survive a relaunch. The picker shows the wrong catalog, often another named provider's models.

## Root cause

Named OpenAI-compatible profiles (`[providers.<name>]`) share **one process-global disk-cache namespace**. Every `new_named_openai_compatible()` constructor does:

```rust
jcode_base::env::set_var("JCODE_OPENROUTER_CACHE_NAMESPACE", profile_name);
```

With several named profiles in one process the **last one constructed wins**, and all profiles' foreground cache reads and writes collide on a single `<last-profile>_models.json`. Each profile then reads a cache whose `source_api_base` does not match its own, `model_disk_cache_source_matches()` rejects it, the picker refetches, and the write-back clobbers the other profile's cache. The list is unstable on every launch.

The background refresh path already passed an explicit `cache_namespace`. Only the foreground paths (`fetch_models`, `refresh_models`, `maybe_schedule_model_catalog_refresh`, and `load_usable_model_disk_cache_entry`) passed `None` and fell back to the env-var-driven `cache_path()`.

## Fix

Add `foreground_cache_namespace()` — `Some(profile_id)` for user-named profiles, `None` otherwise — and use it in all four foreground paths. Standard/direct OpenRouter and built-in profiles keep the existing env-var-driven semantics, so the shared `openrouter` namespace is untouched.

## Tests

New `named_profiles_keep_distinct_disk_cache_namespaces`: constructs two user-named profiles with different base URLs (so the env var points at the second), writes a distinct real on-disk cache for each under a temp `JCODE_HOME`, and asserts each provider reads only its own.

I verified the test actually reproduces the bug: reverting just the `load_usable_model_disk_cache_entry` change makes it fail, and restoring it makes it pass.

`cargo test -p jcode-provider-openrouter-runtime` → **97 passed, 0 failed** (96 pre-existing + 1 new).

Root cause analysis, on-disk evidence, and a fix branch contributed by @alecuba16. Note this covers the model **list** persistence (#607); the related `/model` **selection** persistence proposal in #608 involves a config-writing policy decision and is left for maintainer review.

--- *— Jcode agent (automated triage), on behalf of @1jehuang*