### PR TITLE
test(tui): satisfy iteration-maturity gate in todo completion fixtures

### DIFF
--- a/crates/jcode-tui/src/tui/app/tests/remote_events_reload_01/part_02.rs
+++ b/crates/jcode-tui/src/tui/app/tests/remote_events_reload_01/part_02.rs
@@ -151,6 +151,17 @@ fn test_remote_auto_poke_challenges_abrupt_confidence_increase() {
             }],
         )
         .expect("save todos");
+
+        crate::todo::save_goals(
+            &app.session.id,
+            &[crate::todo::TodoGoal {
+                delivery_state: Some(crate::todo::DeliveryState::WorkflowValidated),
+                autonomy: Some(crate::todo::Autonomy::NecessaryFollowthrough),
+                iteration_maturity: Some(crate::todo::IterationMaturity::OutcomeReached),
+                ..Default::default()
+            }],
+        )
+        .expect("save passing goal");
         app.is_remote = true;
         app.auto_poke_incomplete_todos = true;
         app.is_processing = true;
@@ -198,6 +209,17 @@ fn test_remote_auto_poke_completion_below_threshold_tells_model_to_keep_working(
             }],
         )
         .expect("save todos");
+
+        crate::todo::save_goals(
+            &app.session.id,
+            &[crate::todo::TodoGoal {
+                delivery_state: Some(crate::todo::DeliveryState::WorkflowValidated),
+                autonomy: Some(crate::todo::Autonomy::NecessaryFollowthrough),
+                iteration_maturity: Some(crate::todo::IterationMaturity::OutcomeReached),
+                ..Default::default()
+            }],
+        )
+        .expect("save passing goal");
         app.is_remote = true;
         app.auto_poke_incomplete_todos = true;
         app.is_processing = true;

--- a/crates/jcode-tui/src/tui/app/tests/remote_events_reload_05.rs
+++ b/crates/jcode-tui/src/tui/app/tests/remote_events_reload_05.rs
@@ -142,6 +142,21 @@ fn test_reload_preserves_completed_confidence_spike_challenge() {
         )
         .expect("save completed todo");
 
+        crate::todo::save_goals(
+            &reloaded_app.session.id,
+            &[crate::todo::TodoGoal {
+                delivery_state: Some(crate::todo::DeliveryState::WorkflowValidated),
+                autonomy: Some(crate::todo::Autonomy::NecessaryFollowthrough),
+                iteration_maturity: Some(crate::todo::IterationMaturity::OutcomeReached),
+                ..Default::default()
+            }],
+        )
+        .expect("save passing goal");
+
+        // Pin the default so the clean-cycle finish disarms rather than
+        // re-arming; this test is about the spike-challenge flag, not the
+        // default-on re-arm behavior.
+        reloaded_app.auto_poke_default_on = false;
         assert!(!reloaded_app.schedule_auto_poke_followup_if_needed());
         assert!(!reloaded_app.auto_poke_incomplete_todos);
         assert!(!reloaded_app.todo_confidence_spike_challenged);
@@ -219,6 +234,7 @@ fn low_ownership_is_gated_after_the_completed_todo_was_saved() {
             }],
         )
         .expect("save completed todo");
+
         crate::todo::save_goals(
             &app.session.id,
             &[crate::todo::TodoGoal {
@@ -416,6 +432,17 @@ fn test_gate_digest_is_delivered_at_turn_end_and_rearms_next_cycle() {
         )
         .expect("save completed todo");
 
+        crate::todo::save_goals(
+            &app.session.id,
+            &[crate::todo::TodoGoal {
+                delivery_state: Some(crate::todo::DeliveryState::WorkflowValidated),
+                autonomy: Some(crate::todo::Autonomy::NecessaryFollowthrough),
+                iteration_maturity: Some(crate::todo::IterationMaturity::OutcomeReached),
+                ..Default::default()
+            }],
+        )
+        .expect("save passing goal");
+
         // A point that was flagged during the turn and never resolved.
         crate::todo::append_gate_observations(
             &app.session.id,
@@ -518,8 +545,8 @@ fn completed_cycle_rearms_auto_poke_only_when_default_on() {
             confidence: Some(crate::todo::ConfidenceState::from_legacy_score(100)),
             completion_confidence: Some(crate::todo::ConfidenceState::from_legacy_score(100)),
             confidence_history: vec![
-                crate::todo::ConfidenceState::from_legacy_score(95),
-                crate::todo::ConfidenceState::from_legacy_score(100),
+                crate::todo::ConfidenceState::Validated,
+                crate::todo::ConfidenceState::Verified,
             ],
             ..Default::default()
         };
@@ -528,6 +555,16 @@ fn completed_cycle_rearms_auto_poke_only_when_default_on() {
         app.auto_poke_incomplete_todos = true;
         app.auto_poke_default_on = true;
         crate::todo::save_todos(&app.session.id, &[completed("todo-1")]).expect("save");
+        crate::todo::save_goals(
+            &app.session.id,
+            &[crate::todo::TodoGoal {
+                delivery_state: Some(crate::todo::DeliveryState::WorkflowValidated),
+                autonomy: Some(crate::todo::Autonomy::NecessaryFollowthrough),
+                iteration_maturity: Some(crate::todo::IterationMaturity::OutcomeReached),
+                ..Default::default()
+            }],
+        )
+        .expect("save passing goal");
         assert!(!app.schedule_auto_poke_followup_if_needed());
         assert!(
             app.auto_poke_incomplete_todos,
@@ -540,6 +577,16 @@ fn completed_cycle_rearms_auto_poke_only_when_default_on() {
         app.auto_poke_default_on = true;
         crate::tui::app::commands::disable_auto_poke(&mut app);
         crate::todo::save_todos(&app.session.id, &[completed("todo-2")]).expect("save");
+        crate::todo::save_goals(
+            &app.session.id,
+            &[crate::todo::TodoGoal {
+                delivery_state: Some(crate::todo::DeliveryState::WorkflowValidated),
+                autonomy: Some(crate::todo::Autonomy::NecessaryFollowthrough),
+                iteration_maturity: Some(crate::todo::IterationMaturity::OutcomeReached),
+                ..Default::default()
+            }],
+        )
+        .expect("save passing goal");
         app.auto_poke_incomplete_todos = true; // pretend a stale arm survived
         assert!(!app.schedule_auto_poke_followup_if_needed());
         assert!(

--- a/crates/jcode-tui/src/tui/app/tests/state_model_poke_03.rs
+++ b/crates/jcode-tui/src/tui/app/tests/state_model_poke_03.rs
@@ -2484,6 +2484,8 @@ fn test_finish_turn_auto_poke_queues_confidence_summary_when_todos_done() {
             &app.session.id,
             &[crate::todo::TodoGoal {
                 delivery_state: Some(crate::todo::DeliveryState::WorkflowValidated),
+                autonomy: Some(crate::todo::Autonomy::NecessaryFollowthrough),
+                iteration_maturity: Some(crate::todo::IterationMaturity::OutcomeReached),
                 ..Default::default()
             }],
         )
@@ -2627,6 +2629,17 @@ fn test_finish_turn_challenges_confidence_spike_once() {
         )
         .expect("save todos");
 
+        crate::todo::save_goals(
+            &app.session.id,
+            &[crate::todo::TodoGoal {
+                delivery_state: Some(crate::todo::DeliveryState::WorkflowValidated),
+                autonomy: Some(crate::todo::Autonomy::NecessaryFollowthrough),
+                iteration_maturity: Some(crate::todo::IterationMaturity::OutcomeReached),
+                ..Default::default()
+            }],
+        )
+        .expect("save passing goal");
+
         app.auto_poke_incomplete_todos = true;
         app.is_processing = true;
         super::local::finish_turn(&mut app);
@@ -2648,6 +2661,9 @@ fn test_finish_turn_challenges_confidence_spike_once() {
         app.queued_messages.clear();
         app.pending_queued_dispatch = false;
         app.is_processing = true;
+        // Pin the default so the clean second cycle disarms; this test is
+        // about challenging the spike exactly once.
+        app.auto_poke_default_on = false;
         super::local::finish_turn(&mut app);
 
         assert!(!app.auto_poke_incomplete_todos);


### PR DESCRIPTION
## Summary
- preserve the remaining local-master todo completion fixture updates
- cover iteration-maturity gating across remote reload and state-model poke tests

This was the final local-only commit preventing the checkout from fast-forwarding to remote master.

--- *— Jcode agent (automated triage), on behalf of @1jehuang*