### PR TITLE
Fix pinned todos config-off test isolation

### DIFF
--- a/crates/jcode-desktop2/src/scene.rs
+++ b/crates/jcode-desktop2/src/scene.rs
@@ -1311,12 +1311,7 @@ fn draw_transcript(
                     Affine::scale(scale),
                     color,
                     None,
-                    &Rect::new(
-                        x0,
-                        y0,
-                        x1,
-                        y1,
-                    ),
+                    &Rect::new(x0, y0, x1, y1),
                 );
             }
             if let Some(selection) = model.selection.as_ref()
@@ -1941,18 +1936,10 @@ mod tests {
         for scale in [1.0, 1.25, 1.5, 1.75, 2.0, 2.5] {
             let hairline = 1.0 / scale;
             let origin = 13.37;
-            let (_, first_bottom) = diff_band_y(
-                Rect::new(0.0, 0.0, 100.0, 19.2),
-                origin,
-                hairline,
-                false,
-            );
-            let (second_top, _) = diff_band_y(
-                Rect::new(0.0, 19.2, 100.0, 38.4),
-                origin,
-                hairline,
-                false,
-            );
+            let (_, first_bottom) =
+                diff_band_y(Rect::new(0.0, 0.0, 100.0, 19.2), origin, hairline, false);
+            let (second_top, _) =
+                diff_band_y(Rect::new(0.0, 19.2, 100.0, 38.4), origin, hairline, false);
             let overlap_px = (first_bottom - second_top) * scale;
             assert!(
                 (overlap_px - 1.0).abs() < 1e-9,

--- a/crates/jcode-desktop2/src/tests/actions.rs
+++ b/crates/jcode-desktop2/src/tests/actions.rs
@@ -1590,10 +1590,7 @@ fn a_new_session_preserves_the_old_panel_until_the_new_one_attaches() {
     let (updates_tx, updates_rx) = channel();
     let (commands_tx, _commands_rx) = channel();
     let commands = crate::harness::CommandSender::for_test(commands_tx);
-    app.harness = Some((
-        updates_rx,
-        commands.clone(),
-    ));
+    app.harness = Some((updates_rx, commands.clone()));
 
     app.new_session();
 

--- a/crates/jcode-tui/src/tui/app/tests/todo_card.rs
+++ b/crates/jcode-tui/src/tui/app/tests/todo_card.rs
@@ -205,6 +205,12 @@ impl PinTodosEnvGuard {
         crate::config::invalidate_config_cache();
         Self
     }
+
+    fn disable() -> Self {
+        crate::env::set_var("JCODE_PIN_TODOS", "0");
+        crate::config::invalidate_config_cache();
+        Self
+    }
 }
 
 impl Drop for PinTodosEnvGuard {
@@ -219,6 +225,7 @@ impl Drop for PinTodosEnvGuard {
 #[test]
 fn pinned_todos_payload_stays_empty_when_config_off() {
     let _env_lock = crate::storage::lock_test_env();
+    let _pin_guard = PinTodosEnvGuard::disable();
     let mut app = create_test_app();
     let session_id = app.session.id.clone();
     crate::todo::save_todos(&session_id, &[pinned_band_todo("t1", "pin me", "pending")]).unwrap();


### PR DESCRIPTION
## Summary
- explicitly force `JCODE_PIN_TODOS=0` in the config-off test
- invalidate the configuration cache before creating the test app
- reuse the existing guard cleanup so later tests cannot inherit stale state

## Verification
- `cargo test -p jcode-tui --lib tui::app::tests::pinned_todos_payload_stays_empty_when_config_off -- --exact --test-threads=1`

Fixes #877

---
*— Jcode agent (automated triage), on behalf of @1jehuang*