### PR TITLE
Fix seven reproducible issues from automated triage

### DIFF
--- a/crates/jcode-base/src/prompt.rs
+++ b/crates/jcode-base/src/prompt.rs
@@ -231,6 +231,41 @@ pub struct SkillInfo {
     pub description: String,
 }
 
+const SKILL_DESC_MAX_CHARS: usize = 120;
+
+fn clip_skill_description(description: &str) -> String {
+    let one_line = description.split_whitespace().collect::<Vec<_>>().join(" ");
+    if one_line.chars().count() <= SKILL_DESC_MAX_CHARS {
+        return one_line;
+    }
+
+    let mut clipped: String = one_line
+        .chars()
+        .take(SKILL_DESC_MAX_CHARS.saturating_sub(1))
+        .collect();
+    clipped.push('…');
+    clipped
+}
+
+fn build_available_skills_section(available_skills: &[SkillInfo]) -> Option<String> {
+    if available_skills.is_empty() {
+        return None;
+    }
+
+    let mut section = "# Available Skills\n\nYou have access to the following skills that the user can invoke with `/skillname`:\n".to_string();
+    for skill in available_skills {
+        section.push_str(&format!(
+            "\n- `/{} ` - {}",
+            skill.name,
+            clip_skill_description(&skill.description)
+        ));
+    }
+    section.push_str(
+        "\n\nWhen a user asks about available skills or capabilities, mention these skills.",
+    );
+    Some(section)
+}
+
 /// Information about what's loaded in the context window
 #[derive(Debug, Clone, Default)]
 pub struct ContextInfo {
@@ -453,14 +488,7 @@ pub fn build_system_prompt_full_with_capabilities(
     }
 
     // Add available skills list
-    if !available_skills.is_empty() {
-        let mut skills_section = "# Available Skills\n\nYou have access to the following skills that the user can invoke with `/skillname`:\n".to_string();
-        for skill in available_skills {
-            skills_section.push_str(&format!("\n- `/{} ` - {}", skill.name, skill.description));
-        }
-        skills_section.push_str(
-            "\n\nWhen a user asks about available skills or capabilities, mention these skills.",
-        );
+    if let Some(skills_section) = build_available_skills_section(available_skills) {
         info.skills_chars = skills_section.len();
         parts.push(skills_section);
     }
@@ -546,14 +574,7 @@ pub fn build_system_prompt_split_with_capabilities(
     }
 
     // Add available skills list (fairly static)
-    if !available_skills.is_empty() {
-        let mut skills_section = "# Available Skills\n\nYou have access to the following skills that the user can invoke with `/skillname`:\n".to_string();
-        for skill in available_skills {
-            skills_section.push_str(&format!("\n- `/{} ` - {}", skill.name, skill.description));
-        }
-        skills_section.push_str(
-            "\n\nWhen a user asks about available skills or capabilities, mention these skills.",
-        );
+    if let Some(skills_section) = build_available_skills_section(available_skills) {
         info.skills_chars = skills_section.len();
         static_parts.push(skills_section);
     }
@@ -840,8 +861,10 @@ fn gpu_summary() -> Option<String> {
     }
 }
 
-/// Load AGENTS.md files from a specific working directory
-pub fn load_agents_md_files_from_dir(working_dir: Option<&Path>) -> (Option<String>, ContextInfo) {
+fn load_agents_md_files_from_dirs(
+    project_dir: &Path,
+    global_agents_md: Option<&Path>,
+) -> (Option<String>, ContextInfo) {
     let mut contents = vec![];
     let mut info = ContextInfo::default();
 
@@ -858,21 +881,31 @@ pub fn load_agents_md_files_from_dir(working_dir: Option<&Path>) -> (Option<Stri
         }
     };
 
-    // Project-level files (from specified working directory or current directory)
-    let project_dir = working_dir.unwrap_or(Path::new("."));
-    if let Some((content, size)) = load_file(
-        &project_dir.join("AGENTS.md"),
-        "Project Instructions (AGENTS.md)",
-    ) {
+    let project_agents_md = project_dir.join("AGENTS.md");
+    if let Some((content, size)) = load_file(&project_agents_md, "Project Instructions (AGENTS.md)")
+    {
         info.has_project_agents_md = true;
         info.project_agents_md_chars = size;
         contents.push(content);
     }
 
-    // Home directory files
-    if let Ok(global_agents_md) = crate::storage::user_home_path("AGENTS.md")
+    // Canonical file identity handles cwd=$HOME as well as symlinked aliases.
+    // If either file is absent or cannot be resolved, loading below remains the
+    // source of truth and simply skips unreadable files.
+    let global_duplicates_project = global_agents_md.is_some_and(|global_agents_md| {
+        match (
+            std::fs::canonicalize(&project_agents_md),
+            std::fs::canonicalize(global_agents_md),
+        ) {
+            (Ok(project), Ok(global)) => project == global,
+            _ => false,
+        }
+    });
+
+    if !global_duplicates_project
+        && let Some(global_agents_md) = global_agents_md
         && let Some((content, size)) =
-            load_file(&global_agents_md, "Global Instructions (~/AGENTS.md)")
+            load_file(global_agents_md, "Global Instructions (~/AGENTS.md)")
     {
         info.has_global_agents_md = true;
         info.global_agents_md_chars = size;
@@ -884,6 +917,13 @@ pub fn load_agents_md_files_from_dir(working_dir: Option<&Path>) -> (Option<Stri
     } else {
         (Some(contents.join("\n\n")), info)
     }
+}
+
+/// Load AGENTS.md files from a specific working directory.
+pub fn load_agents_md_files_from_dir(working_dir: Option<&Path>) -> (Option<String>, ContextInfo) {
+    let project_dir = working_dir.unwrap_or(Path::new("."));
+    let global_agents_md = crate::storage::user_home_path("AGENTS.md").ok();
+    load_agents_md_files_from_dirs(project_dir, global_agents_md.as_deref())
 }
 
 /// Load optional prompt overlay markdown from ~/.jcode/ and ./.jcode/

--- a/crates/jcode-base/src/prompt_tests.rs
+++ b/crates/jcode-base/src/prompt_tests.rs
@@ -64,6 +64,61 @@ fn test_skill_prompt_integration() {
 }
 
 #[test]
+fn skill_description_collapses_whitespace_without_clipping_short_text() {
+    assert_eq!(
+        clip_skill_description("  Build\n\tand   test the project.  "),
+        "Build and test the project."
+    );
+}
+
+#[test]
+fn skill_description_clips_to_the_character_limit_with_ellipsis() {
+    let clipped = clip_skill_description(&"a".repeat(SKILL_DESC_MAX_CHARS + 20));
+
+    assert_eq!(clipped.chars().count(), SKILL_DESC_MAX_CHARS);
+    assert!(clipped.ends_with('…'));
+}
+
+#[test]
+fn skill_description_clipping_is_utf8_safe() {
+    let clipped = clip_skill_description(&"ж".repeat(SKILL_DESC_MAX_CHARS + 20));
+
+    assert_eq!(clipped.chars().count(), SKILL_DESC_MAX_CHARS);
+    assert_eq!(
+        clipped
+            .chars()
+            .filter(|character| *character == 'ж')
+            .count(),
+        SKILL_DESC_MAX_CHARS - 1
+    );
+    assert!(clipped.ends_with('…'));
+}
+
+#[test]
+fn full_and_split_prompt_builders_use_the_same_one_line_skill_descriptions() {
+    let skills = vec![SkillInfo {
+        name: "example".to_string(),
+        description: format!("First line\n\t{}", "д".repeat(SKILL_DESC_MAX_CHARS + 20)),
+    }];
+    let expected = build_available_skills_section(&skills).expect("skills section");
+
+    let (full, full_info) = build_system_prompt_full(None, &skills, false, None, None);
+    let (split, split_info) = build_system_prompt_split(None, &skills, false, None, None);
+
+    assert!(full.contains(&expected));
+    assert!(split.static_part.contains(&expected));
+    assert_eq!(full_info.skills_chars, expected.len());
+    assert_eq!(split_info.skills_chars, expected.len());
+    assert!(expected.contains("First line "));
+    assert!(!expected.contains("First line\n"));
+    let entry = expected
+        .lines()
+        .find(|line| line.starts_with("- `/example `"))
+        .expect("example skill entry");
+    assert!(entry.ends_with('…'));
+}
+
+#[test]
 fn test_load_agents_md_files_uses_sandboxed_global_files() {
     let _guard = crate::storage::lock_test_env();
     let prev_home = std::env::var_os("JCODE_HOME");
@@ -86,11 +141,96 @@ fn test_load_agents_md_files_uses_sandboxed_global_files() {
     assert!(!content.contains("~/.AGENTS.md"));
     assert!(content.contains("sandboxed global agents instructions"));
 
+    let sandboxed_home = temp.path().join("external");
+    let (content, info) = load_agents_md_files_from_dir(Some(&sandboxed_home));
+    let content = content.expect("deduplicated home instructions");
+    assert!(info.has_project_agents_md);
+    assert!(!info.has_global_agents_md);
+    assert!(content.contains("# Project Instructions (AGENTS.md)"));
+    assert!(!content.contains("# Global Instructions (~/AGENTS.md)"));
+    assert_eq!(
+        content
+            .matches("sandboxed global agents instructions")
+            .count(),
+        1
+    );
+
     if let Some(prev_home) = prev_home {
         crate::env::set_var("JCODE_HOME", prev_home);
     } else {
         crate::env::remove_var("JCODE_HOME");
     }
+}
+
+#[test]
+fn agents_md_same_canonical_file_is_loaded_only_as_project_instructions() {
+    let project_dir = tempfile::TempDir::new().unwrap();
+    let agents_md = project_dir.path().join("AGENTS.md");
+    std::fs::write(&agents_md, "shared instructions").unwrap();
+
+    let (content, info) = load_agents_md_files_from_dirs(project_dir.path(), Some(&agents_md));
+    let content = content.expect("project instructions");
+
+    assert!(info.has_project_agents_md);
+    assert!(!info.has_global_agents_md);
+    assert!(content.contains("# Project Instructions (AGENTS.md)"));
+    assert!(!content.contains("# Global Instructions (~/AGENTS.md)"));
+    assert_eq!(content.matches("shared instructions").count(), 1);
+}
+
+#[test]
+fn agents_md_distinct_project_and_global_files_are_both_loaded() {
+    let project_dir = tempfile::TempDir::new().unwrap();
+    let global_dir = tempfile::TempDir::new().unwrap();
+    let global_agents_md = global_dir.path().join("AGENTS.md");
+    std::fs::write(project_dir.path().join("AGENTS.md"), "project instructions").unwrap();
+    std::fs::write(&global_agents_md, "global instructions").unwrap();
+
+    let (content, info) =
+        load_agents_md_files_from_dirs(project_dir.path(), Some(&global_agents_md));
+    let content = content.expect("project and global instructions");
+
+    assert!(info.has_project_agents_md);
+    assert!(info.has_global_agents_md);
+    assert!(content.contains("project instructions"));
+    assert!(content.contains("global instructions"));
+}
+
+#[test]
+fn agents_md_missing_global_file_keeps_project_instructions() {
+    let project_dir = tempfile::TempDir::new().unwrap();
+    let global_dir = tempfile::TempDir::new().unwrap();
+    let missing_global_agents_md = global_dir.path().join("missing-AGENTS.md");
+    std::fs::write(project_dir.path().join("AGENTS.md"), "project only").unwrap();
+
+    let (content, info) =
+        load_agents_md_files_from_dirs(project_dir.path(), Some(&missing_global_agents_md));
+    let content = content.expect("project instructions");
+
+    assert!(info.has_project_agents_md);
+    assert!(!info.has_global_agents_md);
+    assert!(content.contains("project only"));
+    assert!(!content.contains("# Global Instructions (~/AGENTS.md)"));
+}
+
+#[cfg(unix)]
+#[test]
+fn agents_md_symlink_alias_is_deduplicated_by_canonical_file_path() {
+    use std::os::unix::fs::symlink;
+
+    let project_dir = tempfile::TempDir::new().unwrap();
+    let global_dir = tempfile::TempDir::new().unwrap();
+    let global_agents_md = global_dir.path().join("AGENTS.md");
+    std::fs::write(&global_agents_md, "symlinked instructions").unwrap();
+    symlink(&global_agents_md, project_dir.path().join("AGENTS.md")).unwrap();
+
+    let (content, info) =
+        load_agents_md_files_from_dirs(project_dir.path(), Some(&global_agents_md));
+    let content = content.expect("project instructions through symlink");
+
+    assert!(info.has_project_agents_md);
+    assert!(!info.has_global_agents_md);
+    assert_eq!(content.matches("symlinked instructions").count(), 1);
 }
 
 #[test]

--- a/crates/jcode-build-support/src/lib.rs
+++ b/crates/jcode-build-support/src/lib.rs
@@ -724,7 +724,22 @@ pub fn publish_local_current_build(repo_dir: &std::path::Path) -> Result<PathBuf
 
 /// Promote an already installed immutable version onto the shared server channel.
 pub fn promote_version_to_shared_server(version: &str) -> Result<Option<String>> {
+    if version.is_empty()
+        || version.trim() != version
+        || version == "."
+        || version == ".."
+        || version.contains(['/', '\\', ':'])
+    {
+        anyhow::bail!("Invalid installed version label: {version:?}");
+    }
     let previous = read_shared_server_version()?;
+    if previous.as_deref() == Some(version) {
+        let target = version_binary_path(version)?;
+        if !target.exists() {
+            anyhow::bail!("Version binary not found at {:?}", target);
+        }
+        return Ok(previous);
+    }
     update_shared_server_symlink(version)?;
     Ok(previous)
 }

--- a/crates/jcode-build-support/src/paths.rs
+++ b/crates/jcode-build-support/src/paths.rs
@@ -171,6 +171,14 @@ pub fn selfdev_build_command_for_target(
     repo_dir: &Path,
     target: SelfDevBuildTarget,
 ) -> SelfDevBuildCommand {
+    selfdev_build_command_for_target_on_platform(repo_dir, target, cfg!(windows))
+}
+
+fn selfdev_build_command_for_target_on_platform(
+    repo_dir: &Path,
+    target: SelfDevBuildTarget,
+    is_windows: bool,
+) -> SelfDevBuildCommand {
     let target = match target {
         SelfDevBuildTarget::Auto => infer_selfdev_build_target(repo_dir),
         explicit => explicit,
@@ -194,7 +202,10 @@ pub fn selfdev_build_command_for_target(
         }
     };
     let wrapper = repo_dir.join("scripts").join("dev_cargo.sh");
-    if wrapper.is_file() {
+    // `bash` on Windows may resolve to WSL, which cannot use the native Rust
+    // toolchain or produce the Windows executable we publish. Avoid both that
+    // ambiguity and native-vs-POSIX path translation by invoking Cargo directly.
+    if wrapper.is_file() && !is_windows {
         let script = wrapper.to_string_lossy();
         let command = specs
             .iter()
@@ -222,11 +233,39 @@ pub fn selfdev_build_command_for_target(
     }
 
     let command = display_build_command("cargo", &specs);
+    if is_windows {
+        return SelfDevBuildCommand {
+            program: "cargo".to_string(),
+            args: cargo_build_args(&specs),
+            display: command,
+        };
+    }
+
     SelfDevBuildCommand {
         program: "bash".to_string(),
         args: vec!["-lc".to_string(), command.clone()],
         display: command,
     }
+}
+
+fn cargo_build_args(specs: &[(&str, &str)]) -> Vec<String> {
+    let mut args = vec![
+        "build".to_string(),
+        "--profile".to_string(),
+        SELFDEV_CARGO_PROFILE.to_string(),
+    ];
+    for (package, binary) in specs {
+        args.extend([
+            "-p".to_string(),
+            (*package).to_string(),
+            "--bin".to_string(),
+            (*binary).to_string(),
+        ]);
+        if *package == "jcode-desktop2" {
+            args.push("--lib".to_string());
+        }
+    }
+    args
 }
 
 fn display_build_command(program: &str, specs: &[(&str, &str)]) -> String {
@@ -696,6 +735,93 @@ mod tests {
         assert!(!tui.display.contains("jcode-desktop"));
         let desktop2 = selfdev_build_command_for_target(repo.path(), SelfDevBuildTarget::Desktop2);
         assert!(!desktop2.display.contains("-p jcode "));
+    }
+
+    #[test]
+    fn windows_selfdev_build_invokes_native_cargo_without_a_shell() {
+        let repo = repo_fixture(false);
+        let scripts = repo.path().join("scripts");
+        std::fs::create_dir_all(&scripts).expect("scripts dir");
+        std::fs::write(scripts.join("dev_cargo.sh"), "#!/usr/bin/env bash\n").expect("wrapper");
+
+        let command = selfdev_build_command_for_target_on_platform(
+            repo.path(),
+            SelfDevBuildTarget::Tui,
+            true,
+        );
+
+        assert_eq!(command.program, "cargo");
+        assert_eq!(
+            command.args,
+            [
+                "build",
+                "--profile",
+                "selfdev",
+                "-p",
+                "jcode",
+                "--bin",
+                "jcode"
+            ]
+        );
+        assert!(
+            !command.args.iter().any(|arg| arg.contains("dev_cargo.sh")),
+            "Windows must not pass a native script path through bash"
+        );
+    }
+
+    #[test]
+    fn unix_selfdev_build_keeps_using_the_wrapper() {
+        let repo = repo_fixture(false);
+        let scripts = repo.path().join("scripts");
+        std::fs::create_dir_all(&scripts).expect("scripts dir");
+        std::fs::write(scripts.join("dev_cargo.sh"), "#!/usr/bin/env bash\n").expect("wrapper");
+
+        let command = selfdev_build_command_for_target_on_platform(
+            repo.path(),
+            SelfDevBuildTarget::Tui,
+            false,
+        );
+
+        assert_eq!(command.program, "bash");
+        assert_eq!(command.args.first().map(String::as_str), Some("-lc"));
+        assert!(
+            command
+                .args
+                .last()
+                .is_some_and(|arg| arg.contains("scripts/dev_cargo.sh"))
+        );
+    }
+
+    #[test]
+    fn windows_cargo_args_build_every_requested_target() {
+        let repo = repo_fixture(false);
+        let command = selfdev_build_command_for_target_on_platform(
+            repo.path(),
+            SelfDevBuildTarget::All,
+            true,
+        );
+
+        assert_eq!(
+            command.args,
+            [
+                "build",
+                "--profile",
+                "selfdev",
+                "-p",
+                "jcode",
+                "--bin",
+                "jcode",
+                "-p",
+                "jcode-desktop2",
+                "--bin",
+                "jcode-desktop2",
+                "--lib",
+                "-p",
+                "jcode-harness-api-server",
+                "--bin",
+                "jcode-harness-api-bridge",
+            ]
+        );
     }
 
     /// `auto` must route a change to the binary that contains it. Before

--- a/crates/jcode-build-support/src/tests.rs
+++ b/crates/jcode-build-support/src/tests.rs
@@ -334,6 +334,59 @@ fn pending_activation_can_complete_and_roll_back() {
 }
 
 #[test]
+fn explicit_promotion_pins_installed_version_without_moving_client_channels() {
+    with_temp_jcode_home(|| {
+        let stable = "0.22.0";
+        let current = "abc1234-dirty-deadbeef";
+        install_binary_at_version(std::env::current_exe().as_ref().unwrap(), stable)
+            .expect("install stable");
+        install_binary_at_version(std::env::current_exe().as_ref().unwrap(), current)
+            .expect("install current");
+        update_stable_symlink(stable).expect("publish stable");
+        update_current_symlink(current).expect("publish current");
+        update_shared_server_symlink(stable).expect("shared server initially tracks stable");
+
+        let previous = promote_version_to_shared_server(current).expect("promote current");
+
+        assert_eq!(previous.as_deref(), Some(stable));
+        assert_eq!(
+            read_shared_server_version().unwrap().as_deref(),
+            Some(current)
+        );
+        assert_eq!(read_current_version().unwrap().as_deref(), Some(current));
+        assert_eq!(read_stable_version().unwrap().as_deref(), Some(stable));
+        assert!(!shared_server_tracks_stable().expect("explicit promotion should pin the channel"));
+
+        let previous = promote_version_to_shared_server(current).expect("repeat promotion");
+        assert_eq!(
+            previous.as_deref(),
+            Some(current),
+            "repeating the same promotion is idempotent"
+        );
+    });
+}
+
+#[test]
+fn explicit_promotion_rejects_missing_and_path_like_versions() {
+    with_temp_jcode_home(|| {
+        let missing = promote_version_to_shared_server("not-installed")
+            .expect_err("missing version must be rejected");
+        assert!(missing.to_string().contains("Version binary not found"));
+
+        for invalid in ["", "..", "../stable", r"..\stable", "C:\\stable"] {
+            let error = promote_version_to_shared_server(invalid)
+                .expect_err("path-like version must be rejected");
+            assert!(
+                error
+                    .to_string()
+                    .contains("Invalid installed version label"),
+                "unexpected error for {invalid:?}: {error:#}"
+            );
+        }
+    });
+}
+
+#[test]
 fn shared_server_candidate_prefers_approved_channel_over_current() {
     with_temp_jcode_home(|| {
         let approved_version = "shared-ok";

--- a/crates/jcode-provider-openrouter/src/request.rs
+++ b/crates/jcode-provider-openrouter/src/request.rs
@@ -21,6 +21,26 @@ pub fn sanitize_tool_parameters_schema(schema: &Value) -> Value {
     jcode_schema_dialect::normalize(schema, &jcode_schema_dialect::registry::OPENROUTER)
 }
 
+fn orphan_tool_output_to_user_message(
+    tool_use_id: &str,
+    output: &str,
+    missing_output: &str,
+) -> Option<Value> {
+    let output = output.trim();
+    if output.is_empty() || output == missing_output {
+        return None;
+    }
+
+    Some(serde_json::json!({
+        "role": "user",
+        "content": format!(
+            "[Recovered orphaned tool output: {}]\n{}",
+            sanitize_tool_id(tool_use_id),
+            output
+        )
+    }))
+}
+
 /// Build OpenAI-compatible chat `messages` for OpenRouter/direct compatible providers.
 ///
 /// This stays in the OpenRouter leaf crate so provider-specific message normalization,
@@ -300,14 +320,34 @@ pub fn build_chat_messages(
         ));
     }
 
+    let mut rewritten_pending_orphans = 0usize;
     if !pending_tool_results.is_empty() {
-        skipped_results += pending_tool_results.len();
+        let mut pending_entries: Vec<(String, String)> = std::mem::take(&mut pending_tool_results)
+            .into_iter()
+            .collect();
+        pending_entries.sort_by(|a, b| a.0.cmp(&b.0));
+        for (tool_use_id, output) in pending_entries {
+            if let Some(message) =
+                orphan_tool_output_to_user_message(&tool_use_id, &output, &missing_output)
+            {
+                api_messages.push(message);
+                rewritten_pending_orphans += 1;
+            } else {
+                skipped_results += 1;
+            }
+        }
     }
 
     if injected_missing > 0 {
         jcode_logging::info(&format!(
             "[openrouter] Injected {} synthetic tool output(s) to prevent API error",
             injected_missing
+        ));
+    }
+    if rewritten_pending_orphans > 0 {
+        jcode_logging::info(&format!(
+            "[openrouter] Rewrote {} pending orphaned tool output(s) as user messages",
+            rewritten_pending_orphans
         ));
     }
     if skipped_results > 0 {
@@ -532,6 +572,28 @@ pub fn build_chat_messages(
     }
 
     api_messages
+}
+
+#[cfg(test)]
+mod request_tests {
+    use super::build_chat_messages;
+    use jcode_message_types::Message;
+    use serde_json::json;
+
+    #[test]
+    fn orphaned_tool_output_is_recovered_as_a_user_message() {
+        let messages = vec![Message::tool_result("call_orphan", "orphan result", false)];
+
+        let api_messages = build_chat_messages(&messages, "", false, false, false);
+
+        assert_eq!(
+            api_messages,
+            vec![json!({
+                "role": "user",
+                "content": "[Recovered orphaned tool output: call_orphan]\norphan result"
+            })]
+        );
+    }
 }
 
 #[cfg(test)]

--- a/crates/jcode-tui/src/tui/app/input.rs
+++ b/crates/jcode-tui/src/tui/app/input.rs
@@ -801,15 +801,54 @@ pub(super) fn handle_text_paste(app: &mut App, text: String) {
     let line_count = text.lines().count().max(1);
     if line_count < 5 {
         insert_input_text(app, &text);
-    } else {
-        app.pasted_contents.push(text);
-        let placeholder = format!(
-            "[pasted {} line{}]",
-            line_count,
-            if line_count == 1 { "" } else { "s" }
-        );
-        insert_input_text(app, &placeholder);
+        return;
     }
+    if expand_matching_paste(app, &text) {
+        return;
+    }
+
+    let placeholder = paste_placeholder(&text);
+    app.pasted_contents.push(text);
+    insert_input_text(app, &placeholder);
+}
+
+fn expand_matching_paste(app: &mut App, text: &str) -> bool {
+    let Some(content_index) = app
+        .pasted_contents
+        .iter()
+        .rposition(|content| content == text)
+    else {
+        return false;
+    };
+
+    let placeholder = paste_placeholder(text);
+    // Placeholders only encode a line count. Skip placeholders belonging to
+    // newer stored pastes with the same shape so equal-length, different text
+    // cannot cause the wrong placeholder to expand.
+    let newer_same_placeholder_count = app.pasted_contents[content_index + 1..]
+        .iter()
+        .filter(|content| paste_placeholder(content) == placeholder)
+        .count();
+    let Some(placeholder_start) = app
+        .input
+        .rmatch_indices(placeholder.as_str())
+        .map(|(position, _)| position)
+        .nth(newer_same_placeholder_count)
+    else {
+        return false;
+    };
+
+    app.follow_chat_bottom_for_typing();
+    app.remember_input_undo_state();
+    app.input.replace_range(
+        placeholder_start..placeholder_start + placeholder.len(),
+        text,
+    );
+    app.cursor_pos = placeholder_start + text.len();
+    app.pasted_contents.remove(content_index);
+    app.reset_tab_completion();
+    app.sync_model_picker_preview_from_input();
+    true
 }
 
 impl App {

--- a/crates/jcode-tui/src/tui/app/input.rs
+++ b/crates/jcode-tui/src/tui/app/input.rs
@@ -822,6 +822,18 @@ fn expand_matching_paste(app: &mut App, text: &str) -> bool {
     };
 
     let placeholder = paste_placeholder(text);
+    let stored_placeholder_count = app
+        .pasted_contents
+        .iter()
+        .filter(|content| paste_placeholder(content) == placeholder)
+        .count();
+    let rendered_placeholder_count = app.input.match_indices(placeholder.as_str()).count();
+    // Placeholder text can also be typed by the user. If the rendered and
+    // stored counts differ, there is no reliable way to identify which
+    // occurrence belongs to this paste, so preserve both the input and store.
+    if rendered_placeholder_count != stored_placeholder_count {
+        return false;
+    }
     // Placeholders only encode a line count. Skip placeholders belonging to
     // newer stored pastes with the same shape so equal-length, different text
     // cannot cause the wrong placeholder to expand.

--- a/crates/jcode-tui/src/tui/app/run_shell.rs
+++ b/crates/jcode-tui/src/tui/app/run_shell.rs
@@ -275,7 +275,7 @@ fn idle_animation_fast_path_blocked_reason(
 pub(super) struct StatusSpinnerRenderer {
     last_frame: Option<Buffer>,
     last_full_frame_at: Option<Instant>,
-    /// Animated rectangle whose surrounding cells are already seeded into
+    /// Animated rectangle whose surrounding cells are currently seeded into
     /// ratatui's working buffer.
     ///
     /// The animation-only repaint used to `clone_from` the whole previous frame
@@ -283,8 +283,9 @@ pub(super) struct StatusSpinnerRenderer {
     /// second at 60fps on a 160x48 terminal, to update ~2200 cells. Once the
     /// working buffer has been seeded for a given rectangle, everything outside it
     /// is already correct (this path is the only writer between full frames), so
-    /// later ticks copy just those rows. Cleared by [`Self::invalidate`] and
-    /// re-seeded whenever the rectangle changes.
+    /// later work can copy just those rows while that seed remains live. Cleared
+    /// by [`Self::invalidate`] and after every buffer swap, because ratatui resets
+    /// the next working buffer as part of the swap.
     seeded_animation_area: Option<Rect>,
     /// Composer contents as of the last full frame.
     ///
@@ -310,6 +311,18 @@ impl StatusSpinnerRenderer {
         // rows again.
         self.seeded_animation_area = None;
         self.last_full_frame_input.clear();
+    }
+
+    /// Present an animation frame and forget its working-buffer seed.
+    ///
+    /// `Terminal::swap_buffers` resets the buffer that the next tick will draw
+    /// into, so cells outside the animation area are no longer seeded there.
+    fn swap_after_animation_frame<B: ratatui::backend::Backend>(
+        &mut self,
+        terminal: &mut ratatui::Terminal<B>,
+    ) {
+        terminal.swap_buffers();
+        self.seeded_animation_area = None;
     }
 
     /// Whether the decorative idle-animation rows can be repainted on their own,
@@ -395,10 +408,9 @@ impl StatusSpinnerRenderer {
             }
             // Seed the working buffer from the last known frame. Only the
             // animated rows can differ once this path owns the screen (it is the
-            // only writer between full frames), so after the first pass we copy
-            // just those rows instead of the whole screen. `seeded_animation_area`
-            // records which rows that invariant covers, and any change to it (or
-            // to the frame identity) forces one full seed again.
+            // only writer between full frames), so a live seed can reuse just
+            // those rows. `swap_buffers` resets the next working buffer, and the
+            // presentation hook below invalidates the seed at that boundary.
             if self.seeded_animation_area == Some(area) {
                 copy_cells_in(previous_frame, current_buffer, area);
             } else {
@@ -426,7 +438,7 @@ impl StatusSpinnerRenderer {
             RestorePosition,
             EndSynchronizedUpdate
         )?;
-        terminal.swap_buffers();
+        self.swap_after_animation_frame(terminal);
         terminal.backend_mut().flush()?;
         // Keep the remembered frame current without cloning the whole screen: it
         // already matches everywhere except the rows just re-rendered. Re-render
@@ -1353,5 +1365,47 @@ mod tests {
             !render_status_spinner_into_buffer(&buffer, area, "⠙"),
             "late overlays own the status cell until the next full frame"
         );
+    }
+
+    #[test]
+    fn presented_animation_frame_requires_reseeding() {
+        let animation_area = Rect::new(0, 1, 10, 2);
+        let mut renderer = StatusSpinnerRenderer {
+            seeded_animation_area: Some(animation_area),
+            ..Default::default()
+        };
+        let backend = ratatui::backend::TestBackend::new(10, 3);
+        let mut terminal = ratatui::Terminal::new(backend).expect("test terminal");
+
+        renderer.swap_after_animation_frame(&mut terminal);
+
+        assert_eq!(renderer.seeded_animation_area, None);
+    }
+
+    #[test]
+    fn idle_animation_repaint_preserves_cells_outside_animation_after_swap() {
+        let area = Rect::new(0, 0, 20, 4);
+        let animation_area = Rect::new(0, 3, 20, 1);
+        let mut previous_frame = Buffer::empty(area);
+        previous_frame.set_string(0, 0, "transcript", Style::default());
+        previous_frame.set_string(0, 2, "> composer", Style::default());
+        let mut renderer = StatusSpinnerRenderer::default();
+        let backend = ratatui::backend::TestBackend::new(area.width, area.height);
+        let mut terminal = ratatui::Terminal::new(backend).expect("test terminal");
+
+        for _ in 0..3 {
+            let working = terminal.current_buffer_mut();
+            if renderer.seeded_animation_area == Some(animation_area) {
+                copy_cells_in(&previous_frame, working, animation_area);
+            } else {
+                working.clone_from(&previous_frame);
+                renderer.seeded_animation_area = Some(animation_area);
+            }
+
+            assert_eq!(working[(0, 0)].symbol(), "t");
+            assert_eq!(working[(0, 2)].symbol(), ">");
+
+            renderer.swap_after_animation_frame(&mut terminal);
+        }
     }
 }

--- a/crates/jcode-tui/src/tui/app/tests/remote_startup_input_03/part_01.rs
+++ b/crates/jcode-tui/src/tui/app/tests/remote_startup_input_03/part_01.rs
@@ -324,6 +324,85 @@ fn test_handle_paste_large() {
 }
 
 #[test]
+fn test_paste_again_expands_placeholder_in_place() {
+    let mut app = create_test_app();
+    let big = "α\nβ\nγ\nδ\nε".to_string();
+
+    app.handle_paste(big.clone());
+    app.handle_key(KeyCode::Char('!'), KeyModifiers::empty())
+        .unwrap();
+    app.handle_paste(big.clone());
+
+    assert_eq!(app.input(), format!("{big}!"));
+    assert_eq!(app.cursor_pos, big.len());
+    assert!(app.pasted_contents.is_empty());
+}
+
+#[test]
+fn test_paste_again_with_different_text_still_collapses() {
+    let mut app = create_test_app();
+
+    app.handle_paste("a\nb\nc\nd\ne".to_string());
+    app.handle_paste("f\ng\nh\ni\nj".to_string());
+
+    assert_eq!(app.input(), "[pasted 5 lines][pasted 5 lines]");
+    assert_eq!(app.pasted_contents.len(), 2);
+}
+
+#[test]
+fn test_paste_again_expands_matching_placeholder_not_newer_same_sized_paste() {
+    let mut app = create_test_app();
+    let first = "a\nb\nc\nd\ne".to_string();
+    let second = "f\ng\nh\ni\nj".to_string();
+
+    app.handle_paste(first.clone());
+    app.handle_key(KeyCode::Char(' '), KeyModifiers::empty())
+        .unwrap();
+    app.handle_paste(second.clone());
+    app.handle_paste(first.clone());
+
+    assert_eq!(app.input(), format!("{first} [pasted 5 lines]"));
+    assert_eq!(app.cursor_pos, first.len());
+    let visible_input = app.input().to_string();
+    assert_eq!(
+        crate::tui::app::input::expand_paste_placeholders(&mut app, &visible_input),
+        format!("{first} {second}")
+    );
+    assert_eq!(app.pasted_contents, vec![second]);
+}
+
+#[test]
+fn test_paste_again_expands_only_most_recent_identical_placeholder() {
+    let mut app = create_test_app();
+    let big = "a\nb\nc\nd\ne".to_string();
+
+    app.set_input_for_test("[pasted 5 lines] [pasted 5 lines]");
+    app.pasted_contents = vec![big.clone(), big.clone()];
+    app.handle_paste(big.clone());
+
+    assert_eq!(app.input(), format!("[pasted 5 lines] {big}"));
+    assert_eq!(app.pasted_contents, vec![big]);
+}
+
+#[test]
+fn test_paste_again_does_not_expand_an_edited_placeholder() {
+    let mut app = create_test_app();
+    let big = "a\nb\nc\nd\ne".to_string();
+
+    app.handle_paste(big.clone());
+    app.handle_key(KeyCode::Backspace, KeyModifiers::empty())
+        .unwrap();
+    app.handle_paste(big);
+
+    assert_eq!(
+        app.input(),
+        "[pasted 5 lines[pasted 5 lines]",
+        "an edited placeholder must not be mistaken for the original"
+    );
+    assert_eq!(app.pasted_contents.len(), 2);
+}
+
+#[test]
 fn test_paste_expansion_on_submit() {
     let mut app = create_test_app();
 

--- a/crates/jcode-tui/src/tui/app/tests/remote_startup_input_03/part_01.rs
+++ b/crates/jcode-tui/src/tui/app/tests/remote_startup_input_03/part_01.rs
@@ -385,6 +385,22 @@ fn test_paste_again_expands_only_most_recent_identical_placeholder() {
 }
 
 #[test]
+fn test_paste_again_does_not_replace_user_typed_placeholder_literal() {
+    let mut app = create_test_app();
+    let big = "a\nb\nc\nd\ne".to_string();
+
+    app.handle_paste(big.clone());
+    app.set_input_for_test("[pasted 5 lines] [pasted 5 lines]");
+    app.handle_paste(big.clone());
+
+    assert_eq!(
+        app.input(),
+        "[pasted 5 lines] [pasted 5 lines][pasted 5 lines]"
+    );
+    assert_eq!(app.pasted_contents, vec![big.clone(), big]);
+}
+
+#[test]
 fn test_paste_again_does_not_expand_an_edited_placeholder() {
     let mut app = create_test_app();
     let big = "a\nb\nc\nd\ne".to_string();

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -601,6 +601,19 @@ pub(crate) enum ServerCommand {
     #[command(hide = true)]
     Keepalive,
 
+    /// Pin the shared server channel to an installed version.
+    ///
+    /// Defaults to the active `current` version. This only selects the daemon's
+    /// binary; run `jcode server reload` separately to apply it.
+    Promote {
+        /// Installed version to promote (defaults to the current channel)
+        version: Option<String>,
+
+        /// Emit JSON instead of human-readable text
+        #[arg(long)]
+        json: bool,
+    },
+
     /// Gracefully reload the running background server onto the newest binary.
     ///
     /// This is the preferred way to pick up an upgrade: the daemon hands its

--- a/src/cli/args/tests.rs
+++ b/src/cli/args/tests.rs
@@ -23,6 +23,33 @@ fn server_start_and_internal_keepalive_parse() {
 }
 
 #[test]
+fn server_promote_parses_default_and_explicit_version() {
+    let current = Args::try_parse_from(["jcode", "server", "promote", "--json"])
+        .expect("server promote should default to current");
+    assert!(matches!(
+        current.command,
+        Some(Command::Server {
+            action: ServerCommand::Promote {
+                version: None,
+                json: true,
+            }
+        })
+    ));
+
+    let explicit = Args::try_parse_from(["jcode", "server", "promote", "abc1234-dirty-deadbeef"])
+        .expect("server promote should accept an installed version label");
+    assert!(matches!(
+        explicit.command,
+        Some(Command::Server {
+            action: ServerCommand::Promote {
+                version: Some(ref version),
+                json: false,
+            }
+        }) if version == "abc1234-dirty-deadbeef"
+    ));
+}
+
+#[test]
 fn telemetry_subcommands_parse() {
     let status = Args::try_parse_from(["jcode", "telemetry", "status", "--json"])
         .expect("telemetry status should parse");

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -2035,6 +2035,57 @@ pub async fn run_usage_command(emit_json: bool) -> Result<()> {
     report_info::run_usage_command(emit_json).await
 }
 
+/// Explicitly pin the daemon's shared-server channel to an installed build.
+/// Promotion and reload intentionally remain separate operations: updates may
+/// advance a shared server that tracks stable, but must not overwrite a build
+/// the user deliberately promoted here.
+pub fn run_server_promote_command(version: Option<&str>, emit_json: bool) -> Result<()> {
+    #[derive(Serialize)]
+    struct ServerPromoteReport {
+        version: String,
+        previous: Option<String>,
+        binary: String,
+        promoted: bool,
+        detail: String,
+    }
+
+    let version = match version {
+        Some(version) => version.to_string(),
+        None => crate::build::read_current_version()?.ok_or_else(|| {
+            anyhow::anyhow!("No current version is installed; pass an installed VERSION explicitly")
+        })?,
+    };
+    let previous = crate::build::promote_version_to_shared_server(&version)?;
+    let binary = crate::build::version_binary_path(&version)?;
+    let promoted = previous.as_deref() != Some(version.as_str());
+    let detail = if promoted {
+        format!(
+            "shared-server channel {} -> {}. Run `jcode server reload` to apply it to the running daemon.",
+            previous.as_deref().unwrap_or("<unset>"),
+            version
+        )
+    } else {
+        format!(
+            "shared-server channel already points to {}. Run `jcode server reload` if the running daemon has not applied it.",
+            version
+        )
+    };
+    let report = ServerPromoteReport {
+        version,
+        previous,
+        binary: binary.display().to_string(),
+        promoted,
+        detail,
+    };
+
+    if emit_json {
+        println!("{}", serde_json::to_string_pretty(&report)?);
+    } else {
+        println!("{}", report.detail);
+    }
+    Ok(())
+}
+
 /// Gracefully reload the running background server onto the newest binary.
 ///
 /// This is the preferred upgrade path (issue #291): instead of killing the

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -212,6 +212,9 @@ pub(crate) async fn run_main(mut args: Args) -> Result<()> {
                 )
                 .await?;
             }
+            ServerCommand::Promote { version, json } => {
+                commands::run_server_promote_command(version.as_deref(), json)?;
+            }
             ServerCommand::Reload { force, json } => {
                 commands::run_server_reload_command(force, json).await?;
             }

--- a/tests/e2e/test_support/mod.rs
+++ b/tests/e2e/test_support/mod.rs
@@ -387,6 +387,7 @@ impl WsTestClient {
             content: content.to_string(),
             images: vec![],
             system_reminder: None,
+            active_skill: None,
             no_reply: false,
         })
         .await


### PR DESCRIPTION
## Summary
- add explicit shared-server build promotion and native Windows self-dev Cargo execution
- expand repeated paste placeholders and repair idle-animation buffer reseeding
- deduplicate home/project `AGENTS.md`, clip skill descriptions safely, and preserve orphaned OpenRouter tool outputs

Fixes #908
Fixes #910
Fixes #911
Fixes #913
Fixes #914
Fixes #916
Fixes #917

## Verification
- `cargo test -p jcode-build-support`
- `cargo test -p jcode-base prompt`
- `cargo test -p jcode-provider-openrouter`
- focused paste and idle-animation regression suites
- `cargo test -p jcode --lib server_promote_parses_default_and_explicit_version`
- `cargo check -p jcode-build-support --target x86_64-pc-windows-gnu`
- `git diff --check origin/master..HEAD`

--- *— Jcode agent (automated triage), on behalf of @1jehuang*
