### PR TITLE
fix: update Celeris model limits (fixes #762)

### DIFF
--- a/crates/jcode-provider-core/src/models.rs
+++ b/crates/jcode-provider-core/src/models.rs
@@ -345,9 +345,9 @@ pub fn open_weight_family_context_limit(model: &str) -> Option<usize> {
         return Some(204_800);
     }
 
-    // --- Celeris celeris-1: 8,192 total (prompt + completion) window ---
+    // --- Celeris celeris-1: 131,072 total (prompt + completion) window ---
     if m.contains("celeris") {
-        return Some(8_192);
+        return Some(131_072);
     }
 
     // --- Xiaomi MiMo V2 family: 256K context ---
@@ -504,6 +504,11 @@ mod tests {
             open_weight_family_context_limit("moonshotai/kimi-k2"),
             Some(262_144)
         );
+    }
+
+    #[test]
+    fn celeris_family_resolves_to_131k_context() {
+        assert_eq!(open_weight_family_context_limit("celeris-1"), Some(131_072));
     }
 
     #[test]

--- a/crates/jcode-provider-openrouter-runtime/src/lib.rs
+++ b/crates/jcode-provider-openrouter-runtime/src/lib.rs
@@ -1082,7 +1082,7 @@ impl OpenRouterProvider {
         }
     }
 
-    fn configured_max_tokens(profile_id: Option<&str>) -> Option<u32> {
+    fn configured_max_tokens(_profile_id: Option<&str>) -> Option<u32> {
         if let Ok(raw) = std::env::var("JCODE_OPENROUTER_MAX_TOKENS") {
             let trimmed = raw.trim();
             if trimmed.is_empty() || trimmed.eq_ignore_ascii_case("auto") {
@@ -1096,14 +1096,6 @@ impl OpenRouterProvider {
                     raw
                 )),
             }
-        }
-
-        // Celeris rejects `max_tokens` values that are not a positive multiple
-        // of 256, and requires prompt + max_tokens <= 8,192. Its own default
-        // (2,048) leaves only ~6K of prompt room, so ask for a smaller
-        // completion budget to keep more of the context window usable.
-        if profile_id.is_some_and(|id| id.eq_ignore_ascii_case("celeris")) {
-            return Some(1_024);
         }
 
         None

--- a/crates/jcode-provider-openrouter-runtime/src/openrouter_tests.rs
+++ b/crates/jcode-provider-openrouter-runtime/src/openrouter_tests.rs
@@ -806,7 +806,7 @@ fn openai_compatible_profiles_with_unverified_live_catalogs_have_static_fallback
 }
 
 #[test]
-fn comtegra_profile_uses_endpoint_default_max_tokens() {
+fn profiles_use_endpoint_default_max_tokens() {
     let _lock = ENV_LOCK.lock();
     let _override = EnvVarGuard::remove("JCODE_OPENROUTER_MAX_TOKENS");
 
@@ -816,6 +816,10 @@ fn comtegra_profile_uses_endpoint_default_max_tokens() {
     );
     assert_eq!(
         OpenRouterProvider::configured_max_tokens(Some("deepseek")),
+        None
+    );
+    assert_eq!(
+        OpenRouterProvider::configured_max_tokens(Some("celeris")),
         None
     );
 }


### PR DESCRIPTION
## Summary

- update Celeris 1's combined context window from 8,192 to 131,072 tokens
- remove the obsolete 1,024-token completion override so Celeris uses its documented endpoint default
- add regression coverage for context and completion-token configuration

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p jcode-provider-core` (116 passed)
- `cargo test -p jcode-provider-openrouter-runtime` (112 passed, 1 ignored)

Confirmed against the official Celeris API reference: https://docs.celeris.ai/api-reference

Addresses #762.

--- *— Jcode agent (automated triage), on behalf of @1jehuang*