### PR TITLE
fix: resolve safe issues from automated triage

### DIFF
--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -352,13 +352,23 @@ Agent-time, autonomy, and pain-attribution fields require the D1 migration in `t
 Any of these methods will disable telemetry completely:
 
 ```bash
-# Option 1: Environment variable
+# Option 1: Persistent CLI setting
+jcode telemetry disable
+
+# Inspect the current setting without creating a telemetry ID
+jcode telemetry status
+jcode telemetry status --json
+
+# Re-enable telemetry
+jcode telemetry enable
+
+# Option 2: Environment variable
 export JCODE_NO_TELEMETRY=1
 
-# Option 2: Standard DO_NOT_TRACK (https://consoledonottrack.com/)
+# Option 3: Standard DO_NOT_TRACK (https://consoledonottrack.com/)
 export DO_NOT_TRACK=1
 
-# Option 3: File-based opt-out
+# Option 4: File-based opt-out
 touch ~/.jcode/no_telemetry
 ```
 
@@ -366,7 +376,7 @@ When opted out, zero network requests are made. The telemetry module short-circu
 
 ## Verification
 
-This is open source. The entire telemetry implementation is in [`src/telemetry.rs`](./src/telemetry.rs) - you can read exactly what gets sent. There are no other network calls related to telemetry anywhere in the codebase.
+This is open source. The telemetry implementation is in [`crates/jcode-telemetry-core/src/`](./crates/jcode-telemetry-core/src/) - you can read exactly what gets sent. There are no other network calls related to telemetry anywhere in the codebase.
 
 ## Data Retention
 

--- a/crates/jcode-app-core/src/tool/bash.rs
+++ b/crates/jcode-app-core/src/tool/bash.rs
@@ -555,6 +555,13 @@ fn build_shell_command(cmd_str: &str) -> TokioCommand {
     }
 }
 
+fn configure_background_command_stdio(command: &mut TokioCommand) {
+    command
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+}
+
 #[cfg(unix)]
 fn build_detached_shell_wrapper(command: &str) -> StdCommand {
     let mut cmd = StdCommand::new("bash");
@@ -1160,9 +1167,8 @@ impl BashTool {
 							Ok(())
 						});
 					}
-					cmd.kill_on_drop(true)
-						.stdout(Stdio::piped())
-						.stderr(Stdio::piped());
+                    cmd.kill_on_drop(true);
+                    configure_background_command_stdio(&mut cmd);
                     if let Some(ref dir) = working_dir {
                         cmd.current_dir(dir);
                     }

--- a/crates/jcode-app-core/src/tool/bash_tests.rs
+++ b/crates/jcode-app-core/src/tool/bash_tests.rs
@@ -30,6 +30,30 @@ fn cargo_wrapper_path_is_shell_quoted() {
     assert_eq!(shell_single_quote("a'b"), "'a'\"'\"'b'");
 }
 
+#[tokio::test]
+async fn background_command_stdin_is_null() {
+    let mut command =
+        build_shell_command("if IFS= read -r _; then printf inherited; else printf eof; fi");
+
+    // Start with a readable pipe so this test does not depend on, or modify, the
+    // test runner's process-wide stdin. Background configuration must replace it.
+    command.stdin(Stdio::piped());
+    configure_background_command_stdio(&mut command);
+
+    let child = command.spawn().expect("background command should spawn");
+    assert!(
+        child.stdin.is_none(),
+        "background commands must not retain a writable stdin pipe"
+    );
+
+    let output = tokio::time::timeout(Duration::from_secs(2), child.wait_with_output())
+        .await
+        .expect("background command should observe EOF instead of blocking")
+        .expect("background command should exit cleanly");
+    assert!(output.status.success());
+    assert_eq!(String::from_utf8_lossy(&output.stdout), "eof");
+}
+
 fn make_ctx(stdin_tx: Option<mpsc::UnboundedSender<StdinInputRequest>>) -> ToolContext {
     ToolContext {
         session_id: "test-session".to_string(),

--- a/crates/jcode-telemetry-core/src/lib.rs
+++ b/crates/jcode-telemetry-core/src/lib.rs
@@ -407,16 +407,62 @@ enum DeliveryMode {
     Blocking(Duration),
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TelemetryOptOutSource {
+    Environment,
+    MarkerFile,
+}
+
+impl TelemetryOptOutSource {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Environment => "environment",
+            Self::MarkerFile => "marker_file",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TelemetryStatus {
+    pub enabled: bool,
+    pub content_sharing_enabled: bool,
+    pub opt_out_source: Option<TelemetryOptOutSource>,
+    pub telemetry_id: Option<String>,
+}
+
+pub fn opt_out_source() -> Option<TelemetryOptOutSource> {
+    if opt_out_forced_by_env() {
+        return Some(TelemetryOptOutSource::Environment);
+    }
+    opt_out_marker_path()
+        .is_some_and(|path| path.exists())
+        .then_some(TelemetryOptOutSource::MarkerFile)
+}
+
+/// Return the current telemetry state without creating a telemetry identity or
+/// changing any persisted state.
+pub fn status() -> TelemetryStatus {
+    let opt_out_source = opt_out_source();
+    TelemetryStatus {
+        enabled: opt_out_source.is_none(),
+        content_sharing_enabled: content_sharing_enabled(),
+        opt_out_source,
+        telemetry_id: read_existing_id(),
+    }
+}
+
 pub fn is_enabled() -> bool {
-    if std::env::var("JCODE_NO_TELEMETRY").is_ok() || std::env::var("DO_NOT_TRACK").is_ok() {
-        logging::debug("telemetry disabled by environment");
-        return false;
+    match opt_out_source() {
+        Some(TelemetryOptOutSource::Environment) => {
+            logging::debug("telemetry disabled by environment");
+            false
+        }
+        Some(TelemetryOptOutSource::MarkerFile) => {
+            logging::debug("telemetry disabled by no_telemetry marker");
+            false
+        }
+        None => true,
     }
-    if opt_out_marker_path().map(|p| p.exists()).unwrap_or(false) {
-        logging::debug("telemetry disabled by no_telemetry marker");
-        return false;
-    }
-    true
 }
 
 /// Marker file recording that the user opted out of anonymous usage telemetry.

--- a/crates/jcode-telemetry-core/src/state_support.rs
+++ b/crates/jcode-telemetry-core/src/state_support.rs
@@ -231,6 +231,16 @@ pub(super) fn get_or_create_id() -> Option<String> {
     Some(id)
 }
 
+pub(super) fn read_existing_id() -> Option<String> {
+    let path = telemetry_id_path()?;
+    let id = match std::fs::read_to_string(path) {
+        Ok(id) => id,
+        Err(_) => return None,
+    };
+    let id = id.trim().to_string();
+    (!id.is_empty()).then_some(id)
+}
+
 pub(super) fn read_install_conversion_id() -> Option<String> {
     let path = install_conversion_id_path()?;
     let fresh = std::fs::metadata(&path)

--- a/crates/jcode-telemetry-core/src/tests.rs
+++ b/crates/jcode-telemetry-core/src/tests.rs
@@ -1,5 +1,8 @@
 use super::*;
-use std::sync::{Mutex, OnceLock};
+use std::{
+    ffi::OsString,
+    sync::{Mutex, MutexGuard, OnceLock},
+};
 
 // All of these tests mutate process-global state: the env-var opt-out tests
 // flip `JCODE_NO_TELEMETRY` / `DO_NOT_TRACK`, while the session tests drive the
@@ -10,12 +13,51 @@ use std::sync::{Mutex, OnceLock};
 // as `None`; the session test's `expect(...)` panicked while holding the
 // `SESSION_STATE` lock and poisoned it, cascading into `PoisonError` failures
 // in every other session test.
-fn global_test_lock() -> std::sync::MutexGuard<'static, ()> {
+struct TestEnvironment {
+    _home: tempfile::TempDir,
+    previous_home: Option<OsString>,
+    previous_no_telemetry: Option<OsString>,
+    previous_do_not_track: Option<OsString>,
+    _lock: MutexGuard<'static, ()>,
+}
+
+impl Drop for TestEnvironment {
+    fn drop(&mut self) {
+        restore_env_var("JCODE_HOME", self.previous_home.take());
+        restore_env_var("JCODE_NO_TELEMETRY", self.previous_no_telemetry.take());
+        restore_env_var("DO_NOT_TRACK", self.previous_do_not_track.take());
+    }
+}
+
+fn restore_env_var(key: &str, value: Option<OsString>) {
+    if let Some(value) = value {
+        jcode_core::env::set_var(key, value);
+    } else {
+        jcode_core::env::remove_var(key);
+    }
+}
+
+fn global_test_lock() -> TestEnvironment {
     static TEST_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-    TEST_LOCK
+    let lock = TEST_LOCK
         .get_or_init(|| Mutex::new(()))
         .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let home = tempfile::tempdir().expect("create isolated telemetry test home");
+    let previous_home = std::env::var_os("JCODE_HOME");
+    let previous_no_telemetry = std::env::var_os("JCODE_NO_TELEMETRY");
+    let previous_do_not_track = std::env::var_os("DO_NOT_TRACK");
+    jcode_core::env::set_var("JCODE_HOME", home.path());
+    jcode_core::env::remove_var("JCODE_NO_TELEMETRY");
+    jcode_core::env::remove_var("DO_NOT_TRACK");
+
+    TestEnvironment {
+        _home: home,
+        previous_home,
+        previous_no_telemetry,
+        previous_do_not_track,
+        _lock: lock,
+    }
 }
 
 #[test]
@@ -59,11 +101,11 @@ fn telemetry_endpoint_uses_production_custom_domain() {
     assert_eq!(TELEMETRY_ENDPOINT, "https://telemetry.jcode.sh/v1/event");
 }
 
-fn lock_test_env() -> std::sync::MutexGuard<'static, ()> {
+fn lock_test_env() -> TestEnvironment {
     global_test_lock()
 }
 
-fn lock_telemetry_test_state() -> std::sync::MutexGuard<'static, ()> {
+fn lock_telemetry_test_state() -> TestEnvironment {
     global_test_lock()
 }
 

--- a/crates/jcode-telemetry-core/src/tests.rs
+++ b/crates/jcode-telemetry-core/src/tests.rs
@@ -126,6 +126,58 @@ fn test_do_not_track() {
 }
 
 #[test]
+fn telemetry_status_on_fresh_home_is_read_only() {
+    let _guard = lock_test_env();
+
+    let snapshot = status();
+
+    assert!(snapshot.enabled);
+    assert_eq!(snapshot.opt_out_source, None);
+    assert_eq!(snapshot.telemetry_id, None);
+    assert!(!snapshot.content_sharing_enabled);
+    assert!(!telemetry_id_path().expect("telemetry id path").exists());
+}
+
+#[test]
+fn telemetry_status_reads_an_existing_id_without_replacing_it() {
+    let _guard = lock_test_env();
+    let path = telemetry_id_path().expect("telemetry id path");
+    write_private_file(&path, "existing-id\n");
+
+    assert_eq!(status().telemetry_id.as_deref(), Some("existing-id"));
+    assert_eq!(std::fs::read_to_string(path).unwrap(), "existing-id\n");
+}
+
+#[test]
+fn telemetry_status_reports_marker_file_opt_out() {
+    let _guard = lock_test_env();
+    assert!(set_usage_telemetry_enabled(false));
+
+    let snapshot = status();
+
+    assert!(!snapshot.enabled);
+    assert_eq!(
+        snapshot.opt_out_source,
+        Some(TelemetryOptOutSource::MarkerFile)
+    );
+}
+
+#[test]
+fn environment_opt_out_takes_precedence_over_marker_file() {
+    let _guard = lock_test_env();
+    assert!(set_usage_telemetry_enabled(false));
+    jcode_core::env::set_var("DO_NOT_TRACK", "1");
+
+    let snapshot = status();
+
+    assert!(!snapshot.enabled);
+    assert_eq!(
+        snapshot.opt_out_source,
+        Some(TelemetryOptOutSource::Environment)
+    );
+}
+
+#[test]
 fn test_is_ci_detects_ci_env() {
     let _guard = lock_test_env();
     // Clear any inherited CI markers so the baseline is deterministic.

--- a/scripts/code_size_budget.json
+++ b/scripts/code_size_budget.json
@@ -62,7 +62,7 @@
     "crates/jcode-render-core/src/math.rs": 1234,
     "crates/jcode-sdk/src/client.rs": 1379,
     "crates/jcode-setup-hints/src/lib.rs": 2635,
-    "crates/jcode-telemetry-core/src/lib.rs": 2340,
+    "crates/jcode-telemetry-core/src/lib.rs": 2386,
     "crates/jcode-terminal-launch/src/lib.rs": 1692,
     "crates/jcode-tui-markdown/src/markdown_latex_image.rs": 1294,
     "crates/jcode-tui-mermaid/src/lib.rs": 1497,

--- a/scripts/dev_cargo.sh
+++ b/scripts/dev_cargo.sh
@@ -369,6 +369,49 @@ meminfo_kib() {
   awk -v key="$key" '$1 == key ":" { print $2; exit }' /proc/meminfo 2>/dev/null || true
 }
 
+macos_available_memory_kib() {
+  command -v vm_stat >/dev/null 2>&1 || return 1
+
+  local stats page_size free_pages inactive_pages speculative_pages
+  stats=$(LC_ALL=C vm_stat 2>/dev/null) || return 1
+  page_size=$(printf '%s\n' "$stats" \
+    | sed -n '1s/.*page size of \([0-9][0-9]*\) bytes.*/\1/p')
+  free_pages=$(printf '%s\n' "$stats" \
+    | awk '$1 == "Pages" && $2 == "free:" { sub(/\.$/, "", $3); print $3; exit }')
+  inactive_pages=$(printf '%s\n' "$stats" \
+    | awk '$1 == "Pages" && $2 == "inactive:" { sub(/\.$/, "", $3); print $3; exit }')
+  speculative_pages=$(printf '%s\n' "$stats" \
+    | awk '$1 == "Pages" && $2 == "speculative:" { sub(/\.$/, "", $3); print $3; exit }')
+
+  [[ "$page_size" =~ ^[0-9]+$ && "$page_size" -gt 0 ]] || return 1
+  [[ "$free_pages" =~ ^[0-9]+$ ]] || return 1
+  [[ "$inactive_pages" =~ ^[0-9]+$ ]] || return 1
+  [[ "$speculative_pages" =~ ^[0-9]+$ ]] || return 1
+
+  # Inactive and speculative pages are reclaimable without swapping. Purgeable
+  # pages are intentionally not added because they can already be represented in
+  # those categories, and double-counting would make the job limit less safe.
+  printf '%s\n' "$(( (free_pages + inactive_pages + speculative_pages) * page_size / 1024 ))"
+}
+
+available_memory_kib() {
+  local value
+  case "$(uname -s)" in
+    Linux)
+      [[ -r /proc/meminfo ]] || return 1
+      value=$(meminfo_kib MemAvailable)
+      ;;
+    Darwin)
+      value=$(macos_available_memory_kib) || return 1
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+  [[ "$value" =~ ^[0-9]+$ && "$value" -gt 0 ]] || return 1
+  printf '%s\n' "$value"
+}
+
 selfdev_low_memory_default_needed() {
   [[ "$(uname -s)" == "Linux" ]] || return 1
   [[ -r /proc/meminfo ]] || return 1
@@ -410,7 +453,8 @@ cpu_count() {
 # off before earlyoom SIGTERMs it. Clamp into [1, cpus]. On an idle 15 GiB
 # machine this still uses ~7 of 8 cores; under memory pressure a fresh build
 # backs off further. An explicit CARGO_BUILD_JOBS / JCODE_BUILD_JOBS always
-# wins, and non-Linux hosts fall back to the cargo/.cargo default.
+# wins. Linux reads MemAvailable; macOS conservatively sums reclaimable vm_stat
+# pages. Unsupported hosts and failed probes fall back to Cargo's configuration.
 select_build_jobs() {
   # Respect an explicit override from either env var.
   local override="${JCODE_BUILD_JOBS:-${CARGO_BUILD_JOBS:-}}"
@@ -425,17 +469,14 @@ select_build_jobs() {
     unset CARGO_BUILD_JOBS
   fi
 
-  # Adaptive sizing only on Linux where /proc/meminfo is available; elsewhere we
-  # leave cargo to honor the .cargo/config.toml default.
-  if [[ "$(uname -s)" != "Linux" || ! -r /proc/meminfo ]]; then
+  local mem_available_kib
+  if ! mem_available_kib=$(available_memory_kib); then
     build_jobs_status="cargo-default"
     return
   fi
 
-  local cpus mem_available_kib mib_per_job_default mib_per_job
+  local cpus mib_per_job_default mib_per_job
   cpus=$(cpu_count)
-  mem_available_kib=$(meminfo_kib MemAvailable)
-  [[ -n "$mem_available_kib" && "$mem_available_kib" =~ ^[0-9]+$ ]] || mem_available_kib=0
 
   # Per-job memory budget (MiB). Sized with a cushion above the largest measured
   # rustc unit (jcode-base, ~1.6 GiB RSS sampled) so an idle machine uses nearly

--- a/scripts/test_dev_cargo_jobs.sh
+++ b/scripts/test_dev_cargo_jobs.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+mkdir -p "$tmp/bin" "$tmp/home" "$tmp/work"
+
+cat > "$tmp/bin/uname" <<'EOF'
+#!/usr/bin/env bash
+case "${1:-}" in
+  -s) printf '%s\n' "${TEST_UNAME_S:-Darwin}" ;;
+  -m) printf '%s\n' "${TEST_UNAME_M:-arm64}" ;;
+  *) printf '%s\n' "${TEST_UNAME_S:-Darwin}" ;;
+esac
+EOF
+
+cat > "$tmp/bin/nproc" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "${TEST_CPU_COUNT:-8}"
+EOF
+
+cat > "$tmp/bin/vm_stat" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${TEST_VM_STAT_MODE:-valid}" == "failed" ]]; then
+  exit 1
+fi
+if [[ "${TEST_VM_STAT_MODE:-valid}" == "malformed" ]]; then
+  cat <<'STATS'
+Mach Virtual Memory Statistics: (page size of 16384 bytes)
+Pages free:                               unknown.
+STATS
+  exit 0
+fi
+cat <<STATS
+Mach Virtual Memory Statistics: (page size of 16384 bytes)
+Pages free:                               32768.
+Pages active:                            99999.
+Pages inactive:                         393216.
+Pages speculative:                       32768.
+Pages throttled:                             0.
+Pages wired down:                        99999.
+Pages purgeable:                         65536.
+STATS
+EOF
+
+chmod +x "$tmp/bin/uname" "$tmp/bin/nproc" "$tmp/bin/vm_stat"
+
+run_setup() {
+  (
+    unset CARGO_BUILD_JOBS JCODE_BUILD_JOBS
+    export PATH="$tmp/bin:$PATH"
+    export HOME="$tmp/home"
+    export TMPDIR="$tmp/work"
+    export JCODE_BUILD_GIT_HASH=test
+    export JCODE_PARALLEL_FRONTEND=0
+    export SCCACHE_DISABLE=1
+    for assignment in "$@"; do
+      export "$assignment"
+    done
+    "$repo_root/scripts/dev_cargo.sh" --print-setup
+  )
+}
+
+assert_line() {
+  local output="$1" expected="$2"
+  if ! grep -Fqx "$expected" <<<"$output"; then
+    printf 'expected setup output to contain %q\noutput:\n%s\n' "$expected" "$output" >&2
+    exit 1
+  fi
+}
+
+# 32,768 free + 393,216 inactive + 32,768 speculative 16 KiB pages =
+# 7,168 MiB available. At 1,792 MiB/job, memory limits an 8-CPU Mac to 4 jobs.
+output=$(run_setup)
+assert_line "$output" 'os=Darwin'
+assert_line "$output" 'build_jobs_status=adaptive:4 (cpus=8, mem_avail=7168MiB, budget=1792MiB/job)'
+assert_line "$output" 'cargo_build_jobs=4'
+
+# Both documented overrides bypass memory probing, with JCODE_BUILD_JOBS taking
+# precedence when both are present.
+output=$(run_setup TEST_VM_STAT_MODE=failed CARGO_BUILD_JOBS=7)
+assert_line "$output" 'build_jobs_status=override:7'
+assert_line "$output" 'cargo_build_jobs=7'
+output=$(run_setup TEST_VM_STAT_MODE=failed CARGO_BUILD_JOBS=7 JCODE_BUILD_JOBS=3)
+assert_line "$output" 'build_jobs_status=override:3'
+assert_line "$output" 'cargo_build_jobs=3'
+
+# If vm_stat cannot be read, leave CARGO_BUILD_JOBS unset so Cargo can apply its
+# own config/default rather than guessing from invalid memory data.
+output=$(run_setup TEST_VM_STAT_MODE=failed)
+assert_line "$output" 'build_jobs_status=cargo-default'
+assert_line "$output" 'cargo_build_jobs=<unset>'
+output=$(run_setup TEST_VM_STAT_MODE=malformed)
+assert_line "$output" 'build_jobs_status=cargo-default'
+assert_line "$output" 'cargo_build_jobs=<unset>'
+output=$(run_setup TEST_UNAME_S=FreeBSD)
+assert_line "$output" 'build_jobs_status=cargo-default'
+assert_line "$output" 'cargo_build_jobs=<unset>'
+
+echo 'dev_cargo job sizing tests passed'

--- a/src/cli/acp.rs
+++ b/src/cli/acp.rs
@@ -103,6 +103,73 @@ struct SessionUiState {
     reasoning_effort: Option<String>,
 }
 
+#[derive(Debug, Default)]
+struct TurnUsage {
+    reported: bool,
+    input_tokens: u64,
+    output_tokens: u64,
+    cached_read_tokens: Option<u64>,
+    cached_write_tokens: Option<u64>,
+}
+
+impl TurnUsage {
+    fn add(
+        &mut self,
+        input_tokens: u64,
+        output_tokens: u64,
+        cached_read_tokens: Option<u64>,
+        cached_write_tokens: Option<u64>,
+    ) {
+        self.reported = true;
+        self.input_tokens = self.input_tokens.saturating_add(input_tokens);
+        self.output_tokens = self.output_tokens.saturating_add(output_tokens);
+        add_optional_tokens(&mut self.cached_read_tokens, cached_read_tokens);
+        add_optional_tokens(&mut self.cached_write_tokens, cached_write_tokens);
+    }
+
+    fn to_acp(&self) -> Option<Value> {
+        if !self.reported {
+            return None;
+        }
+
+        let total_tokens = self
+            .input_tokens
+            .saturating_add(self.output_tokens)
+            .saturating_add(self.cached_read_tokens.unwrap_or(0))
+            .saturating_add(self.cached_write_tokens.unwrap_or(0));
+        let mut usage = json!({
+            "totalTokens": total_tokens,
+            "inputTokens": self.input_tokens,
+            "outputTokens": self.output_tokens,
+        });
+        let object = usage.as_object_mut().expect("usage is an object");
+        if let Some(tokens) = self.cached_read_tokens {
+            object.insert("cachedReadTokens".to_string(), json!(tokens));
+        }
+        if let Some(tokens) = self.cached_write_tokens {
+            object.insert("cachedWriteTokens".to_string(), json!(tokens));
+        }
+        Some(usage)
+    }
+}
+
+fn add_optional_tokens(total: &mut Option<u64>, tokens: Option<u64>) {
+    if let Some(tokens) = tokens {
+        *total = Some(total.unwrap_or(0).saturating_add(tokens));
+    }
+}
+
+fn prompt_response(stop_reason: &str, usage: &TurnUsage) -> Value {
+    let mut response = json!({ "stopReason": stop_reason });
+    if let Some(usage) = usage.to_acp() {
+        response
+            .as_object_mut()
+            .expect("prompt response is an object")
+            .insert("usage".to_string(), usage);
+    }
+    response
+}
+
 impl SessionUiState {
     fn from_history_fields(
         provider_name: Option<String>,
@@ -859,7 +926,7 @@ impl AcpRuntime {
                 }),
             )
             .await?;
-            self.write_result(rpc_id, json!({ "stopReason": "end_turn" }))
+            self.write_result(rpc_id, prompt_response("end_turn", &TurnUsage::default()))
                 .await?;
             return Ok(());
         }
@@ -886,6 +953,7 @@ impl AcpRuntime {
 
         let mut mapper = EventMapper::new(session.session_id.clone(), self.profile);
         let mut stop_reason = "end_turn".to_string();
+        let mut turn_usage = TurnUsage::default();
         loop {
             let event = match session.read_event().await {
                 Ok(event) => event,
@@ -912,10 +980,11 @@ impl AcpRuntime {
                 }
                 ServerEvent::TokenUsage {
                     input,
-                    output: _,
+                    output,
                     cache_read_input,
                     cache_creation_input,
                 } => {
+                    turn_usage.add(input, output, cache_read_input, cache_creation_input);
                     let (provider_name, context_limit) = {
                         let state = session.ui_state.lock().await;
                         (
@@ -990,7 +1059,7 @@ impl AcpRuntime {
         }
 
         cleanup_prompt_state(&session).await;
-        self.write_result(rpc_id, json!({ "stopReason": stop_reason }))
+        self.write_result(rpc_id, prompt_response(&stop_reason, &turn_usage))
             .await?;
         Ok(())
     }
@@ -1840,6 +1909,49 @@ mod tests {
         assert!(text.contains("Embedded resource: file:///tmp/a.rs"));
         assert!(text.contains("Resource link: b.rs"));
         assert_eq!(images, vec![("image/png".to_string(), "abc".to_string())]);
+    }
+
+    #[test]
+    fn prompt_response_reports_usage_accumulated_across_the_turn() {
+        let mut usage = TurnUsage::default();
+        usage.add(10, 2, Some(4), Some(5));
+        usage.add(20, 3, Some(6), Some(7));
+
+        assert_eq!(
+            prompt_response("end_turn", &usage),
+            json!({
+                "stopReason": "end_turn",
+                "usage": {
+                    "totalTokens": 57,
+                    "inputTokens": 30,
+                    "outputTokens": 5,
+                    "cachedReadTokens": 10,
+                    "cachedWriteTokens": 12,
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn prompt_response_omits_unreported_usage_and_cache_fields() {
+        assert_eq!(
+            prompt_response("end_turn", &TurnUsage::default()),
+            json!({ "stopReason": "end_turn" })
+        );
+
+        let mut usage = TurnUsage::default();
+        usage.add(10, 2, None, None);
+        assert_eq!(
+            prompt_response("cancelled", &usage),
+            json!({
+                "stopReason": "cancelled",
+                "usage": {
+                    "totalTokens": 12,
+                    "inputTokens": 10,
+                    "outputTokens": 2,
+                }
+            })
+        );
     }
 
     #[test]

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -254,6 +254,10 @@ pub(crate) enum Command {
         json: bool,
     },
 
+    /// Inspect or change anonymous telemetry settings
+    #[command(subcommand)]
+    Telemetry(TelemetryCommand),
+
     /// Self-development mode: run as a canary session on the shared server
     #[command(alias = "selfdev")]
     SelfDev {
@@ -548,6 +552,20 @@ pub(crate) enum Command {
         #[arg(long = "api-socket")]
         api_socket: Option<String>,
     },
+}
+
+#[derive(Subcommand, Debug)]
+pub(crate) enum TelemetryCommand {
+    /// Show the current telemetry state without creating an anonymous ID
+    Status {
+        /// Emit JSON instead of human-readable text
+        #[arg(long)]
+        json: bool,
+    },
+    /// Enable anonymous usage telemetry
+    Enable,
+    /// Disable all telemetry persistently
+    Disable,
 }
 
 #[derive(Subcommand, Debug)]

--- a/src/cli/args/tests.rs
+++ b/src/cli/args/tests.rs
@@ -23,6 +23,30 @@ fn server_start_and_internal_keepalive_parse() {
 }
 
 #[test]
+fn telemetry_subcommands_parse() {
+    let status = Args::try_parse_from(["jcode", "telemetry", "status", "--json"])
+        .expect("telemetry status should parse");
+    assert!(matches!(
+        status.command,
+        Some(Command::Telemetry(TelemetryCommand::Status { json: true }))
+    ));
+
+    let enable = Args::try_parse_from(["jcode", "telemetry", "enable"])
+        .expect("telemetry enable should parse");
+    assert!(matches!(
+        enable.command,
+        Some(Command::Telemetry(TelemetryCommand::Enable))
+    ));
+
+    let disable = Args::try_parse_from(["jcode", "telemetry", "disable"])
+        .expect("telemetry disable should parse");
+    assert!(matches!(
+        disable.command,
+        Some(Command::Telemetry(TelemetryCommand::Disable))
+    ));
+}
+
+#[test]
 fn test_provider_choice_aliases_parse() {
     let args = Args::try_parse_from(["jcode", "--provider", "z.ai", "run", "smoke"]).unwrap();
     assert_eq!(args.provider, ProviderChoice::Zai);

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -7,8 +7,7 @@ use std::time::Instant;
 
 use super::args::{
     AmbientCommand, Args, AuthCommand, CloudCommand, CloudSessionsCommand, Command, MemoryCommand,
-    ModelCommand, ProviderCommand, RestartCommand, ServerCommand, SessionCommand,
-    TranscriptModeArg,
+    ModelCommand, ProviderCommand, RestartCommand, ServerCommand, SessionCommand, TranscriptModeArg,
 };
 use crate::{
     agent, auth, build, provider, provider_catalog, server, session, setup_hints, startup_profile,
@@ -300,6 +299,7 @@ pub(crate) async fn run_main(mut args: Args) -> Result<()> {
         Some(Command::Usage { json }) => {
             commands::run_usage_command(json).await?;
         }
+        Some(Command::Telemetry(action)) => super::telemetry::run(action)?,
         Some(Command::SelfDev { build }) => {
             selfdev::run_self_dev(build, args.resume).await?;
         }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -15,4 +15,5 @@ pub mod provider_init;
 pub mod selfdev;
 pub mod startup;
 pub mod terminal;
+pub mod telemetry;
 pub mod tui_launch;

--- a/src/cli/proctitle.rs
+++ b/src/cli/proctitle.rs
@@ -23,6 +23,7 @@ pub(crate) fn initial_title(args: &Args) -> String {
         Some(Command::Update) => "jcode update".to_string(),
         Some(Command::Version { .. }) => "jcode version".to_string(),
         Some(Command::Usage { .. }) => "jcode usage".to_string(),
+        Some(Command::Telemetry(_)) => "jcode telemetry".to_string(),
         Some(Command::SelfDev { .. }) => "jcode:selfdev".to_string(),
         Some(Command::Debug { .. }) => "jcode debug".to_string(),
         Some(Command::Auth(_)) => "jcode auth".to_string(),

--- a/src/cli/startup.rs
+++ b/src/cli/startup.rs
@@ -113,8 +113,14 @@ pub async fn run() -> Result<()> {
     perf::init_background();
     startup_profile::mark("perf_init");
 
-    telemetry::record_install_if_first_run();
-    telemetry::record_upgrade_if_needed();
+    // Telemetry settings commands must run before they can cause telemetry. In
+    // particular, a first-ever `jcode telemetry disable` must not emit the
+    // install event that the command is trying to opt out of. Keep the normal
+    // startup ordering unchanged for every other invocation.
+    if !is_telemetry_subcommand_invocation(std::env::args_os()) {
+        telemetry::record_install_if_first_run();
+        telemetry::record_upgrade_if_needed();
+    }
     startup_profile::mark("telemetry_check");
 
     let args = parse_and_prepare_args()?;
@@ -126,6 +132,48 @@ pub async fn run() -> Result<()> {
     }
 
     Ok(())
+}
+
+fn is_telemetry_subcommand_invocation(
+    args: impl IntoIterator<Item = impl AsRef<std::ffi::OsStr>>,
+) -> bool {
+    let mut args = args.into_iter().skip(1);
+    while let Some(arg) = args.next() {
+        let arg = arg.as_ref();
+        if arg == std::ffi::OsStr::new("telemetry") {
+            return true;
+        }
+        let text = arg.to_string_lossy();
+        if !text.starts_with('-') {
+            return false;
+        }
+        if text == "--" {
+            return args
+                .next()
+                .is_some_and(|arg| arg.as_ref() == std::ffi::OsStr::new("telemetry"));
+        }
+        let option = text.split_once('=').map_or(text.as_ref(), |(name, _)| name);
+        let takes_separate_value = !text.contains('=')
+            && matches!(
+                option,
+                "-p" | "--provider"
+                    | "-C"
+                    | "--cwd"
+                    | "--remote-working-dir"
+                    | "--spawn-hotkey"
+                    | "--socket"
+                    | "-m"
+                    | "--model"
+                    | "--provider-profile"
+                    | "--tool-profile"
+                    | "--tools"
+                    | "--disabled-tools"
+            );
+        if takes_separate_value && args.next().is_none() {
+            return false;
+        }
+    }
+    false
 }
 
 /// Register provider runtimes that live downstream of `jcode-base` with the
@@ -417,6 +465,37 @@ mod tests {
 
     fn parse_args(argv: &[&str]) -> Args {
         Args::parse_from(argv)
+    }
+
+    #[test]
+    fn telemetry_subcommand_skips_startup_telemetry() {
+        assert!(is_telemetry_subcommand_invocation([
+            "jcode",
+            "telemetry",
+            "disable"
+        ]));
+        assert!(is_telemetry_subcommand_invocation([
+            "jcode",
+            "--no-update",
+            "telemetry",
+            "disable"
+        ]));
+        assert!(is_telemetry_subcommand_invocation([
+            "jcode",
+            "--provider",
+            "openai",
+            "telemetry",
+            "disable"
+        ]));
+    }
+
+    #[test]
+    fn telemetry_prompt_does_not_skip_normal_startup_telemetry() {
+        assert!(!is_telemetry_subcommand_invocation([
+            "jcode",
+            "run",
+            "telemetry"
+        ]));
     }
 
     #[test]

--- a/src/cli/telemetry.rs
+++ b/src/cli/telemetry.rs
@@ -1,0 +1,78 @@
+use anyhow::{Result, bail};
+
+use super::args::TelemetryCommand;
+
+pub(crate) fn run(action: TelemetryCommand) -> Result<()> {
+    match action {
+        TelemetryCommand::Status { json } => run_status(json),
+        TelemetryCommand::Enable => run_enable(),
+        TelemetryCommand::Disable => run_disable(),
+    }
+}
+
+fn run_status(json: bool) -> Result<()> {
+    let status = crate::telemetry::status();
+    let source = status.opt_out_source.map(|source| source.as_str());
+
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&serde_json::json!({
+                "enabled": status.enabled,
+                "content_sharing_enabled": status.content_sharing_enabled,
+                "opt_out_source": source,
+                "telemetry_id": status.telemetry_id,
+            }))?
+        );
+        return Ok(());
+    }
+
+    println!(
+        "Anonymous usage telemetry: {}",
+        if status.enabled {
+            "enabled"
+        } else {
+            "disabled"
+        }
+    );
+    println!(
+        "Content sharing: {}",
+        if status.content_sharing_enabled {
+            "enabled"
+        } else {
+            "disabled"
+        }
+    );
+    if let Some(source) = source {
+        println!("Opt-out source: {source}");
+    }
+    println!(
+        "Anonymous telemetry ID: {}",
+        status.telemetry_id.as_deref().unwrap_or("not assigned")
+    );
+    Ok(())
+}
+
+fn run_enable() -> Result<()> {
+    if !crate::telemetry::set_usage_telemetry_enabled(true) {
+        bail!("failed to persist telemetry setting");
+    }
+
+    if crate::telemetry::opt_out_forced_by_env() {
+        println!("Telemetry remains disabled because JCODE_NO_TELEMETRY or DO_NOT_TRACK is set.");
+    } else {
+        println!("Telemetry enabled.");
+    }
+    Ok(())
+}
+
+fn run_disable() -> Result<()> {
+    if !crate::telemetry::set_usage_telemetry_enabled(false) {
+        bail!("failed to persist telemetry setting");
+    }
+    if !crate::telemetry::set_content_sharing_enabled(false) {
+        bail!("telemetry was disabled, but the content-sharing setting could not be cleared");
+    }
+    println!("Telemetry disabled.");
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- report ACP per-turn token usage (#906)
- give background commands valid null stdin (#903)
- isolate telemetry tests from user configuration (#892)
- make fresh-machine telemetry opt-out effective before install telemetry (#893)
- size macOS development builds from available memory (#891)

## Verification

- `cargo test --profile selfdev -p jcode-app-core background_command_stdin_is_null`
- `cargo test --profile selfdev -p jcode-telemetry-core` (39 passed)
- `cargo test --profile selfdev -p jcode telemetry_`
- `scripts/dev_cargo.sh build --profile selfdev -p jcode --bin jcode`
- fresh scratch `JCODE_HOME`: `telemetry status`, `disable`, and `status` confirmed marker-file opt-out with no telemetry ID

---
*— Jcode agent (automated triage), on behalf of @1jehuang*