### PR TITLE
fix: address safe provider and documentation triage items

### DIFF
--- a/crates/jcode-base/src/provider_catalog.rs
+++ b/crates/jcode-base/src/provider_catalog.rs
@@ -45,6 +45,16 @@ pub fn resolve_openai_compatible_profile_with_api_key_hint(
         requires_api_key: profile.requires_api_key,
     };
 
+    // MiniMax historically used OPENAI_API_KEY because it exposes an
+    // OpenAI-compatible API. Prefer the dedicated key, but keep existing
+    // installations working when only the legacy binding is configured.
+    if profile.id == MINIMAX_PROFILE.id
+        && load_env_value_from_env_or_config(profile.api_key_env, profile.env_file).is_none()
+        && load_env_value_from_env_or_config("OPENAI_API_KEY", profile.env_file).is_some()
+    {
+        resolved.api_key_env = "OPENAI_API_KEY".to_string();
+    }
+
     apply_profile_key_based_endpoint_overrides(profile, &mut resolved, api_key_hint);
 
     if profile.id != OPENAI_COMPAT_PROFILE.id {
@@ -222,7 +232,7 @@ fn apply_profile_key_based_endpoint_overrides(
         .map(str::trim)
         .filter(|key| !key.is_empty())
         .map(ToString::to_string)
-        .or_else(|| load_env_value_from_env_or_config(profile.api_key_env, profile.env_file));
+        .or_else(|| load_env_value_from_env_or_config(&resolved.api_key_env, &resolved.env_file));
 
     if key
         .as_deref()

--- a/crates/jcode-base/src/provider_catalog_tests.rs
+++ b/crates/jcode-base/src/provider_catalog_tests.rs
@@ -196,7 +196,9 @@ fn resolved_named_profile_skips_non_chat_models_when_picking_newest_default() {
 #[test]
 fn minimax_token_plan_keys_resolve_to_china_endpoint_without_changing_international_default() {
     let _lock = crate::storage::lock_test_env();
-    let _guard = EnvGuard::save(&["MINIMAX_API_KEY", "OPENAI_API_KEY"]);
+    let _guard = EnvGuard::save(&["JCODE_HOME", "MINIMAX_API_KEY", "OPENAI_API_KEY"]);
+    let home = tempfile::tempdir().expect("temporary JCODE_HOME");
+    crate::env::set_var("JCODE_HOME", home.path());
     crate::env::remove_var("MINIMAX_API_KEY");
     crate::env::remove_var("OPENAI_API_KEY");
 
@@ -213,6 +215,11 @@ fn minimax_token_plan_keys_resolve_to_china_endpoint_without_changing_internatio
     );
     assert_eq!(china.api_base, MINIMAX_CHINA_API_BASE);
     assert_eq!(china.setup_url, MINIMAX_CHINA_SETUP_URL);
+
+    crate::env::set_var("OPENAI_API_KEY", "sk-cp-legacy-token");
+    let legacy = resolve_openai_compatible_profile(MINIMAX_PROFILE);
+    assert_eq!(legacy.api_key_env, "OPENAI_API_KEY");
+    assert_eq!(legacy.api_base, MINIMAX_CHINA_API_BASE);
 }
 
 #[test]

--- a/crates/jcode-base/src/provider_catalog_tests.rs
+++ b/crates/jcode-base/src/provider_catalog_tests.rs
@@ -92,7 +92,7 @@ fn auth_issue_profile_metadata_matches_direct_provider_endpoints() {
     assert_eq!(DEEPSEEK_PROFILE.default_model, Some("deepseek-v4-flash"));
     assert_eq!(DEEPSEEK_PROFILE.setup_url, "https://api-docs.deepseek.com/");
     assert_eq!(MINIMAX_PROFILE.api_base, "https://api.minimax.io/v1");
-    assert_eq!(MINIMAX_PROFILE.api_key_env, "OPENAI_API_KEY");
+    assert_eq!(MINIMAX_PROFILE.api_key_env, "MINIMAX_API_KEY");
     assert_eq!(
         ALIBABA_CODING_PLAN_PROFILE.api_base,
         "https://coding-intl.dashscope.aliyuncs.com/v1"

--- a/crates/jcode-base/src/provider_catalog_tests.rs
+++ b/crates/jcode-base/src/provider_catalog_tests.rs
@@ -196,7 +196,8 @@ fn resolved_named_profile_skips_non_chat_models_when_picking_newest_default() {
 #[test]
 fn minimax_token_plan_keys_resolve_to_china_endpoint_without_changing_international_default() {
     let _lock = crate::storage::lock_test_env();
-    let _guard = EnvGuard::save(&["OPENAI_API_KEY"]);
+    let _guard = EnvGuard::save(&["MINIMAX_API_KEY", "OPENAI_API_KEY"]);
+    crate::env::remove_var("MINIMAX_API_KEY");
     crate::env::remove_var("OPENAI_API_KEY");
 
     let international = resolve_openai_compatible_profile(MINIMAX_PROFILE);
@@ -1144,7 +1145,7 @@ fn open_weight_family_context_limits_match_published_windows() {
 fn minimax_default_provider_applies_minimax_api_key_env_not_openrouter() {
     // Regression for #407: `default_provider = "minimax"` (the built-in MiniMax
     // profile) must resolve credentials from the profile's documented
-    // OPENAI_API_KEY / minimax.env, not the generic OPENROUTER_API_KEY /
+    // MINIMAX_API_KEY / minimax.env, not the generic OPENROUTER_API_KEY /
     // openrouter.env. The earlier bug surfaced as
     // "OPENROUTER_API_KEY not found ..." when applying the configured
     // default_model.

--- a/crates/jcode-base/src/provider_catalog_tests.rs
+++ b/crates/jcode-base/src/provider_catalog_tests.rs
@@ -1141,7 +1141,7 @@ fn open_weight_family_context_limits_match_published_windows() {
 }
 
 #[test]
-fn minimax_default_provider_applies_openai_api_key_env_not_openrouter() {
+fn minimax_default_provider_applies_minimax_api_key_env_not_openrouter() {
     // Regression for #407: `default_provider = "minimax"` (the built-in MiniMax
     // profile) must resolve credentials from the profile's documented
     // OPENAI_API_KEY / minimax.env, not the generic OPENROUTER_API_KEY /
@@ -1181,8 +1181,8 @@ fn minimax_default_provider_applies_openai_api_key_env_not_openrouter() {
         std::env::var("JCODE_OPENROUTER_API_KEY_NAME")
             .ok()
             .as_deref(),
-        Some("OPENAI_API_KEY"),
-        "MiniMax profile must use OPENAI_API_KEY, not OPENROUTER_API_KEY"
+        Some("MINIMAX_API_KEY"),
+        "MiniMax profile must use MINIMAX_API_KEY, not OPENROUTER_API_KEY"
     );
     assert_eq!(
         std::env::var("JCODE_OPENROUTER_ENV_FILE").ok().as_deref(),

--- a/crates/jcode-provider-metadata/src/catalog.rs
+++ b/crates/jcode-provider-metadata/src/catalog.rs
@@ -320,7 +320,7 @@ pub const MINIMAX_PROFILE: OpenAiCompatibleProfile = OpenAiCompatibleProfile {
     id: "minimax",
     display_name: "MiniMax",
     api_base: "https://api.minimax.io/v1",
-    api_key_env: "OPENAI_API_KEY",
+    api_key_env: "MINIMAX_API_KEY",
     env_file: "minimax.env",
     setup_url: "https://platform.minimax.io/docs/guides/text-generation",
     default_model: Some("MiniMax-M2.7"),

--- a/crates/jcode-provider-metadata/src/lib.rs
+++ b/crates/jcode-provider-metadata/src/lib.rs
@@ -450,7 +450,7 @@ mod tests {
     #[test]
     fn minimax_profile_uses_official_openai_compatible_configuration() {
         assert_eq!(MINIMAX_PROFILE.api_base, "https://api.minimax.io/v1");
-        assert_eq!(MINIMAX_PROFILE.api_key_env, "OPENAI_API_KEY");
+        assert_eq!(MINIMAX_PROFILE.api_key_env, "MINIMAX_API_KEY");
     }
 
     #[test]

--- a/docs/AMBIENT_MODE.md
+++ b/docs/AMBIENT_MODE.md
@@ -5,6 +5,10 @@
 >
 > Ambient mode is disabled by default. Enable it with `[ambient] enabled = true`
 > and configure an available subscription or API provider before use.
+>
+> The core ambient runner is implemented. Later sections also retain forward-looking
+> design ideas; examples such as cold-start gating, warm-up bypass, and per-project
+> policy fields are not all available configuration options yet.
 
 A proactive, always-on agent mode that works autonomously without user prompting. Like a brain consolidating memories during sleep, ambient mode tends to the memory graph, identifies useful work, and acts on the user's behalf — all while staying within resource limits.
 

--- a/docs/AMBIENT_MODE.md
+++ b/docs/AMBIENT_MODE.md
@@ -1,7 +1,10 @@
 # Ambient Mode
 
-> **Status:** Design
-> **Updated:** 2026-02-08
+> **Status:** Implemented
+> **Updated:** 2026-08-16
+>
+> Ambient mode is disabled by default. Enable it with `[ambient] enabled = true`
+> and configure an available subscription or API provider before use.
 
 A proactive, always-on agent mode that works autonomously without user prompting. Like a brain consolidating memories during sleep, ambient mode tends to the memory graph, identifies useful work, and acts on the user's behalf — all while staying within resource limits.
 
@@ -919,48 +922,14 @@ This is a distributed systems problem that will be addressed once ambient is sta
 
 ---
 
-## Implementation Phases
+## Implementation Status
 
-### Phase 1: Foundation
-- [ ] Ambient agent loop (spawn, run, sleep)
-- [ ] Single-instance guard
-- [ ] Basic scheduling (fixed interval with max ceiling)
-- [ ] Provider selection chain (OpenAI OAuth → Anthropic OAuth → pay-per-token opt-in → disabled)
-- [ ] Configuration (`[ambient]` section in config)
-- [ ] Storage layout
-
-### Phase 2: Memory Consolidation — Garden
-- [ ] Full graph-wide dedup scan
-- [ ] Fact verification against codebase
-- [ ] Retroactive session extraction (crashed/missed sessions)
-- [ ] Pruning dead memories (low confidence + low strength)
-- [ ] Relationship discovery across sessions
-- [ ] Embedding backfill
-- [ ] Contradiction resolution
-
-### Phase 3: Scheduling
-- [ ] `schedule_ambient` tool for agent self-scheduling
-- [ ] Scheduled queue (persistent, with context)
-- [ ] Adaptive resource calculator
-- [ ] Usage history tracking
-- [ ] Rate limit awareness (from provider response headers)
-- [ ] Event triggers (session close, crash, git push)
-- [ ] Active session detection → pause/throttle
-
-### Phase 4: Proactive Work
-- [ ] Scout: analyze recent sessions + git history
-- [ ] Infer user priorities from memories
-- [ ] Identify actionable work
-- [ ] Execute on separate branch
-- [ ] Report results
-
-### Phase 5: Info Widget
-- [ ] Ambient status display in TUI
-- [ ] Queue preview
-- [ ] Last cycle summary
-- [ ] Next wake estimate
-- [ ] Budget bar (user vs ambient vs remaining)
+Ambient mode is shipped. The runtime loop, persistent scheduling, memory garden,
+proactive work flow, channel integration, configuration, tools, and TUI status
+display are implemented. The source of truth for current behavior is
+`crates/jcode-app-core/src/ambient/`; remaining enhancements are tracked as
+GitHub issues rather than in the original design checklist.
 
 ---
 
-*Last updated: 2026-02-08*
+*Last updated: 2026-08-16*


### PR DESCRIPTION
## Summary
- use `MINIMAX_API_KEY` for the built-in MiniMax provider, matching the documented configuration
- update both MiniMax metadata regression assertions
- mark ambient mode as implemented, note that it is disabled by default, and replace the stale design checklist

## Verification
- `cargo test -p jcode-provider-metadata minimax_profile_uses_official_openai_compatible_configuration`
- `cargo test -p jcode-base --lib auth_issue_profile_metadata_matches_direct_provider_endpoints`
- `git diff --check`

Fixes #969
Fixes #965

--- *— Jcode agent (automated triage), on behalf of @1jehuang*