### PR TITLE
fix: update Claude OAuth client version

### DIFF
--- a/crates/jcode-base/src/auth/oauth.rs
+++ b/crates/jcode-base/src/auth/oauth.rs
@@ -957,7 +957,10 @@ async fn fetch_claude_profile_email_at_url(
     let resp = client
         .get(profile_url)
         .header("Accept", "application/json")
-        .header("User-Agent", "claude-cli/1.0.0")
+        .header(
+            "User-Agent",
+            crate::provider::anthropic::CLAUDE_CLI_USER_AGENT,
+        )
         .header("anthropic-beta", "oauth-2025-04-20,claude-code-20250219")
         .bearer_auth(access_token)
         .send()

--- a/crates/jcode-base/src/provider/anthropic.rs
+++ b/crates/jcode-base/src/provider/anthropic.rs
@@ -36,7 +36,7 @@ pub fn is_cache_ttl_1h() -> bool {
 }
 
 /// User-Agent for OAuth requests, matching the official Claude Code CLI.
-pub const CLAUDE_CLI_USER_AGENT: &str = "claude-cli/2.1.123 (external, sdk-cli)";
+pub const CLAUDE_CLI_USER_AGENT: &str = "claude-cli/2.1.257 (external, sdk-cli)";
 
 pub const OAUTH_BETA_HEADERS: &str = ANTHROPIC_OAUTH_BETA_HEADERS;
 

--- a/crates/jcode-base/src/sidecar.rs
+++ b/crates/jcode-base/src/sidecar.rs
@@ -35,9 +35,6 @@ const CLAUDE_API_URL: &str = "https://api.anthropic.com/v1/messages?beta=true";
 /// Claude Messages API endpoint for direct API-key access (no OAuth beta flag).
 const CLAUDE_API_KEY_URL: &str = "https://api.anthropic.com/v1/messages";
 
-/// User-Agent for OAuth requests (must match Claude CLI format)
-const CLAUDE_CLI_USER_AGENT: &str = "claude-cli/1.0.0";
-
 /// Beta headers required for OAuth
 const OAUTH_BETA_HEADERS: &str = "oauth-2025-04-20,claude-code-20250219";
 
@@ -552,7 +549,10 @@ impl Sidecar {
             self.client
                 .post(CLAUDE_API_URL)
                 .header("Authorization", format!("Bearer {}", creds.access_token))
-                .header("User-Agent", CLAUDE_CLI_USER_AGENT)
+                .header(
+                    "User-Agent",
+                    crate::provider::anthropic::CLAUDE_CLI_USER_AGENT,
+                )
                 .header("anthropic-version", "2023-06-01")
                 .header("anthropic-beta", OAUTH_BETA_HEADERS)
                 .header("content-type", "application/json")

--- a/crates/jcode-provider-anthropic-runtime/src/lib.rs
+++ b/crates/jcode-provider-anthropic-runtime/src/lib.rs
@@ -413,7 +413,7 @@ async fn ensure_oauth_preflight(
             rate_limit_tier: "default_claude_ai".to_string(),
             first_token_time: 1_740_976_801_491,
             email: email_address,
-            app_version: "2.1.123".to_string(),
+            app_version: "2.1.257".to_string(),
         },
         forced_variations: Default::default(),
         forced_features: Vec::new(),

--- a/crates/jcode-provider-anthropic/src/lib.rs
+++ b/crates/jcode-provider-anthropic/src/lib.rs
@@ -7,7 +7,7 @@ use serde_json::{Value, json};
 
 /// Claude Code billing attribution text observed in the official CLI's system
 /// prompt blocks.
-pub const OAUTH_BILLING_HEADER: &str = "cc_version=2.1.123; cc_entrypoint=sdk-cli; cch=33f85;";
+pub const OAUTH_BILLING_HEADER: &str = "cc_version=2.1.257; cc_entrypoint=sdk-cli; cch=33f85;";
 
 const CLAUDE_CODE_IDENTITY: &str = "You are a Claude agent, built on Anthropic's Claude Agent SDK.";
 


### PR DESCRIPTION
## Summary
- update all three Claude OAuth client-version identities from 2.1.123 to 2.1.257
- restore compatibility with Anthropic's server-side minimum-version gate

## Verification
- `cargo check -p jcode-base -p jcode-provider-anthropic -p jcode-provider-anthropic-runtime`
- confirmed no Rust source retains `2.1.123` and all three identity sites use `2.1.257`

Fixes #1134

--- *— Jcode agent (automated triage), on behalf of @1jehuang*