### PR TITLE
fix: isolate git info cache in tests

### DIFF
--- a/crates/jcode-tui/src/tui/app/helpers.rs
+++ b/crates/jcode-tui/src/tui/app/helpers.rs
@@ -1071,6 +1071,15 @@ pub(super) fn encode_rgba_as_png(width: usize, height: usize, rgba: &[u8]) -> Op
     Some(buf)
 }
 
+#[cfg(test)]
+pub(super) fn gather_git_info() -> Option<GitInfo> {
+    GIT_INFO_CACHE
+        .lock()
+        .ok()
+        .and_then(|guard| guard.as_ref().and_then(|(_, cached, _)| cached.clone()))
+}
+
+#[cfg(not(test))]
 pub(super) fn gather_git_info() -> Option<GitInfo> {
     use std::time::Instant;
 
@@ -1311,6 +1320,7 @@ pub(crate) fn format_countdown_until(target: chrono::DateTime<chrono::Utc>) -> S
     }
 }
 
+#[cfg(not(test))]
 fn gather_git_info_inner() -> Option<GitInfo> {
     use std::process::Command;
 


### PR DESCRIPTION
## Summary
- prevent test binaries from spawning the live background Git probe
- make tests read only explicitly seeded Git-info cache data
- leave production stale-while-revalidate behavior unchanged

## Verification
- `cargo check -p jcode-tui`
- `cargo test -p jcode-tui --lib -- --exact --test-threads=1 tui::app::tests::test_background_task_markdown_is_suppressed_even_if_role_was_lost`

Fixes #1133

--- *— Jcode agent (automated triage), on behalf of @1jehuang*