### PR TITLE
Fix provider-specific effort and service-tier UI

### DIFF
--- a/crates/jcode-tui/src/tui/app/inline_interactive.rs
+++ b/crates/jcode-tui/src/tui/app/inline_interactive.rs
@@ -4120,9 +4120,10 @@ mod tests {
         assert!(route_supports_reasoning_effort("openai-oauth"));
         assert!(route_supports_reasoning_effort("openai-api-key"));
         assert!(route_supports_reasoning_effort("openrouter"));
-        assert!(route_supports_reasoning_effort(
+        assert!(!route_supports_reasoning_effort(
             "openai-compatible:llamacpp"
         ));
+        assert!(!route_supports_reasoning_effort("openai-compatible:zai"));
         assert!(!route_supports_reasoning_effort("copilot"));
         assert!(!route_supports_reasoning_effort("bedrock"));
         assert!(!route_supports_reasoning_effort("https"));

--- a/crates/jcode-tui/src/tui/app/inline_interactive_placeholder_routes.rs
+++ b/crates/jcode-tui/src/tui/app/inline_interactive_placeholder_routes.rs
@@ -40,7 +40,9 @@ pub(super) fn route_supports_reasoning_effort(api_method: &str) -> bool {
         | Method::OpenAIOAuth
         | Method::OpenAIApiKey
         | Method::OpenRouter => true,
-        Method::OpenAiCompatible { profile_id } => profile_id.is_some(),
+        // Named OpenAI-compatible profiles expose effort through `/effort`.
+        // Expanding them here creates one duplicate picker row per effort.
+        Method::OpenAiCompatible { .. } => false,
         Method::JcodeSubscription
         | Method::Copilot
         | Method::Cursor

--- a/crates/jcode-tui/src/tui/info_widget_model.rs
+++ b/crates/jcode-tui/src/tui/info_widget_model.rs
@@ -334,7 +334,11 @@ fn append_model_runtime_metadata(spans: &mut Vec<Span<'static>>, data: &InfoWidg
         ));
     }
 
-    if let Some(tier) = data.service_tier.as_deref().and_then(short_service_tier) {
+    let is_openai = data
+        .provider_name
+        .as_deref()
+        .is_some_and(|provider| provider.trim().to_ascii_lowercase().starts_with("openai"));
+    if is_openai && let Some(tier) = data.service_tier.as_deref().and_then(short_service_tier) {
         spans.push(Span::styled(" ", Style::default()));
         spans.push(Span::styled(
             format!("[{tier}]"),
@@ -436,7 +440,8 @@ mod tests {
     #[test]
     fn model_widget_and_overview_show_same_runtime_metadata() {
         let rect = Rect::new(0, 0, 40, 8);
-        let data = data();
+        let mut data = data();
+        data.provider_name = Some("openai".to_string());
 
         let independent = first_line_text(render_model_widget(&data, rect));
         let overview = first_line_text(render_model_info(&data, rect));
@@ -445,5 +450,16 @@ mod tests {
         assert!(independent.contains("[fast]"));
         assert!(overview.contains("(hi)"));
         assert!(overview.contains("[fast]"));
+    }
+
+    #[test]
+    fn non_openai_provider_hides_openai_service_tier() {
+        let rect = Rect::new(0, 0, 40, 8);
+        let mut data = data();
+        data.model = Some("deepseek-v4-flash".to_string());
+        data.provider_name = Some("deepseek".to_string());
+
+        assert!(!first_line_text(render_model_widget(&data, rect)).contains("[fast]"));
+        assert!(!first_line_text(render_model_info(&data, rect)).contains("[fast]"));
     }
 }


### PR DESCRIPTION
## Summary
- keep named OpenAI-compatible models to one picker row and use `/effort` for effort selection
- only render the OpenAI `[fast]` service-tier badge for OpenAI providers
- add regressions for Z.AI picker rows and DeepSeek badge rendering

## Verification
- `cargo test -p jcode-tui --lib route_effort_support_covers_effort_capable_runtimes_only`
- `cargo test -p jcode-tui --lib non_openai_provider_hides_openai_service_tier`
- `cargo test -p jcode-tui --lib model_widget_and_overview_show_same_runtime_metadata`

Fixes #742. Fixes #739.

--- *— Jcode agent (automated triage), on behalf of @1jehuang*