### PR TITLE
fix: resolve safe issues from automated triage

### DIFF
--- a/crates/jcode-base/src/config/default_file.rs
+++ b/crates/jcode-base/src/config/default_file.rs
@@ -56,6 +56,9 @@ scroll_prompt_down = "ctrl+]"
 # Scroll bookmark toggle (stash position, jump to bottom, press again to return)
 scroll_bookmark = "ctrl+g"
 
+# Auto-poke toggle. Set "" to disable.
+auto_poke_toggle = "ctrl+p"
+
 # Optional fallback scroll bindings (useful on macOS terminals that forward Command)
 # Leave unset by default; on macOS Cmd+K / Cmd+J move up / down by prompt instead.
 scroll_up_fallback = ""

--- a/crates/jcode-base/src/config/default_file.rs
+++ b/crates/jcode-base/src/config/default_file.rs
@@ -154,6 +154,9 @@ debug_socket = false
 # Set false here or set JCODE_NO_EMOJI=1 for ASCII fallbacks.
 emoji = true
 
+# Usage percentage wording: "left" (default) or "used".
+usage_display = "left"
+
 # Show thinking/reasoning content (default: false)
 show_thinking = false
 

--- a/crates/jcode-base/src/config/display_summary.rs
+++ b/crates/jcode-base/src/config/display_summary.rs
@@ -27,6 +27,7 @@ impl Config {
 - Prompt up: `{}`
 - Prompt down: `{}`
 - Scroll bookmark: `{}`
+- Auto-poke toggle: `{}`
 - Workspace left: `{}`
 - Workspace down: `{}`
 - Workspace up: `{}`
@@ -143,6 +144,11 @@ impl Config {
             self.keybindings.scroll_prompt_up,
             self.keybindings.scroll_prompt_down,
             self.keybindings.scroll_bookmark,
+            if self.keybindings.auto_poke_toggle.trim().is_empty() {
+                "disabled"
+            } else {
+                self.keybindings.auto_poke_toggle.trim()
+            },
             self.keybindings.workspace_left,
             self.keybindings.workspace_down,
             self.keybindings.workspace_up,

--- a/crates/jcode-base/src/config_tests.rs
+++ b/crates/jcode-base/src/config_tests.rs
@@ -82,6 +82,24 @@ fn auto_poke_feature_defaults_on_and_parses_false() {
 }
 
 #[test]
+fn auto_poke_toggle_key_defaults_parses_and_reports_disabled() {
+    assert_eq!(Config::default().keybindings.auto_poke_toggle, "ctrl+p");
+
+    let remapped: Config = toml::from_str("[keybindings]\nauto_poke_toggle = \"alt+p\"\n")
+        .expect("keybindings.auto_poke_toggle should parse");
+    assert_eq!(remapped.keybindings.auto_poke_toggle, "alt+p");
+
+    let disabled: Config = toml::from_str("[keybindings]\nauto_poke_toggle = \"\"\n")
+        .expect("an empty auto-poke toggle should parse");
+    assert!(disabled.keybindings.auto_poke_toggle.is_empty());
+    assert!(
+        disabled
+            .display_string()
+            .contains("- Auto-poke toggle: `disabled`")
+    );
+}
+
+#[test]
 fn auto_poke_environment_override_uses_standard_boolean_values() {
     let _guard = crate::storage::lock_test_env();
     let previous = std::env::var_os("JCODE_AUTO_POKE");

--- a/crates/jcode-base/src/mcp/protocol.rs
+++ b/crates/jcode-base/src/mcp/protocol.rs
@@ -607,6 +607,7 @@ impl McpConfig {
         Self::import_from_codex_once();
 
         let mut merged = Self::default();
+        let claude_mcp_enabled = std::env::var_os("JCODE_DISABLE_CLAUDE_MCP").is_none();
 
         // Load jcode's own global config (~/.jcode/mcp.json)
         if let Ok(jcode_dir) = crate::storage::jcode_dir() {
@@ -620,7 +621,9 @@ impl McpConfig {
 
         // Claude Code user/global config (~/.claude.json): top-level mcpServers
         // plus per-project entries for the project directory.
-        if let Ok(claude_json) = crate::storage::user_home_path(".claude.json") {
+        if claude_mcp_enabled
+            && let Ok(claude_json) = crate::storage::user_home_path(".claude.json")
+        {
             if claude_json.exists() {
                 let cwd = project_dir.map(std::path::Path::to_path_buf);
                 let config = Self::load_claude_json(&claude_json, cwd.as_deref());
@@ -637,7 +640,9 @@ impl McpConfig {
         // Older Claude Code global config is also a live source. Reading it on
         // every load preserves compatibility without copying any inline env
         // values into ~/.jcode/mcp.json.
-        if let Ok(claude_mcp) = crate::storage::user_home_path(".claude/mcp.json") {
+        if claude_mcp_enabled
+            && let Ok(claude_mcp) = crate::storage::user_home_path(".claude/mcp.json")
+        {
             if claude_mcp.exists()
                 && let Ok(config) = Self::load_from_file(&claude_mcp)
             {

--- a/crates/jcode-base/src/mcp/protocol_tests.rs
+++ b/crates/jcode-base/src/mcp/protocol_tests.rs
@@ -758,6 +758,62 @@ fn legacy_claude_config_is_live_and_deletions_do_not_leave_a_snapshot() {
 }
 
 #[test]
+fn disabling_claude_mcp_skips_both_live_sources_but_preserves_jcode_sources() {
+    let _guard = crate::storage::lock_test_env();
+    let previous_home = std::env::var_os("JCODE_HOME");
+    let previous_disable = std::env::var_os("JCODE_DISABLE_CLAUDE_MCP");
+    let home = tempfile::tempdir().expect("home tempdir");
+    let project = tempfile::tempdir().expect("project tempdir");
+    crate::env::set_var("JCODE_HOME", home.path());
+    crate::env::set_var("JCODE_DISABLE_CLAUDE_MCP", "1");
+
+    std::fs::write(
+        home.path().join("mcp.json"),
+        r#"{"mcpServers":{"jcode-global":{"command":"jcode-global"}}}"#,
+    )
+    .expect("write jcode global config");
+    std::fs::create_dir_all(project.path().join(".jcode")).expect("create jcode project dir");
+    std::fs::write(
+        project.path().join(".jcode/mcp.json"),
+        r#"{"mcpServers":{"jcode-project":{"command":"jcode-project"}}}"#,
+    )
+    .expect("write jcode project config");
+
+    let external = home.path().join("external");
+    std::fs::create_dir_all(external.join(".claude")).expect("create Claude config dirs");
+    std::fs::write(
+        external.join(".claude.json"),
+        r#"{"mcpServers":{"claude-current":{"command":"claude-current"}}}"#,
+    )
+    .expect("write current Claude config");
+    std::fs::write(
+        external.join(".claude/mcp.json"),
+        r#"{"mcpServers":{"claude-legacy":{"command":"claude-legacy"}}}"#,
+    )
+    .expect("write legacy Claude config");
+
+    let result = std::panic::catch_unwind(|| {
+        let config = McpConfig::load_for_dir(Some(project.path()));
+        assert!(config.servers.contains_key("jcode-global"));
+        assert!(config.servers.contains_key("jcode-project"));
+        assert!(!config.servers.contains_key("claude-current"));
+        assert!(!config.servers.contains_key("claude-legacy"));
+    });
+
+    if let Some(previous_home) = previous_home {
+        crate::env::set_var("JCODE_HOME", previous_home);
+    } else {
+        crate::env::remove_var("JCODE_HOME");
+    }
+    if let Some(previous_disable) = previous_disable {
+        crate::env::set_var("JCODE_DISABLE_CLAUDE_MCP", previous_disable);
+    } else {
+        crate::env::remove_var("JCODE_DISABLE_CLAUDE_MCP");
+    }
+    result.expect("Claude MCP opt-out assertions");
+}
+
+#[test]
 fn mcp_source_logs_explain_provenance_without_config_values() {
     let live = McpConfig::live_claude_log_message(2, "~/.claude.json");
     assert!(live.contains("Loaded 2 server(s) live from Claude Code (~/.claude.json)"));

--- a/crates/jcode-base/src/skill.rs
+++ b/crates/jcode-base/src/skill.rs
@@ -477,6 +477,17 @@ impl SkillRegistry {
 
     /// Parse a SKILL.md file
     fn parse_skill(path: &Path) -> Result<Skill> {
+        Self::parse_skill_inner(path).map_err(|error| {
+            crate::logging::warn(&format!(
+                "Failed to parse skill file '{}': {}",
+                path.display(),
+                error
+            ));
+            error
+        })
+    }
+
+    fn parse_skill_inner(path: &Path) -> Result<Skill> {
         let content = std::fs::read_to_string(path)?;
 
         // Parse YAML frontmatter
@@ -962,6 +973,14 @@ mod tests {
         .expect("write skill");
     }
 
+    fn write_skill_file(skills_dir: &Path, name: &str, content: &str) -> PathBuf {
+        let dir = skills_dir.join(name);
+        std::fs::create_dir_all(&dir).expect("create skill dir");
+        let path = dir.join("SKILL.md");
+        std::fs::write(&path, content).expect("write skill");
+        path
+    }
+
     #[test]
     fn parse_invocation_supports_a_trailing_prompt() {
         assert_eq!(
@@ -1099,6 +1118,37 @@ mod tests {
             .expect("project-local .agents skill should load");
         assert_eq!(skill.description, "Test skill agents-only");
         assert!(skill.path.starts_with(temp.path()));
+    }
+
+    #[test]
+    fn malformed_skill_does_not_block_directory_loaders() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let skills_dir = temp.path().join("skills");
+        write_skill_file(
+            &skills_dir,
+            "valid",
+            "---\nname: valid\ndescription: Valid skill\n---\n\nUse valid.\n",
+        );
+        write_skill_file(
+            &skills_dir,
+            "malformed",
+            "---\nname: malformed\ndescription: Triggers: invalid yaml\n---\n\nBroken.\n",
+        );
+
+        let mut registry = SkillRegistry::default();
+        registry
+            .load_from_dir(&skills_dir)
+            .expect("load skills while skipping malformed file");
+        assert!(registry.contains("valid"));
+        assert!(!registry.contains("malformed"));
+
+        let mut counted_registry = SkillRegistry::default();
+        let count = counted_registry
+            .load_from_dir_count(&skills_dir)
+            .expect("count skills while skipping malformed file");
+        assert_eq!(count, 1);
+        assert!(counted_registry.contains("valid"));
+        assert!(!counted_registry.contains("malformed"));
     }
 
     #[test]

--- a/crates/jcode-config-types/src/display.rs
+++ b/crates/jcode-config-types/src/display.rs
@@ -115,6 +115,8 @@ pub struct DisplayConfig {
     /// sessions (issue #674).
     #[serde(default = "default_true")]
     pub external_sessions: bool,
+    /// Usage percentage wording: "left" (default) or "used".
+    pub usage_display: String,
     /// When to show the overscroll status line below the input
     /// (off/on/overscroll, default: overscroll). "overscroll" is the elastic
     /// reveal when scrolling past the bottom, "on" keeps it always visible.
@@ -157,6 +159,7 @@ impl Default for DisplayConfig {
             colors: std::collections::BTreeMap::new(),
             active_sessions_manager: false,
             external_sessions: true,
+            usage_display: "left".to_string(),
             overscroll_status: OverscrollStatusMode::default(),
         }
     }
@@ -202,6 +205,10 @@ impl DisplayConfig {
     pub fn reasoning_enabled(&self) -> bool {
         !matches!(self.reasoning_display(), ReasoningDisplayMode::Off)
     }
+
+    pub fn usage_display_used(&self) -> bool {
+        self.usage_display.eq_ignore_ascii_case("used")
+    }
 }
 
 #[cfg(test)]
@@ -218,5 +225,14 @@ mod tests {
         let disabled: DisplayConfig =
             serde_json::from_str(r#"{"pin_todos":false}"#).expect("display config");
         assert!(!disabled.pin_todos);
+    }
+
+    #[test]
+    fn usage_percentage_wording_defaults_to_left_and_accepts_used() {
+        assert_eq!(DisplayConfig::default().usage_display, "left");
+
+        let used: DisplayConfig =
+            serde_json::from_str(r#"{"usage_display":"used"}"#).expect("display config");
+        assert!(used.usage_display_used());
     }
 }

--- a/crates/jcode-config-types/src/keybindings.rs
+++ b/crates/jcode-config-types/src/keybindings.rs
@@ -277,6 +277,12 @@ pub const KEYBINDING_DEFAULTS: &[KeybindingDefault] = &[
         other: PlatformDefault::dev("ctrl+g"),
     },
     KeybindingDefault {
+        id: "auto_poke_toggle",
+        description: "Toggle auto-poke",
+        macos: PlatformDefault::dev("ctrl+p"),
+        other: PlatformDefault::dev("ctrl+p"),
+    },
+    KeybindingDefault {
         id: "scroll_up_fallback",
         description: "Optional fallback scroll-up binding",
         // Left unbound on every platform by default: on macOS Cmd+K is reserved

--- a/crates/jcode-config-types/src/lib.rs
+++ b/crates/jcode-config-types/src/lib.rs
@@ -952,6 +952,8 @@ pub struct KeybindingsConfig {
     pub scroll_prompt_down: String,
     /// Scroll bookmark toggle key (default: "ctrl+g")
     pub scroll_bookmark: String,
+    /// Toggle auto-poke (default: "ctrl+p"). Set "" to disable.
+    pub auto_poke_toggle: String,
     /// Scroll up fallback key (default: unset; Cmd+K moves up by prompt on macOS)
     pub scroll_up_fallback: String,
     /// Scroll down fallback key (default: unset; Cmd+J moves down by prompt on macOS)
@@ -1018,6 +1020,7 @@ impl Default for KeybindingsConfig {
             scroll_prompt_up: get("scroll_prompt_up", "ctrl+["),
             scroll_prompt_down: get("scroll_prompt_down", "ctrl+]"),
             scroll_bookmark: get("scroll_bookmark", "ctrl+g"),
+            auto_poke_toggle: get("auto_poke_toggle", "ctrl+p"),
             scroll_up_fallback: get("scroll_up_fallback", ""),
             scroll_down_fallback: get("scroll_down_fallback", ""),
             workspace_left: get("workspace_left", "alt+h"),

--- a/crates/jcode-tui/src/tui/app/hotkey_feedback.rs
+++ b/crates/jcode-tui/src/tui/app/hotkey_feedback.rs
@@ -116,6 +116,11 @@ pub(super) fn build_registry(inputs: &RegistryInputs<'_>) -> Vec<KnownHotkey> {
 
     // Configured pane/mode toggles (pre-control shortcuts).
     push(
+        inputs.toggles.auto_poke.binding().cloned(),
+        "auto_poke_toggle",
+        "toggle auto-poke",
+    );
+    push(
         inputs.toggles.copy_selection.binding().cloned(),
         "copy_selection_toggle",
         "toggle copy/selection mode",
@@ -341,11 +346,6 @@ pub(super) fn build_registry(inputs: &RegistryInputs<'_>) -> Vec<KnownHotkey> {
         ctrl('s'),
         "input_stash",
         "stash or restore the input draft",
-    ));
-    out.push(KnownHotkey::new(
-        ctrl('p'),
-        "auto_poke_toggle",
-        "toggle auto-poke",
     ));
     out.push(KnownHotkey::new(
         ctrl('t'),
@@ -907,7 +907,7 @@ mod tests {
     }
 
     #[test]
-    fn lookup_finds_builtin_ctrl_p_auto_poke() {
+    fn lookup_finds_configured_ctrl_p_auto_poke() {
         let registry = test_inputs_registry(false);
         let info = lookup(&registry, true, KeyCode::Char('p'), KeyModifiers::CONTROL)
             .expect("ctrl+p known");
@@ -1122,6 +1122,7 @@ mod tests {
         let registry = test_inputs_registry(false);
         let toggles = crate::tui::keybind::load_toggle_keys();
         let toggle_bindings: &[(&str, Option<&KeyBinding>)] = &[
+            ("auto_poke_toggle", toggles.auto_poke.binding()),
             ("side_panel_toggle", toggles.side_panel.binding()),
             ("copy_selection_toggle", toggles.copy_selection.binding()),
             ("diagram_pane_toggle", toggles.diagram_pane.binding()),

--- a/crates/jcode-tui/src/tui/app/inline_interactive.rs
+++ b/crates/jcode-tui/src/tui/app/inline_interactive.rs
@@ -97,13 +97,16 @@ use placeholder_routes::route_supports_reasoning_effort;
 /// "openai-compatible:myprofile"), or a bare openai-compatible profile id
 /// ("myprofile"). Matching is case/format-insensitive via the shared provider
 /// label normalizer. Routes for the active model are always kept so the
-/// current selection never disappears from the picker, and a filter that
+/// current selection never disappears from the picker, but only when their
+/// provider and API method match the active route. A filter that
 /// matches nothing falls back to the unfiltered list instead of an empty
 /// picker.
 fn filter_routes_by_provider_allowlist(
     routes: Vec<crate::provider::ModelRoute>,
     allowlist: Option<&[String]>,
     current_model: &str,
+    current_provider: &str,
+    current_api_method: Option<&str>,
 ) -> Vec<crate::provider::ModelRoute> {
     use crate::provider::normalize_model_route_provider_label as normalize;
 
@@ -137,9 +140,17 @@ fn filter_routes_by_provider_allowlist(
         })
     };
 
+    let route_is_current = |route: &crate::provider::ModelRoute| {
+        route.model == current_model
+            && crate::provider::model_route_provider_labels_match(&route.provider, current_provider)
+            && current_api_method.is_none_or(|api_method| {
+                crate::provider::ModelRouteApiMethod::parse(&route.api_method)
+                    == crate::provider::ModelRouteApiMethod::parse(api_method)
+            })
+    };
     let filtered: Vec<crate::provider::ModelRoute> = routes
         .iter()
-        .filter(|route| route.model == current_model || route_matches(route))
+        .filter(|route| route_is_current(route) || route_matches(route))
         .cloned()
         .collect();
     if filtered.is_empty() {
@@ -1401,6 +1412,14 @@ impl App {
         } else {
             self.provider.model().to_string()
         };
+        let current_provider = if self.is_remote {
+            self.remote_provider_name
+                .clone()
+                .unwrap_or_else(|| "remote".to_string())
+        } else {
+            self.provider.display_name()
+        };
+        let current_api_method = self.current_route_api_method();
         let config = crate::config::config();
         let config_default_model = config.provider.default_model.clone();
         let config_default_provider = config.provider.default_provider.clone();
@@ -1454,6 +1473,8 @@ impl App {
             routes,
             config.provider.model_picker_providers.as_deref(),
             &current_model,
+            &current_provider,
+            current_api_method.as_deref(),
         );
 
         if routes.is_empty() {
@@ -1534,13 +1555,6 @@ impl App {
             }
         }
 
-        let current_provider = if self.is_remote {
-            self.remote_provider_name
-                .clone()
-                .unwrap_or_else(|| "remote".to_string())
-        } else {
-            self.provider.name().to_string()
-        };
         let recent_auth_provider = self
             .recent_authenticated_provider
             .as_ref()
@@ -4273,6 +4287,8 @@ mod tests {
             routes.clone(),
             Some(&["Llama.CPP".to_string()]),
             "unrelated-current",
+            "OpenAI",
+            None,
         );
         assert_eq!(filtered.len(), 1);
         assert_eq!(filtered[0].model, "qwen3-coder");
@@ -4282,6 +4298,8 @@ mod tests {
             routes.clone(),
             Some(&["llamacpp".to_string()]),
             "unrelated-current",
+            "OpenAI",
+            None,
         );
         assert_eq!(filtered.len(), 1);
         assert_eq!(filtered[0].provider, "llama.cpp");
@@ -4291,6 +4309,8 @@ mod tests {
             routes.clone(),
             Some(&["claude-oauth".to_string(), "openrouter".to_string()]),
             "unrelated-current",
+            "OpenAI",
+            None,
         );
         let models: Vec<&str> = filtered.iter().map(|r| r.model.as_str()).collect();
         assert_eq!(models, ["claude-fable-5", "deepseek/deepseek-v4-pro"]);
@@ -4308,6 +4328,8 @@ mod tests {
             routes.clone(),
             Some(&["llamacpp".to_string()]),
             "gpt-5.5",
+            "OpenAI",
+            Some("openai-oauth"),
         );
         let models: Vec<&str> = filtered.iter().map(|r| r.model.as_str()).collect();
         assert_eq!(models, ["gpt-5.5", "qwen3-coder"]);
@@ -4317,21 +4339,90 @@ mod tests {
             routes.clone(),
             Some(&["nonexistent".to_string()]),
             "unrelated-current",
+            "OpenAI",
+            None,
         );
         assert_eq!(filtered.len(), routes.len());
 
         // None / empty / blank-entry allowlists are no-ops.
         assert_eq!(
-            filter_routes_by_provider_allowlist(routes.clone(), None, "x").len(),
+            filter_routes_by_provider_allowlist(routes.clone(), None, "x", "OpenAI", None).len(),
             2
         );
         assert_eq!(
-            filter_routes_by_provider_allowlist(routes.clone(), Some(&[]), "x").len(),
+            filter_routes_by_provider_allowlist(routes.clone(), Some(&[]), "x", "OpenAI", None,)
+                .len(),
             2
         );
         assert_eq!(
-            filter_routes_by_provider_allowlist(routes, Some(&["  ".to_string()]), "x").len(),
+            filter_routes_by_provider_allowlist(
+                routes,
+                Some(&["  ".to_string()]),
+                "x",
+                "OpenAI",
+                None,
+            )
+            .len(),
             2
+        );
+    }
+
+    #[test]
+    fn provider_allowlist_does_not_keep_disallowed_route_sharing_current_model() {
+        let routes = vec![
+            model_route(
+                "moonshotai/Kimi-K3",
+                "my-provider",
+                "openai-compatible:my-provider",
+            ),
+            model_route("moonshotai/Kimi-K3", "Copilot", "copilot"),
+        ];
+
+        let filtered = filter_routes_by_provider_allowlist(
+            routes,
+            Some(&["my-provider".to_string()]),
+            "moonshotai/Kimi-K3",
+            "my-provider",
+            Some("openai-compatible:my-provider"),
+        );
+
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].provider, "my-provider");
+    }
+
+    #[test]
+    fn provider_allowlist_keeps_only_exact_active_route_when_model_and_provider_overlap() {
+        let routes = vec![
+            model_route("gpt-5.5", "OpenAI", "openai-oauth"),
+            model_route("gpt-5.5", "OpenAI", "openai-api-key"),
+            model_route("gpt-5.5", "Copilot", "copilot"),
+            model_route("qwen3-coder", "llama.cpp", "openai-compatible:llamacpp"),
+        ];
+
+        let filtered = filter_routes_by_provider_allowlist(
+            routes,
+            Some(&["llamacpp".to_string()]),
+            "gpt-5.5",
+            "OpenAI",
+            Some("openai-oauth"),
+        );
+
+        let routes: Vec<(&str, &str, &str)> = filtered
+            .iter()
+            .map(|route| {
+                (
+                    route.model.as_str(),
+                    route.provider.as_str(),
+                    route.api_method.as_str(),
+                )
+            })
+            .collect();
+        assert_eq!(
+            routes,
+            [
+                ("gpt-5.5", "OpenAI", "openai-oauth"),
+                ("qwen3-coder", "llama.cpp", "openai-compatible:llamacpp"),
+            ]
         );
     }
 }

--- a/crates/jcode-tui/src/tui/app/input.rs
+++ b/crates/jcode-tui/src/tui/app/input.rs
@@ -1948,10 +1948,6 @@ pub(super) fn handle_control_key(app: &mut App, code: KeyCode) -> bool {
             app.toggle_input_stash();
             true
         }
-        KeyCode::Char('p') => {
-            super::commands::toggle_auto_poke_hotkey_local(app);
-            true
-        }
         KeyCode::Char('v') => {
             paste_from_clipboard(app);
             true
@@ -2278,6 +2274,10 @@ pub(super) fn handle_pre_control_shortcuts(
 
     let macos_option_shortcut =
         crate::tui::keybind::shortcut_char_for_macos_option_key(code, modifiers);
+    if app.toggle_keys.auto_poke.matches(code, modifiers) {
+        super::commands::toggle_auto_poke_hotkey_local(app);
+        return true;
+    }
     if app.toggle_keys.copy_selection.matches(code, modifiers) {
         app.toggle_copy_selection_mode();
         return true;

--- a/crates/jcode-tui/src/tui/app/model_context.rs
+++ b/crates/jcode-tui/src/tui/app/model_context.rs
@@ -195,7 +195,7 @@ impl App {
 
     /// The api_method string of the route currently in use, used to exclude the
     /// failed route and to recognize same-model/different-method alternatives.
-    fn current_route_api_method(&self) -> Option<String> {
+    pub(super) fn current_route_api_method(&self) -> Option<String> {
         if self.is_remote {
             return self.session.route_api_method.clone();
         }

--- a/crates/jcode-tui/src/tui/app/remote/key_handling.rs
+++ b/crates/jcode-tui/src/tui/app/remote/key_handling.rs
@@ -390,6 +390,42 @@ async fn handle_remote_key_internal(
         return Ok(());
     }
 
+    if app.toggle_keys.auto_poke.matches(code, modifiers) {
+        if app.auto_poke_incomplete_todos {
+            let cleared = app_mod::commands::disable_auto_poke(app);
+            app.set_status_notice("Poke: OFF");
+            app.push_display_message(DisplayMessage::system(
+                app_mod::commands::poke_disabled_message(cleared),
+            ));
+        } else {
+            match app_mod::commands::activate_auto_poke(app) {
+                app_mod::commands::PokeActivation::EnabledNoIncomplete => {
+                    app.push_display_message(DisplayMessage::system(
+                        app_mod::commands::poke_enabled_without_incomplete_message(),
+                    ));
+                }
+                app_mod::commands::PokeActivation::Queued => {
+                    app.push_display_message(DisplayMessage::system(
+                        app_mod::commands::poke_queued_display_message(),
+                    ));
+                }
+                app_mod::commands::PokeActivation::SendNow {
+                    incomplete_count,
+                    poke_msg,
+                } => {
+                    app.push_display_message(DisplayMessage::system(
+                        app_mod::commands::poke_triggered_display_message(incomplete_count),
+                    ));
+
+                    let _ =
+                        begin_remote_send(app, remote, poke_msg, vec![], true, None, true, 0).await;
+                    app.visible_turn_started = Some(Instant::now());
+                }
+            }
+        }
+        return Ok(());
+    }
+
     if app.toggle_keys.side_panel.matches(code, modifiers) {
         app.toggle_side_panel();
         return Ok(());
@@ -698,50 +734,6 @@ async fn handle_remote_key_internal(
             }
             KeyCode::Char('s') => {
                 app.toggle_input_stash();
-                return Ok(());
-            }
-            KeyCode::Char('p') => {
-                if app.auto_poke_incomplete_todos {
-                    let cleared = app_mod::commands::disable_auto_poke(app);
-                    app.set_status_notice("Poke: OFF");
-                    app.push_display_message(DisplayMessage::system(
-                        app_mod::commands::poke_disabled_message(cleared),
-                    ));
-                } else {
-                    match app_mod::commands::activate_auto_poke(app) {
-                        app_mod::commands::PokeActivation::EnabledNoIncomplete => {
-                            app.push_display_message(DisplayMessage::system(
-                                app_mod::commands::poke_enabled_without_incomplete_message(),
-                            ));
-                        }
-                        app_mod::commands::PokeActivation::Queued => {
-                            app.push_display_message(DisplayMessage::system(
-                                app_mod::commands::poke_queued_display_message(),
-                            ));
-                        }
-                        app_mod::commands::PokeActivation::SendNow {
-                            incomplete_count,
-                            poke_msg,
-                        } => {
-                            app.push_display_message(DisplayMessage::system(
-                                app_mod::commands::poke_triggered_display_message(incomplete_count),
-                            ));
-
-                            let _ = begin_remote_send(
-                                app,
-                                remote,
-                                poke_msg,
-                                vec![],
-                                true,
-                                None,
-                                true,
-                                0,
-                            )
-                            .await;
-                            app.visible_turn_started = Some(Instant::now());
-                        }
-                    }
-                }
                 return Ok(());
             }
             KeyCode::Char('v') => {

--- a/crates/jcode-tui/src/tui/app/tui_state.rs
+++ b/crates/jcode-tui/src/tui/app/tui_state.rs
@@ -1593,6 +1593,7 @@ impl crate::tui::TuiState for App {
             swarm_info,
             background_info,
             usage_info,
+            usage_display_used: crate::config::config().display.usage_display_used(),
             tokens_per_second,
             provider_name: if uses_remote_widget_metadata {
                 self.remote_provider_name

--- a/crates/jcode-tui/src/tui/info_widget.rs
+++ b/crates/jcode-tui/src/tui/info_widget.rs
@@ -623,6 +623,8 @@ pub struct InfoWidgetData {
     pub background_info: Option<BackgroundInfo>,
     /// Subscription usage info
     pub usage_info: Option<UsageInfo>,
+    /// Show consumed rather than remaining percentages in usage limits.
+    pub usage_display_used: bool,
     /// Streaming output tokens per second (approximate)
     pub tokens_per_second: Option<f32>,
     /// Active provider name (openrouter/openai/anthropic/...)
@@ -2080,7 +2082,11 @@ fn render_sections(
     if let Some(info) = &data.usage_info
         && info.available
     {
-        lines.extend(render_usage_compact(info, inner.width));
+        lines.extend(render_usage_compact(
+            info,
+            inner.width,
+            data.usage_display_used,
+        ));
     }
 
     if let Some(cache) = data.cache_hit_info.as_ref() {

--- a/crates/jcode-tui/src/tui/info_widget_model.rs
+++ b/crates/jcode-tui/src/tui/info_widget_model.rs
@@ -409,6 +409,7 @@ mod tests {
             swarm_info: None,
             background_info: None,
             usage_info: None,
+            usage_display_used: false,
             tokens_per_second: None,
             provider_name: None,
             auth_method: crate::tui::info_widget::AuthMethod::Unknown,

--- a/crates/jcode-tui/src/tui/info_widget_tests.rs
+++ b/crates/jcode-tui/src/tui/info_widget_tests.rs
@@ -626,7 +626,7 @@ fn cost_based_usage_widgets_show_price_and_tokens() {
     assert!(expanded_text.contains("$0.0123"));
     assert!(expanded_text.contains("12.3K in + 678 out"));
 
-    let compact_text = lines_text(&render_usage_compact(&usage, 40));
+    let compact_text = lines_text(&render_usage_compact(&usage, 40, false));
     assert!(compact_text.contains("$0.0123"));
     assert!(compact_text.contains("12.3K in + 678 out"));
 }

--- a/crates/jcode-tui/src/tui/info_widget_usage.rs
+++ b/crates/jcode-tui/src/tui/info_widget_usage.rs
@@ -73,6 +73,7 @@ pub(super) fn render_usage_widget(data: &InfoWidgetData, inner: Rect) -> Vec<Lin
                     five_hr_left,
                     five_hr_reset.as_deref(),
                     inner.width,
+                    data.usage_display_used,
                 ));
             }
             if let Some(secondary_label) = info.secondary_limit_label.as_deref() {
@@ -82,6 +83,7 @@ pub(super) fn render_usage_widget(data: &InfoWidgetData, inner: Rect) -> Vec<Lin
                     seven_day_left,
                     seven_day_reset.as_deref(),
                     inner.width,
+                    data.usage_display_used,
                 ));
             }
             if let Some(spark_usage) = info.spark {
@@ -97,6 +99,7 @@ pub(super) fn render_usage_widget(data: &InfoWidgetData, inner: Rect) -> Vec<Lin
                     spark_left,
                     spark_reset.as_deref(),
                     inner.width,
+                    data.usage_display_used,
                 ));
             }
             lines
@@ -104,7 +107,11 @@ pub(super) fn render_usage_widget(data: &InfoWidgetData, inner: Rect) -> Vec<Lin
     }
 }
 
-pub(super) fn render_usage_compact(info: &UsageInfo, width: u16) -> Vec<Line<'static>> {
+pub(super) fn render_usage_compact(
+    info: &UsageInfo,
+    width: u16,
+    usage_display_used: bool,
+) -> Vec<Line<'static>> {
     if !info.available {
         return Vec::new();
     }
@@ -151,6 +158,7 @@ pub(super) fn render_usage_compact(info: &UsageInfo, width: u16) -> Vec<Line<'st
             five_hr_left,
             five_hr_reset.as_deref(),
             width,
+            usage_display_used,
         ));
     }
     if let Some(secondary_label) = info.secondary_limit_label.as_deref() {
@@ -160,6 +168,7 @@ pub(super) fn render_usage_compact(info: &UsageInfo, width: u16) -> Vec<Line<'st
             seven_day_left,
             seven_day_reset.as_deref(),
             width,
+            usage_display_used,
         ));
     }
     if let Some(spark_usage) = info.spark {
@@ -175,6 +184,7 @@ pub(super) fn render_usage_compact(info: &UsageInfo, width: u16) -> Vec<Line<'st
             spark_left,
             spark_reset.as_deref(),
             width,
+            usage_display_used,
         ));
     }
     lines
@@ -186,6 +196,7 @@ fn render_labeled_bar(
     left_pct: u8,
     reset_time: Option<&str>,
     width: u16,
+    usage_display_used: bool,
 ) -> Line<'static> {
     let color = if left_pct <= 20 {
         rgb(255, 100, 100)
@@ -198,25 +209,26 @@ fn render_labeled_bar(
     const LABEL_WIDTH: usize = 7;
     const MIN_BAR_WIDTH: usize = 4;
 
+    let (display_pct, display_word) = if usage_display_used {
+        (used_pct, "used")
+    } else {
+        (left_pct, "left")
+    };
+    let percentage_suffix = format!(" {}% {}", display_pct, display_word);
     let full_suffix = match reset_time {
         Some(reset) if left_pct == 0 => format!(" resets {}", reset),
-        Some(reset) => format!(" {}% left · {}", left_pct, reset),
-        None => format!(" {}% left", left_pct),
+        Some(reset) => format!("{} · {}", percentage_suffix, reset),
+        None => percentage_suffix.clone(),
     };
-    // On narrow widgets keep the reset visible and progressively shorten the
-    // percentage wording before sacrificing the bar. The exhausted wording is
-    // already compact and remains unchanged.
+    // On narrow widgets keep the percentage wording unambiguous, dropping the
+    // reset countdown before sacrificing the bar. Exhausted wording is unchanged.
     let suffix = match reset_time {
-        Some(reset) if left_pct > 0 => {
-            let compact = format!(" {}% · {}", left_pct, reset);
-            let reset_only = format!(" · {}", reset);
+        Some(_) if left_pct > 0 => {
             let budget = usize::from(width).saturating_sub(LABEL_WIDTH + MIN_BAR_WIDTH);
             if UnicodeWidthStr::width(full_suffix.as_str()) <= budget {
                 full_suffix
-            } else if UnicodeWidthStr::width(compact.as_str()) <= budget {
-                compact
             } else {
-                reset_only
+                percentage_suffix
             }
         }
         _ => full_suffix,
@@ -257,27 +269,54 @@ mod tests {
 
     #[test]
     fn usage_bar_shows_reset_countdown_before_exhaustion() {
-        let text = line_text(&render_labeled_bar("5-hour", 38, 62, Some("4h 5m"), 40));
+        let text = line_text(&render_labeled_bar(
+            "5-hour",
+            38,
+            62,
+            Some("4h 5m"),
+            40,
+            false,
+        ));
 
         assert!(text.contains("62% left · 4h 5m"));
         assert!(UnicodeWidthStr::width(text.as_str()) <= 40);
     }
 
     #[test]
-    fn usage_bar_keeps_countdown_within_narrow_width() {
-        let text = line_text(&render_labeled_bar("Weekly", 19, 81, Some("1d 4h"), 23));
+    fn usage_bar_keeps_wording_unambiguous_within_narrow_width() {
+        let text = line_text(&render_labeled_bar(
+            "Weekly",
+            19,
+            81,
+            Some("1d 4h"),
+            23,
+            true,
+        ));
 
-        assert!(text.contains("81% · 1d 4h"));
+        assert!(text.contains("19% used"));
+        assert!(!text.contains("1d 4h"));
         assert!(UnicodeWidthStr::width(text.as_str()) <= 23);
         assert!(text.contains('▰') || text.contains('▱'));
     }
 
     #[test]
+    fn used_wording_does_not_change_remaining_budget_color_thresholds() {
+        let left = render_labeled_bar("5-hour", 85, 15, None, 24, false);
+        let used = render_labeled_bar("5-hour", 85, 15, None, 24, true);
+
+        assert!(line_text(&left).contains("15% left"));
+        assert!(line_text(&used).contains("85% used"));
+        assert_eq!(left.spans[1].style.fg, Some(rgb(255, 100, 100)));
+        assert_eq!(used.spans[1].style.fg, left.spans[1].style.fg);
+    }
+
+    #[test]
     fn exhausted_usage_bar_preserves_resets_wording_and_width() {
-        let text = line_text(&render_labeled_bar("5-hour", 100, 0, Some("12m"), 24));
+        let text = line_text(&render_labeled_bar("5-hour", 100, 0, Some("12m"), 24, true));
 
         assert!(text.contains("resets 12m"));
         assert!(!text.contains("0% left"));
+        assert!(!text.contains("100% used"));
         assert!(UnicodeWidthStr::width(text.as_str()) <= 24);
     }
 
@@ -291,7 +330,7 @@ mod tests {
             ..Default::default()
         };
 
-        let lines = render_usage_compact(&info, 40);
+        let lines = render_usage_compact(&info, 40, false);
         let text = lines.iter().map(line_text).collect::<Vec<_>>().join("\n");
 
         assert!(text.contains("Monthly"));

--- a/crates/jcode-tui/src/tui/keybind.rs
+++ b/crates/jcode-tui/src/tui/keybind.rs
@@ -376,6 +376,7 @@ impl ToggleBinding {
 /// All configurable pane / mode toggle keybindings.
 #[derive(Clone, Debug)]
 pub struct ToggleKeys {
+    pub auto_poke: ToggleBinding,
     pub side_panel: ToggleBinding,
     pub copy_selection: ToggleBinding,
     pub diagram_pane: ToggleBinding,
@@ -389,6 +390,13 @@ pub struct ToggleKeys {
 pub fn load_toggle_keys() -> ToggleKeys {
     let cfg = config();
     ToggleKeys {
+        auto_poke: ToggleBinding::load_with_default(
+            &cfg.keybindings.auto_poke_toggle,
+            KeyBinding {
+                code: KeyCode::Char('p'),
+                modifiers: KeyModifiers::CONTROL,
+            },
+        ),
         side_panel: ToggleBinding::load(&cfg.keybindings.side_panel_toggle, 'm'),
         copy_selection: ToggleBinding::load(&cfg.keybindings.copy_selection_toggle, 'y'),
         diagram_pane: ToggleBinding::load(&cfg.keybindings.diagram_pane_toggle, 't'),
@@ -614,6 +622,21 @@ pub fn load_open_resume_key() -> OptionalBinding {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn auto_poke_toggle_can_be_remapped_or_disabled() {
+        let default = KeyBinding {
+            code: KeyCode::Char('p'),
+            modifiers: KeyModifiers::CONTROL,
+        };
+        let remapped = ToggleBinding::load_with_default("alt+p", default.clone());
+        assert!(remapped.matches(KeyCode::Char('p'), KeyModifiers::ALT));
+        assert!(!remapped.matches(KeyCode::Char('p'), KeyModifiers::CONTROL));
+
+        let disabled = ToggleBinding::load_with_default("", default);
+        assert!(disabled.binding().is_none());
+        assert!(!disabled.matches(KeyCode::Char('p'), KeyModifiers::CONTROL));
+    }
 
     #[test]
     fn new_terminal_alt_enter_binding_parses_and_matches() {


### PR DESCRIPTION
## Summary
- report malformed `SKILL.md` parse failures instead of silently skipping them
- let users opt out of importing Claude MCP sources
- isolate model-picker allowlists by exact active route
- add configurable usage percentage wording
- add a configurable/disableable auto-poke toggle key

## Verification
- `cargo fmt --all -- --check` passed
- focused regression tests for each change passed in worker runs
- integrated `jcode-base --lib`: 1312 passed; one unrelated existing `grok-build` lifecycle-normalization test failed
- broad `jcode-tui --lib` reached the changed tests but stalled in unrelated long-running app tests; the focused TUI rerun was blocked by the host-wide Cargo gate

Fixes #952
Fixes #947
Fixes #946
Fixes #945
Fixes #944

--- *— Jcode agent (automated triage), on behalf of @1jehuang*