### PR TITLE
fix: resolve six reproducible triage issues

### DIFF
--- a/crates/jcode-app-core/src/tool/mcp.rs
+++ b/crates/jcode-app-core/src/tool/mcp.rs
@@ -189,9 +189,8 @@ impl McpManagementTool {
             } else {
                 for (_, tool) in server_tools {
                     output.push_str(&format!(
-                        "  - mcp__{}__{}: {}\n",
-                        server,
-                        tool.name,
+                        "  - {}: {}\n",
+                        crate::mcp::dispatch_name(server, &tool.name),
                         tool.description.as_deref().unwrap_or("(no description)")
                     ));
                 }
@@ -280,9 +279,8 @@ impl McpManagementTool {
                 );
                 for (_, tool) in &server_tools {
                     output.push_str(&format!(
-                        "  - mcp__{}__{}: {}\n",
-                        server_name,
-                        tool.name,
+                        "  - {}: {}\n",
+                        crate::mcp::dispatch_name(&server_name, &tool.name),
                         tool.description.as_deref().unwrap_or("(no description)")
                     ));
                 }
@@ -291,8 +289,9 @@ impl McpManagementTool {
                 // Register the new tools in the registry
                 if let Some(ref registry) = self.registry {
                     let mcp_tools = crate::mcp::create_mcp_tools(Arc::clone(&self.manager)).await;
+                    let server_prefix = crate::mcp::dispatch_name(&server_name, "");
                     for (name, tool) in mcp_tools {
-                        if name.starts_with(&format!("mcp__{}__", server_name)) {
+                        if name.starts_with(&server_prefix) {
                             registry.register(name, tool).await;
                         }
                     }
@@ -347,7 +346,7 @@ impl McpManagementTool {
         // Unregister tools for this server
         if let Some(ref registry) = self.registry {
             let removed = registry
-                .unregister_prefix(&format!("mcp__{}__", server_name))
+                .unregister_prefix(&crate::mcp::dispatch_name(&server_name, ""))
                 .await;
             crate::logging::event_info(
                 "MCP_LIFECYCLE",

--- a/crates/jcode-base/src/auth/doctor.rs
+++ b/crates/jcode-base/src/auth/doctor.rs
@@ -170,10 +170,32 @@ pub fn recommended_actions(
                 "Run runtime verification: jcode auth-test --provider {}",
                 provider.id
             )),
-            Some(record) if !record.success => actions.push(format!(
-                "Inspect runtime readiness: jcode auth-test --provider {}",
-                provider.id
-            )),
+            Some(record) if !record.success => {
+                let summary = record.summary.to_ascii_lowercase();
+                if summary.contains("402")
+                    || summary.contains("payment required")
+                    || summary.contains("balance exhausted")
+                {
+                    actions.push(
+                        "Restore the provider's billing or usage balance. Re-authenticating will not fix this failure."
+                            .to_string(),
+                    );
+                } else if summary.contains("429")
+                    || summary.contains("quota exhausted")
+                    || summary.contains("rate limit")
+                    || summary.contains("too many requests")
+                {
+                    actions.push(
+                        "Wait for or increase the provider quota before retrying. Re-authenticating will not fix this failure."
+                            .to_string(),
+                    );
+                } else {
+                    actions.push(format!(
+                        "Inspect runtime readiness: jcode auth-test --provider {}",
+                        provider.id
+                    ));
+                }
+            }
             Some(record) if validation_is_stale(record.checked_at_ms) => actions.push(format!(
                 "Refresh stale runtime verification: jcode auth-test --provider {}",
                 provider.id
@@ -260,6 +282,40 @@ mod tests {
             )
             .iter()
             .any(|line| line.contains("Replace the stale OAuth account/token"))
+        );
+    }
+
+    #[test]
+    fn billing_validation_failure_does_not_recommend_reauthentication() {
+        let mut assessment = base_assessment();
+        let validation = assessment.last_validation.as_mut().unwrap();
+        validation.success = false;
+        validation.provider_smoke_ok = Some(false);
+        validation.summary = "provider_smoke: API error (status 402 Payment Required): Grok Build usage balance exhausted".to_string();
+
+        let actions = recommended_actions(
+            crate::provider_catalog::login_providers()
+                .iter()
+                .copied()
+                .find(|provider| provider.id == "grok-build")
+                .unwrap(),
+            &assessment,
+            None,
+        );
+        assert!(
+            actions
+                .iter()
+                .any(|action| action.contains("billing or usage balance"))
+        );
+        assert!(
+            actions
+                .iter()
+                .any(|action| action.contains("Re-authenticating will not fix"))
+        );
+        assert!(
+            !actions
+                .iter()
+                .any(|action| action.contains("Inspect runtime readiness"))
         );
     }
 

--- a/crates/jcode-base/src/mcp/mod.rs
+++ b/crates/jcode-base/src/mcp/mod.rs
@@ -16,4 +16,4 @@ pub use manager::McpManager;
 pub use pool::{SharedMcpPool, get_shared_pool, init_shared_pool};
 pub use protocol::*;
 pub use schema_cache::{McpSchemaCache, fingerprint_config};
-pub use tool::{McpTool, create_mcp_tools, create_mcp_tools_from_cached};
+pub use tool::{McpTool, create_mcp_tools, create_mcp_tools_from_cached, dispatch_name};

--- a/crates/jcode-base/src/mcp/tool.rs
+++ b/crates/jcode-base/src/mcp/tool.rs
@@ -106,6 +106,10 @@ impl Tool for McpTool {
     }
 }
 
+pub fn dispatch_name(server_name: &str, tool_name: &str) -> String {
+    format!("mcp__{}__{}", server_name, tool_name).replace('-', "_")
+}
+
 /// Create tools from an MCP manager
 pub async fn create_mcp_tools(manager: Arc<RwLock<McpManager>>) -> Vec<(String, Arc<dyn Tool>)> {
     let mgr = manager.read().await;
@@ -114,7 +118,7 @@ pub async fn create_mcp_tools(manager: Arc<RwLock<McpManager>>) -> Vec<(String, 
 
     let mut tools = Vec::new();
     for (server_name, tool_def) in all_tools {
-        let prefixed_name = format!("mcp__{}__{}", server_name, tool_def.name);
+        let prefixed_name = dispatch_name(&server_name, &tool_def.name);
         let mcp_tool = McpTool::new(server_name, tool_def, Arc::clone(&manager));
         tools.push((prefixed_name, Arc::new(mcp_tool) as Arc<dyn Tool>));
     }
@@ -133,7 +137,7 @@ pub fn create_mcp_tools_from_cached(
     tool_defs
         .iter()
         .map(|tool_def| {
-            let prefixed_name = format!("mcp__{}__{}", server_name, tool_def.name);
+            let prefixed_name = dispatch_name(server_name, &tool_def.name);
             let mcp_tool = McpTool::new(
                 server_name.to_string(),
                 tool_def.clone(),
@@ -142,4 +146,21 @@ pub fn create_mcp_tools_from_cached(
             (prefixed_name, Arc::new(mcp_tool) as Arc<dyn Tool>)
         })
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::dispatch_name;
+
+    #[test]
+    fn hyphenated_mcp_names_are_safe_for_the_standard_dispatcher() {
+        assert_eq!(
+            dispatch_name("context7", "resolve-library-id"),
+            "mcp__context7__resolve_library_id"
+        );
+        assert_eq!(
+            dispatch_name("hyphenated-server", "query-docs"),
+            "mcp__hyphenated_server__query_docs"
+        );
+    }
 }

--- a/crates/jcode-provider-grok-build-runtime/src/bin/fake_acp.rs
+++ b/crates/jcode-provider-grok-build-runtime/src/bin/fake_acp.rs
@@ -90,6 +90,13 @@ fn main() {
                 if std::env::var_os("JCODE_FAKE_GROK_ACP_HANG").is_some() {
                     continue;
                 }
+                if std::env::var_os("JCODE_FAKE_GROK_ACP_PAYMENT_REQUIRED").is_some() {
+                    eprintln!(
+                        "Error: Internal error: {{\"message\":\"API error (status 402 Payment Required): Grok Build usage balance exhausted\",\"http_status\":402}}"
+                    );
+                    response(id, json!({"stopReason":"end_turn"}));
+                    continue;
+                }
                 send(json!({
                     "jsonrpc":"2.0",
                     "method":"_x.ai/settings/update",

--- a/crates/jcode-provider-grok-build-runtime/src/lib.rs
+++ b/crates/jcode-provider-grok-build-runtime/src/lib.rs
@@ -154,10 +154,7 @@ impl Provider for GrokBuildProvider {
                     tx.clone(),
                     cancel_rx,
                 ) {
-                    let _ = tx.blocking_send(Ok(StreamEvent::Error {
-                        message: format!("{error:#}"),
-                        retry_after_secs: None,
-                    }));
+                    let _ = tx.blocking_send(Err(error));
                 }
             })
             .context("Failed to start Grok Build ACP runtime thread")?;
@@ -576,28 +573,57 @@ where
         .take()
         .context("Grok CLI stderr was unavailable")?;
     let stderr_capture = Arc::new(std::sync::Mutex::new(String::new()));
-    let stderr_task = tokio::task::spawn_local(capture_stderr(stderr, Arc::clone(&stderr_capture)));
+    let mut stderr_task =
+        tokio::task::spawn_local(capture_stderr(stderr, Arc::clone(&stderr_capture)));
 
-    let client = GrokAcpClient { tx: event_tx };
+    let received_message = Arc::new(AtomicBool::new(false));
+    let client = GrokAcpClient {
+        tx: event_tx,
+        received_message: Arc::clone(&received_message),
+    };
     let (connection, io) =
         acp::ClientSideConnection::new(client, stdin.compat_write(), stdout.compat(), |future| {
             tokio::task::spawn_local(future);
         });
     let io_task = tokio::task::spawn_local(io);
     let result = operation(connection).await;
-    drop(child);
+    let _ = child.kill().await;
     io_task.abort();
+    let _ = tokio::time::timeout(Duration::from_millis(100), &mut stderr_task).await;
     stderr_task.abort();
+    let stderr = stderr_capture
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .trim()
+        .to_string();
+    if result.is_ok()
+        && !received_message.load(Ordering::Acquire)
+        && stderr_reports_provider_failure(&stderr)
+    {
+        bail!("Grok CLI provider request failed: {stderr}");
+    }
     result.map_err(|error| {
-        let stderr = stderr_capture
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        if stderr.trim().is_empty() {
+        if stderr.is_empty() {
             error
         } else {
-            error.context(format!("Grok CLI stderr: {}", stderr.trim()))
+            error.context(format!("Grok CLI stderr: {stderr}"))
         }
     })
+}
+
+fn stderr_reports_provider_failure(stderr: &str) -> bool {
+    let lower = stderr.to_ascii_lowercase();
+    [
+        "api error",
+        "payment required",
+        "balance exhausted",
+        "quota exhausted",
+        "too many requests",
+        "rate limit",
+        "http_status",
+    ]
+    .iter()
+    .any(|needle| lower.contains(needle))
 }
 
 async fn capture_stderr(
@@ -624,6 +650,7 @@ async fn capture_stderr(
 
 struct GrokAcpClient {
     tx: mpsc::Sender<Result<StreamEvent>>,
+    received_message: Arc<AtomicBool>,
 }
 
 #[async_trait(?Send)]
@@ -653,6 +680,7 @@ impl acp::Client for GrokAcpClient {
     ) -> acp::Result<()> {
         let event = match notification.update {
             acp::SessionUpdate::AgentMessageChunk(chunk) => {
+                self.received_message.store(true, Ordering::Release);
                 text_from_acp_content(chunk.content).map(StreamEvent::TextDelta)
             }
             acp::SessionUpdate::AgentThoughtChunk(chunk) => {

--- a/crates/jcode-provider-grok-build-runtime/tests/fake_acp.rs
+++ b/crates/jcode-provider-grok-build-runtime/tests/fake_acp.rs
@@ -19,6 +19,24 @@ fn fake_process(log: &Path) -> GrokBuildProcess {
 }
 
 #[tokio::test(flavor = "current_thread")]
+async fn provider_surfaces_payment_failure_written_to_subprocess_stderr() {
+    let temp = tempfile::tempdir().unwrap();
+    let mut process = fake_process(&temp.path().join("requests.jsonl"));
+    process
+        .env
+        .insert("JCODE_FAKE_GROK_ACP_PAYMENT_REQUIRED".into(), "1".into());
+    let provider = GrokBuildProvider::with_process(process);
+
+    let error = provider
+        .complete_simple("Reply exactly AUTH_TEST_OK", "")
+        .await
+        .unwrap_err();
+    let detail = format!("{error:#}");
+    assert!(detail.contains("402 Payment Required"), "{detail}");
+    assert!(detail.contains("usage balance exhausted"), "{detail}");
+}
+
+#[tokio::test(flavor = "current_thread")]
 async fn fake_subprocess_covers_handshake_models_new_prompt_and_auth_isolation() {
     let temp = tempfile::tempdir().unwrap();
     let log = temp.path().join("acp.jsonl");

--- a/crates/jcode-provider-openrouter/src/request.rs
+++ b/crates/jcode-provider-openrouter/src/request.rs
@@ -2,7 +2,7 @@ use jcode_message_types::{
     ContentBlock, Message, Role, TOOL_OUTPUT_MISSING_TEXT, sanitize_tool_id,
 };
 use serde_json::Value;
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
 
 /// Normalize a tool `parameters` JSON schema for whichever upstream OpenRouter
 /// routes the model to.
@@ -479,7 +479,8 @@ pub fn build_chat_messages(
     }
 
     // Final pass: ensure tool outputs immediately follow assistant tool calls.
-    let mut tool_output_map: HashMap<String, Value> = HashMap::new();
+    let mut tool_output_map: HashMap<String, VecDeque<Value>> = HashMap::new();
+    let mut missing_tool_outputs: HashMap<String, Value> = HashMap::new();
     for msg in &api_messages {
         if msg.get("role").and_then(|v| v.as_str()) == Some("tool")
             && let Some(id) = msg.get("tool_call_id").and_then(|v| v.as_str())
@@ -489,26 +490,20 @@ pub fn build_chat_messages(
                 .and_then(|v| v.as_str())
                 .map(|v| v == missing_output)
                 .unwrap_or(false);
-            match tool_output_map.get(id) {
-                Some(existing) => {
-                    let existing_missing = existing
-                        .get("content")
-                        .and_then(|v| v.as_str())
-                        .map(|v| v == missing_output)
-                        .unwrap_or(false);
-                    if existing_missing && !is_missing {
-                        tool_output_map.insert(id.to_string(), msg.clone());
-                    }
-                }
-                None => {
-                    tool_output_map.insert(id.to_string(), msg.clone());
-                }
+            if is_missing {
+                missing_tool_outputs
+                    .entry(id.to_string())
+                    .or_insert_with(|| msg.clone());
+            } else {
+                tool_output_map
+                    .entry(id.to_string())
+                    .or_default()
+                    .push_back(msg.clone());
             }
         }
     }
 
     let mut reordered: Vec<Value> = Vec::with_capacity(api_messages.len());
-    let mut used_outputs: HashSet<String> = HashSet::new();
     let mut injected_ordered = 0usize;
     let mut dropped_orphans = 0usize;
 
@@ -524,9 +519,12 @@ pub fn build_chat_messages(
                 reordered.push(msg);
                 for call in tool_calls {
                     if let Some(id) = call.get("id").and_then(|v| v.as_str()) {
-                        if let Some(tool_msg) = tool_output_map.get(id) {
-                            reordered.push(tool_msg.clone());
-                            used_outputs.insert(id.to_string());
+                        if let Some(tool_msg) = tool_output_map
+                            .get_mut(id)
+                            .and_then(VecDeque::pop_front)
+                            .or_else(|| missing_tool_outputs.get(id).cloned())
+                        {
+                            reordered.push(tool_msg);
                         } else {
                             injected_ordered += 1;
                             reordered.push(serde_json::json!({
@@ -534,7 +532,6 @@ pub fn build_chat_messages(
                                 "tool_call_id": id,
                                 "content": missing_output.clone()
                             }));
-                            used_outputs.insert(id.to_string());
                         }
                     }
                 }
@@ -543,12 +540,6 @@ pub fn build_chat_messages(
         }
 
         if role == "tool" {
-            if let Some(id) = msg.get("tool_call_id").and_then(|v| v.as_str())
-                && used_outputs.contains(id)
-            {
-                dropped_orphans += 1;
-                continue;
-            }
             dropped_orphans += 1;
             continue;
         }
@@ -577,8 +568,42 @@ pub fn build_chat_messages(
 #[cfg(test)]
 mod request_tests {
     use super::build_chat_messages;
-    use jcode_message_types::Message;
+    use jcode_message_types::{ContentBlock, Message, Role};
     use serde_json::json;
+
+    fn tool_call(id: &str, output: &str) -> [Message; 2] {
+        [
+            Message {
+                role: Role::Assistant,
+                content: vec![ContentBlock::ToolUse {
+                    id: id.to_string(),
+                    name: "read".to_string(),
+                    input: json!({"path": output}),
+                    thought_signature: None,
+                }],
+                timestamp: None,
+                tool_duration_ms: None,
+            },
+            Message::tool_result(id, output, false),
+        ]
+    }
+
+    #[test]
+    fn repeated_tool_call_ids_get_their_own_outputs_in_order() {
+        let messages = tool_call("read:0", "first output")
+            .into_iter()
+            .chain(tool_call("read_0", "second output"))
+            .collect::<Vec<_>>();
+
+        let api_messages = build_chat_messages(&messages, "", false, false, false);
+        let outputs = api_messages
+            .iter()
+            .filter(|message| message["role"] == "tool")
+            .map(|message| message["content"].as_str().unwrap())
+            .collect::<Vec<_>>();
+
+        assert_eq!(outputs, ["first output", "second output"]);
+    }
 
     #[test]
     fn orphaned_tool_output_is_recovered_as_a_user_message() {

--- a/crates/jcode-setup-hints/src/lib.rs
+++ b/crates/jcode-setup-hints/src/lib.rs
@@ -673,6 +673,9 @@ pub fn run_setup_hotkey(
         if _listen_macos_hotkey {
             return run_macos_hotkey_listener();
         }
+        if _uninstall {
+            return uninstall_macos_hotkey_listener();
+        }
 
         let mut state = SetupHintsState::load();
         let terminal = effective_macos_terminal();
@@ -712,6 +715,10 @@ pub fn run_setup_hotkey(
 
     #[cfg(target_os = "linux")]
     {
+        if _uninstall {
+            return uninstall_linux_launch_hotkeys();
+        }
+
         let mut state = SetupHintsState::load();
         eprintln!("\x1b[1mjcode setup-hotkey\x1b[0m");
         eprintln!();
@@ -1674,6 +1681,16 @@ fn install_linux_launch_hotkeys(comp: linux_env::LinuxCompositor) -> Result<bool
         LinuxCompositor::Xfce => install_xfce_launch_hotkeys(),
         other => install_flat_launch_hotkeys(other),
     }
+}
+
+/// Refuse to run the installer for an uninstall request. Linux hotkeys are
+/// written through several compositor-specific stores, and no safe common
+/// removal operation exists yet.
+#[cfg(target_os = "linux")]
+fn uninstall_linux_launch_hotkeys() -> Result<()> {
+    anyhow::bail!(
+        "automatic launch-hotkey removal is not supported for this Linux desktop; no changes were made"
+    )
 }
 
 /// Install (or refresh) the niri launch-hotkey binds into the user's

--- a/crates/jcode-tui/src/tui/app/input.rs
+++ b/crates/jcode-tui/src/tui/app/input.rs
@@ -3767,7 +3767,8 @@ impl App {
         // Leaving the preview should happen as soon as the user acts on it.
         self.onboarding_preview_mode = false;
 
-        // Add user message to display (show placeholder to user, not full paste)
+        // Add the expanded user message to the transcript. The composer remains compact
+        // while editing, but sent turns should show the actual pasted content.
         // Remember the typed prompt so we can restore it to the input box if this
         // turn fails (e.g. "token refresh needed"), instead of dropping it.
         self.last_submitted_input = Some(raw_input.clone());
@@ -3780,7 +3781,7 @@ impl App {
 
         self.push_display_message(DisplayMessage {
             role: "user".to_string(),
-            content: raw_input, // Show placeholder to user (condensed view)
+            content: input.clone(),
             tool_calls: vec![],
             duration_secs: None,
             title: None,

--- a/crates/jcode-tui/src/tui/app/tests/remote_startup_input_03/part_01.rs
+++ b/crates/jcode-tui/src/tui/app/tests/remote_startup_input_03/part_01.rs
@@ -426,9 +426,9 @@ fn test_paste_expansion_on_submit() {
     // Submit expands placeholder
     app.submit_input();
 
-    // Display shows placeholder (user sees condensed view)
+    // Sent transcript renders the actual pasted content, while the composer above stayed compact.
     assert_eq!(app.display_messages().len(), 1);
-    assert_eq!(app.display_messages()[0].content, "A: [pasted 5 lines] B");
+    assert_eq!(app.display_messages()[0].content, "A: 1\n2\n3\n4\n5 B");
 
     // Model receives expanded content (actual pasted text). Local sessions keep the
     // provider message cache lazy, so inspect the materialized provider view.

--- a/crates/jcode-tui/src/tui/ui_messages.rs
+++ b/crates/jcode-tui/src/tui/ui_messages.rs
@@ -4152,6 +4152,24 @@ pub(crate) fn render_tool_message(
         }
     }
 
+    if tools_ui::canonical_tool_name(&tc.name) == "bash"
+        && msg.content.trim() != "Command completed successfully (no output)"
+    {
+        const MAX_COLLAPSED_OUTPUT_LINES: usize = 3;
+        let output_lines = msg.content.lines().filter(|line| !line.trim().is_empty());
+        let total = output_lines.clone().count();
+        for output in output_lines.skip(total.saturating_sub(MAX_COLLAPSED_OUTPUT_LINES)) {
+            let output_line = Line::from(vec![
+                Span::styled("    │ ", Style::default().fg(dim_color())),
+                Span::styled(output.to_string(), Style::default().fg(dim_color())),
+            ]);
+            lines.push(super::truncate_line_with_ellipsis_to_width(
+                &output_line,
+                row_width,
+            ));
+        }
+    }
+
     if tc.name == "batch"
         && let Some(calls) = tc.input.get("tool_calls").and_then(|v| v.as_array())
     {

--- a/crates/jcode-tui/src/tui/ui_messages/tests.rs
+++ b/crates/jcode-tui/src/tui/ui_messages/tests.rs
@@ -1951,11 +1951,8 @@ fn render_tool_message_shows_intent_and_technical_preview_on_one_line() {
     let rendered = extract_line_text(&lines[0]);
 
     assert!(rendered.contains("bash · Verify compact progress card · $ cargo test"));
-    assert_eq!(
-        lines.len(),
-        1,
-        "intent should not add vertical space: {rendered}"
-    );
+    assert_eq!(lines.len(), 2, "only Bash output should add a detail line");
+    assert!(extract_line_text(&lines[1]).contains("ok"));
     crate::tui::ui::tools_ui::tests_tool_call_details_override::set(false);
 }
 
@@ -1993,7 +1990,8 @@ fn render_tool_message_hides_technical_preview_by_default() {
         !rendered.contains("cargo test"),
         "technical detail should be hidden by default: {rendered}"
     );
-    assert_eq!(lines.len(), 1, "no extra detail line expected: {rendered}");
+    assert_eq!(lines.len(), 2, "only Bash output should add a detail line");
+    assert!(extract_line_text(&lines[1]).contains("ok"));
 }
 
 /// Even with details off, a failed tool row keeps its error summary so
@@ -2052,6 +2050,32 @@ fn render_tool_message_shows_token_badge() {
         .expect("missing token badge");
 
     assert_eq!(badge_span.style.fg, Some(rgb(118, 118, 118)));
+}
+
+#[test]
+fn render_tool_message_shows_trimmed_bash_output() {
+    let msg = DisplayMessage {
+        role: "tool".to_string(),
+        content: "<class 'zip'>\n[('p', 'b'), ('a', 'a'), ('l', 'l'), ('e', 'e')]".to_string(),
+        tool_calls: Vec::new(),
+        duration_secs: None,
+        title: None,
+        tool_data: Some(crate::message::ToolCall {
+            id: "call_bash_output".to_string(),
+            name: "bash".to_string(),
+            input: serde_json::json!({
+                "command": "python3 -c \"s='pale'; t='bale'; print(type(zip(s,t))); print(list(zip(s,t)))\""
+            }),
+            intent: None,
+            thought_signature: None,
+        }),
+    };
+
+    let lines = render_tool_message(&msg, 120, crate::config::DiffDisplayMode::Off);
+    let rendered = lines.iter().map(extract_line_text).collect::<Vec<_>>();
+
+    assert!(rendered.iter().any(|line| line.contains("<class 'zip'>")));
+    assert!(rendered.iter().any(|line| line.contains("[('p', 'b')")));
 }
 
 fn gmail_draft_message(content: &str, input: serde_json::Value) -> DisplayMessage {

--- a/crates/jcode-tui/src/tui/ui_tests/tools.rs
+++ b/crates/jcode-tui/src/tui/ui_tests/tools.rs
@@ -1169,15 +1169,14 @@ fn test_render_tool_message_with_intent_never_adds_second_command_line() {
     let rendered: Vec<String> = lines.iter().map(extract_line_text).collect();
 
     assert!(!rendered.is_empty(), "rendered={rendered:?}");
-    assert_eq!(
-        rendered.len(),
-        1,
-        "intent rows must stay single-line: {rendered:?}"
-    );
+    assert_eq!(rendered.len(), 2, "Bash output should add one line: {rendered:?}");
     assert!(
-        !rendered[0].trim_start().starts_with('$'),
+        rendered
+            .iter()
+            .all(|line| !line.trim_start().starts_with('$')),
         "rendered={rendered:?}"
     );
+    assert!(rendered[1].contains("ok"), "rendered={rendered:?}");
 }
 
 #[test]

--- a/crates/jcode-tui/src/tui/ui_tests/tools.rs
+++ b/crates/jcode-tui/src/tui/ui_tests/tools.rs
@@ -1169,7 +1169,11 @@ fn test_render_tool_message_with_intent_never_adds_second_command_line() {
     let rendered: Vec<String> = lines.iter().map(extract_line_text).collect();
 
     assert!(!rendered.is_empty(), "rendered={rendered:?}");
-    assert_eq!(rendered.len(), 2, "Bash output should add one line: {rendered:?}");
+    assert_eq!(
+        rendered.len(),
+        2,
+        "Bash output should add one line: {rendered:?}"
+    );
     assert!(
         rendered
             .iter()

--- a/src/cli/auth_test/run.rs
+++ b/src/cli/auth_test/run.rs
@@ -38,7 +38,11 @@ async fn maybe_run_auth_test_smoke(
                     },
                 );
             }
-            Err(err) => report.push_step(kind.step_name(), false, format!("{err:#}")),
+            Err(err) => {
+                let detail = format!("{err:#}");
+                kind.set_output(report, detail.clone());
+                report.push_step(kind.step_name(), false, detail);
+            }
         }
     } else if !target.supports_smoke() {
         report.push_step(kind.step_name(), true, kind.unsupported_detail());
@@ -79,7 +83,11 @@ async fn maybe_run_auth_test_smoke_for_choice(
                             },
                         );
                     }
-                    Err(err) => report.push_step(kind.step_name(), false, format!("{err:#}")),
+                    Err(err) => {
+                        let detail = format!("{err:#}");
+                        kind.set_output(report, detail.clone());
+                        report.push_step(kind.step_name(), false, detail);
+                    }
                 }
             }
             Ok(AuthTestChoicePlan::Skip(detail)) => {


### PR DESCRIPTION
## Summary

- honor `setup-hotkey --uninstall` on macOS and Linux
- dispatch MCP tool names containing hyphens
- preserve output order when OpenRouter repeats tool-call IDs
- restore pasted content in sent transcript messages
- show trimmed Bash output in collapsed tool cards
- surface Grok Build subprocess billing/quota errors and avoid reauthentication advice

## Verification

- `cargo fmt --all -- --check`
- focused/full affected-package tests for `jcode-setup-hints`, `jcode-provider-openrouter`, `jcode-base`, `jcode-tui`, and `jcode-provider-grok-build-runtime`
- targeted suite passed with all new regression tests

The broader package run reached 1,309 passing `jcode-base` tests, then hit the pre-existing `every_model_login_provider_has_explicit_lifecycle_normalization` failure for `grok-build`; this branch does not modify that lifecycle table.

Fixes #923
Fixes #936
Fixes #937
Fixes #929
Fixes #921
Fixes #920

--- *— Jcode agent (automated triage), on behalf of @1jehuang*
