### PR TITLE
fix(stream): bound initial response wait for blackholed providers

### DIFF
--- a/crates/jcode-provider-anthropic-runtime/src/lib.rs
+++ b/crates/jcode-provider-anthropic-runtime/src/lib.rs
@@ -1765,6 +1765,7 @@ async fn stream_response(
         .await;
 
     let connect_start = std::time::Instant::now();
+    let stream_idle_timeout = jcode_base::provider::stream_idle_timeout();
     // Build request with appropriate auth headers
     let url = if is_oauth { API_URL_OAUTH } else { API_URL };
 
@@ -1812,11 +1813,12 @@ async fn stream_response(
             .header("anthropic-beta", beta_header);
     }
 
-    let response = req
-        .json(&request)
-        .send()
-        .await
-        .context("Failed to send request to Anthropic API")?;
+    let response = jcode_provider_core::transport::send_with_initial_response_timeout(
+        req.json(&request),
+        stream_idle_timeout,
+    )
+    .await
+    .context("Failed to send request to Anthropic API")?;
 
     let connect_ms = connect_start.elapsed().as_millis();
     jcode_base::logging::info(&format!(
@@ -1852,20 +1854,18 @@ async fn stream_response(
     // Idle timeout between streamed chunks. Configurable via
     // `[provider] stream_idle_timeout_secs` / `JCODE_STREAM_IDLE_TIMEOUT_SECS`
     // so slow reasoning models don't trip a premature timeout (issue #434).
-    let sse_chunk_timeout = jcode_base::provider::stream_idle_timeout();
-
     loop {
-        let chunk = match tokio::time::timeout(sse_chunk_timeout, stream.next()).await {
+        let chunk = match tokio::time::timeout(stream_idle_timeout, stream.next()).await {
             Ok(Some(chunk_result)) => chunk_result.context("Error reading stream chunk")?,
             Ok(None) => break, // stream ended normally
             Err(_) => {
                 jcode_base::logging::warn(&format!(
                     "Anthropic SSE stream timed out (no data for {}s)",
-                    sse_chunk_timeout.as_secs()
+                    stream_idle_timeout.as_secs()
                 ));
                 anyhow::bail!(
                     "Stream read timeout: no data received for {} seconds",
-                    sse_chunk_timeout.as_secs()
+                    stream_idle_timeout.as_secs()
                 );
             }
         };

--- a/crates/jcode-provider-core/Cargo.toml
+++ b/crates/jcode-provider-core/Cargo.toml
@@ -19,7 +19,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 rand = "0.9.3"
 sha2 = "0.10"
-tokio = { version = "1", features = ["sync"] }
+tokio = { version = "1", features = ["sync", "time"] }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["sync", "macros", "rt"] }

--- a/crates/jcode-provider-core/src/transport.rs
+++ b/crates/jcode-provider-core/src/transport.rs
@@ -5,6 +5,28 @@
 //! a fresh connection, or a real error to surface. Keeping the classifier here
 //! ensures all providers recognize the same fault vocabulary.
 
+use anyhow::Result;
+use std::time::Duration;
+
+/// Send a request while bounding the wait for response headers.
+///
+/// Reqwest's `send` future covers connection establishment and the wait for
+/// response headers, but streaming body reads happen after it resolves. Provider
+/// stream loops apply their own idle timeout to those body reads, so using the
+/// same budget here closes the zero-response-bytes gap without imposing an
+/// overall deadline on a legitimately long stream.
+pub async fn send_with_initial_response_timeout(
+    request: reqwest::RequestBuilder,
+    timeout: Duration,
+) -> Result<reqwest::Response> {
+    match tokio::time::timeout(timeout, request.send()).await {
+        Ok(response) => Ok(response?),
+        Err(_) => anyhow::bail!(
+            "Initial response timeout: no response headers received within {timeout:?}"
+        ),
+    }
+}
+
 /// Whether an error message describes a transient transport-level fault
 /// (connection reset, DNS hiccup, TLS teardown, HTTP/2 stream error, ...)
 /// that is likely to succeed on retry with a fresh connection.
@@ -66,7 +88,62 @@ pub fn is_transient_transport_error(error_str: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::is_transient_transport_error;
+    use super::{is_transient_transport_error, send_with_initial_response_timeout};
+    use std::io::Read;
+    use std::net::TcpListener;
+    use std::sync::mpsc;
+    use std::thread;
+    use std::time::{Duration, Instant};
+
+    #[tokio::test]
+    async fn accepted_request_without_response_headers_times_out() {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind blackhole server");
+        let address = listener.local_addr().expect("read blackhole address");
+        let (request_seen_tx, request_seen_rx) = mpsc::channel();
+        let (release_tx, release_rx) = mpsc::channel();
+
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept request");
+            stream
+                .set_read_timeout(Some(Duration::from_secs(2)))
+                .expect("set request read timeout");
+            let mut request = [0_u8; 4096];
+            let bytes_read = stream.read(&mut request).expect("read request");
+            assert!(bytes_read > 0, "client should send request bytes");
+            request_seen_tx.send(()).expect("report request received");
+
+            // Keep the socket open without sending status or response headers.
+            let _ = release_rx.recv_timeout(Duration::from_secs(2));
+        });
+
+        let request = reqwest::Client::new()
+            .post(format!("http://{address}/chat/completions"))
+            .body("{}");
+        let timeout = Duration::from_millis(250);
+        let started = Instant::now();
+        let error = send_with_initial_response_timeout(request, timeout)
+            .await
+            .expect_err("blackholed response should time out");
+
+        assert!(
+            error.to_string().contains("Initial response timeout"),
+            "unexpected error: {error:#}"
+        );
+        assert!(
+            is_transient_transport_error(&error.to_string()),
+            "initial response timeouts must enter provider retry machinery"
+        );
+        assert!(
+            started.elapsed() < Duration::from_secs(2),
+            "initial response wait exceeded its timeout"
+        );
+        request_seen_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("server should receive the request before the timeout");
+
+        let _ = release_tx.send(());
+        server.join().expect("blackhole server should exit");
+    }
 
     #[test]
     fn http2_stream_protocol_error_is_transient() {

--- a/crates/jcode-provider-openai-runtime/src/openai_stream_runtime.rs
+++ b/crates/jcode-provider-openai-runtime/src/openai_stream_runtime.rs
@@ -119,13 +119,15 @@ pub(super) async fn stream_response(
 
     emit_connection_phase(&tx, ConnectionPhase::SendingRequest).await;
     let connect_start = std::time::Instant::now();
+    let idle_timeout = effective_https_idle_timeout(&request);
 
-    let response = builder
-        .json(&request)
-        .send()
-        .await
-        .context("Failed to send request to OpenAI API")
-        .map_err(OpenAIStreamFailure::Other)?;
+    let response = jcode_provider_core::transport::send_with_initial_response_timeout(
+        builder.json(&request),
+        idle_timeout,
+    )
+    .await
+    .context("Failed to send request to OpenAI API")
+    .map_err(OpenAIStreamFailure::Other)?;
 
     let connect_ms = connect_start.elapsed().as_millis();
     jcode_base::logging::info(&format!(
@@ -250,8 +252,6 @@ pub(super) async fn stream_response(
     // minutes get cancelled prematurely. Resolved from
     // `[provider] stream_idle_timeout_secs` / `JCODE_STREAM_IDLE_TIMEOUT_SECS`
     // (issue #434).
-    let idle_timeout = effective_https_idle_timeout(&request);
-
     use futures::StreamExt;
     loop {
         let result = match tokio::time::timeout(idle_timeout, stream.next()).await {

--- a/crates/jcode-provider-openrouter-runtime/src/openrouter_sse_stream.rs
+++ b/crates/jcode-provider-openrouter-runtime/src/openrouter_sse_stream.rs
@@ -167,6 +167,7 @@ async fn stream_response(
         }))
         .await;
     let connect_start = std::time::Instant::now();
+    let stream_idle_timeout = jcode_base::provider::stream_idle_timeout();
 
     let url = format!("{}/chat/completions", api_base);
     let mut req = apply_kimi_coding_agent_headers(
@@ -187,20 +188,21 @@ async fn stream_response(
             .header("X-Title", "jcode");
     }
 
-    let response = req
-        .json(&request)
-        .send()
-        .await
-        .with_context(|| {
-            let hint = local_endpoint_troubleshooting_hint(&api_base, &model);
-            format!(
-                "Failed to send OpenAI-compatible chat request\n  endpoint: {}\n  model: {}\n  auth: {}\n{}",
-                url,
-                model,
-                auth.label(),
-                hint
-            )
-        })?;
+    let response = jcode_provider_core::transport::send_with_initial_response_timeout(
+        req.json(&request),
+        stream_idle_timeout,
+    )
+    .await
+    .with_context(|| {
+        let hint = local_endpoint_troubleshooting_hint(&api_base, &model);
+        format!(
+            "Failed to send OpenAI-compatible chat request\n  endpoint: {}\n  model: {}\n  auth: {}\n{}",
+            url,
+            model,
+            auth.label(),
+            hint
+        )
+    })?;
 
     let connect_ms = connect_start.elapsed().as_millis();
     jcode_base::logging::info(&format!(
@@ -241,11 +243,10 @@ async fn stream_response(
     // tokens don't trip a premature timeout (issue #196). Resolved from
     // `[provider] stream_idle_timeout_secs` / `JCODE_STREAM_IDLE_TIMEOUT_SECS`,
     // defaulting to 180s. Shared with the native provider paths (issue #434).
-    let sse_chunk_timeout = jcode_base::provider::stream_idle_timeout();
-    let idle_timeout_secs = sse_chunk_timeout.as_secs();
+    let idle_timeout_secs = stream_idle_timeout.as_secs();
 
     loop {
-        let event = match tokio::time::timeout(sse_chunk_timeout, stream.next()).await {
+        let event = match tokio::time::timeout(stream_idle_timeout, stream.next()).await {
             Ok(Some(Ok(event))) => event,
             Ok(Some(Err(e))) => anyhow::bail!(
                 "OpenAI-compatible stream error\n  endpoint: {}\n  model: {}\n  auth: {}\n  error: {}",


### PR DESCRIPTION
## Summary

- Bound the initial streaming HTTP response wait, covering connection establishment through receipt of response headers.
- Reused each request's existing stream idle-timeout budget, without adding an overall deadline to long-running response bodies.
- Applied the guard to OpenAI-compatible/OpenRouter SSE, native OpenAI HTTPS/SSE, and Anthropic SSE paths.
- Preserved existing error contexts and emitted a normal timeout error that the transport retry classifier already treats as transient.

## Root cause

The streaming providers called `RequestBuilder::send().await` without a deadline. Reqwest does not return a `Response` until response headers arrive, while the existing idle timeout was only installed afterward around `stream.next()`. An upstream that accepted the connection but never sent response headers therefore remained stuck before the guarded stream loop forever.

## Regression coverage

A local TCP blackhole test now accepts and reads the request, keeps the socket open, and sends no response headers. It verifies that the initial wait times out promptly and that the resulting error is classified as retryable.

## Validation

- `cargo test -p jcode-provider-core -p jcode-provider-openrouter-runtime -p jcode-provider-anthropic-runtime -p jcode-provider-openai-runtime --lib`: 376 passed, 4 ignored live tests.
- `cargo clippy -p jcode-provider-core -p jcode-provider-openrouter-runtime -p jcode-provider-anthropic-runtime -p jcode-provider-openai-runtime --lib --no-deps -- -D warnings`: passed.
- `scripts/dev_cargo.sh build --profile selfdev -p jcode --bin jcode`: passed.
- The requested test-inclusive clippy command is blocked on clean `origin/master` before this patch's runtime crates finish: `jcode-provider-bedrock::configured_bearer_token_for_runtime` is already dead code under this feature graph. With dependencies excluded, clean-master test files also have existing `await_holding_lock` and `useless_conversion` warnings. No unrelated lint suppressions or fixes are included here.
- `scripts/check_guardrails.sh --skip-slow`: format, lockfile, warning budget, test-size, panic, dependency-boundary, wildcard-export, and desktop frame gates passed. Remaining code-size and swallowed-error failures are existing clean-master growth in unrelated files; this patch was adjusted so `jcode-provider-core/src/lib.rs` stays flat.

Fixes #620

---
*— Jcode agent (automated triage), on behalf of @1jehuang*