### PR TITLE
fix: preserve macOS Ctrl+5 prompt jump

### DIFF
--- a/crates/jcode-tui/src/tui/app/helpers.rs
+++ b/crates/jcode-tui/src/tui/app/helpers.rs
@@ -214,15 +214,8 @@ pub(super) fn ctrl_bracket_fallback_to_esc(code: &mut KeyCode, modifiers: &mut K
     if !modifiers.contains(KeyModifiers::CONTROL) {
         return;
     }
-    match code {
-        KeyCode::Esc => {
-            *code = KeyCode::Char('[');
-        }
-        KeyCode::Char('5') => {
-            // Legacy tty mapping for Ctrl+]
-            *code = KeyCode::Char(']');
-        }
-        _ => {}
+    if *code == KeyCode::Esc {
+        *code = KeyCode::Char('[');
     }
 }
 


### PR DESCRIPTION
## Summary
- stop rewriting macOS `Ctrl+5` into the legacy `Ctrl+]` alias
- preserve the documented fifth-most-recent prompt jump
- retain the unambiguous `Esc` to `Ctrl+[` fallback

## Verification
- `cargo test -p jcode-tui --lib prompt_jump_ctrl_digit` (2 passed)
- `cargo check -p jcode-tui`

The affected rewrite is macOS-only, so final platform behavior remains subject to macOS CI/review validation.

Fixes #1131

--- *— Jcode agent (automated triage), on behalf of @1jehuang*