### PR TITLE
Retry OpenAI-compatible stream_read_error failures

### DIFF
--- a/crates/jcode-provider-core/src/transport.rs
+++ b/crates/jcode-provider-core/src/transport.rs
@@ -77,6 +77,7 @@ pub fn is_transient_transport_error(error_str: &str) -> bool {
         // or RST_STREAM / GOAWAY frames from the server or an intermediary.
         || lower.contains("http2 error")
         || lower.contains("stream error")
+        || lower.contains("stream_read_error")
         || lower.contains("protocol error")
         || lower.contains("refused_stream")
         || lower.contains("refused stream")
@@ -186,5 +187,18 @@ mod tests {
                 "should be transient: {error}"
             );
         }
+    }
+
+    /// OpenAI-compatible stream failure with structured upstream_error payload.
+    /// Regression test for issue #885: stream_read_error should be retried.
+    #[test]
+    fn openai_compatible_stream_read_error_is_transient() {
+        // Formatted output from extract_error_with_retry when receiving:
+        // { "type": "error", "error": { "type": "upstream_error", "code": "stream_read_error" } }
+        assert!(is_transient_transport_error(
+            "upstream_error: stream_read_error"
+        ));
+        // Also test the identifier in isolation (case-insensitive)
+        assert!(is_transient_transport_error("stream_read_error"));
     }
 }

--- a/crates/jcode-provider-core/src/transport.rs
+++ b/crates/jcode-provider-core/src/transport.rs
@@ -188,17 +188,4 @@ mod tests {
             );
         }
     }
-
-    /// OpenAI-compatible stream failure with structured upstream_error payload.
-    /// Regression test for issue #885: stream_read_error should be retried.
-    #[test]
-    fn openai_compatible_stream_read_error_is_transient() {
-        // Formatted output from extract_error_with_retry when receiving:
-        // { "type": "error", "error": { "type": "upstream_error", "code": "stream_read_error" } }
-        assert!(is_transient_transport_error(
-            "upstream_error: stream_read_error"
-        ));
-        // Also test the identifier in isolation (case-insensitive)
-        assert!(is_transient_transport_error("stream_read_error"));
-    }
 }

--- a/crates/jcode-provider-openai/src/stream.rs
+++ b/crates/jcode-provider-openai/src/stream.rs
@@ -888,6 +888,23 @@ mod tests {
     use super::*;
 
     #[test]
+    fn structured_stream_read_error_is_extracted_and_classified_as_transient() {
+        let error = serde_json::json!({
+            "type": "upstream_error",
+            "code": "stream_read_error"
+        });
+
+        let (message, retry_after) = extract_error_with_retry(&None, &Some(error));
+
+        assert_eq!(
+            message,
+            "upstream_error (stream_read_error): OpenAI response stream error (unknown)"
+        );
+        assert_eq!(retry_after, None);
+        assert!(jcode_provider_core::is_transient_transport_error(&message));
+    }
+
+    #[test]
     fn parse_text_wrapped_tool_call_rejects_non_object_json() {
         let text = "prefix to=functions.read [1,2,3]";
         let parsed = parse_text_wrapped_tool_call(text);


### PR DESCRIPTION
## Summary
- classify the structured OpenAI-compatible `stream_read_error` identifier as a transient transport failure
- preserve the existing bounded retry path
- add regression coverage for the reported identifier

## Verification
- `cargo test -p jcode-provider-core --lib` (125 passed)
- GitHub CI: macOS, Windows, Windows cross-target, PowerShell, TypeScript SDK, setup, release, linked-issue, and Greptile checks pass
- Linux is blocked by the pre-existing `pinned_todos_payload_stays_empty_when_config_off` failure tracked in #877; Format/Quality are blocked by pre-existing desktop formatting on `master`

Fixes #885

---
*— Jcode agent (automated triage), on behalf of @1jehuang*
