### PR TITLE
fix: isolate sandboxed homes from macOS Keychain

### DIFF
--- a/crates/jcode-base/src/auth/claude.rs
+++ b/crates/jcode-base/src/auth/claude.rs
@@ -788,6 +788,9 @@ pub fn native_credentials_present() -> bool {
     {
         return true;
     }
+    if crate::storage::running_with_sandboxed_home() {
+        return false;
+    }
     claude_code_keychain_item_exists()
 }
 

--- a/crates/jcode-base/src/auth/claude_tests.rs
+++ b/crates/jcode-base/src/auth/claude_tests.rs
@@ -82,6 +82,30 @@ fn jcode_path_respects_jcode_home() {
 }
 
 #[test]
+fn sandboxed_jcode_home_is_detected_without_hiding_explicit_env_credentials() {
+    let _lock = crate::storage::lock_test_env();
+    let temp = tempfile::TempDir::new().unwrap();
+    let _home = EnvVarGuard::set("JCODE_HOME", temp.path());
+
+    assert!(crate::storage::running_with_sandboxed_home());
+
+    let _token = EnvVarGuard::set(
+        CLAUDE_CODE_OAUTH_TOKEN_ENV,
+        std::path::Path::new("test-token"),
+    );
+    assert!(native_credentials_present());
+}
+
+#[test]
+fn real_jcode_home_is_not_treated_as_a_sandbox() {
+    let _lock = crate::storage::lock_test_env();
+    let real_home = dirs::home_dir().unwrap().join(".jcode");
+    let _home = EnvVarGuard::set("JCODE_HOME", &real_home);
+
+    assert!(!crate::storage::running_with_sandboxed_home());
+}
+
+#[test]
 fn load_auth_file_renames_existing_labels_to_animal_scheme() {
     let _lock = crate::storage::lock_test_env();
     let temp = tempfile::TempDir::new().unwrap();

--- a/crates/jcode-storage/src/lib.rs
+++ b/crates/jcode-storage/src/lib.rs
@@ -156,6 +156,25 @@ pub fn jcode_dir() -> Result<PathBuf> {
     Ok(home.join(".jcode"))
 }
 
+/// Whether `JCODE_HOME` redirects this process away from the user's real
+/// `~/.jcode` directory.
+///
+/// Sandboxed runs must not consult machine-global resources, such as the macOS
+/// Keychain, that cannot be redirected beneath `JCODE_HOME`.
+pub fn running_with_sandboxed_home() -> bool {
+    let Some(configured) = std::env::var_os("JCODE_HOME").map(PathBuf::from) else {
+        return false;
+    };
+    let Some(default) = dirs::home_dir().map(|home| home.join(".jcode")) else {
+        return true;
+    };
+
+    match (configured.canonicalize(), default.canonicalize()) {
+        (Ok(configured), Ok(default)) => configured != default,
+        _ => configured != default,
+    }
+}
+
 pub fn logs_dir() -> Result<PathBuf> {
     Ok(jcode_dir()?.join("logs"))
 }


### PR DESCRIPTION
## Summary
- detect when `JCODE_HOME` redirects away from the real `~/.jcode`
- skip ambient macOS Keychain discovery in sandboxed runs
- continue honoring an explicitly supplied `CLAUDE_CODE_OAUTH_TOKEN`

## Verification
- sandbox detection and real-home control tests pass
- explicit env-token precedence test passes
- reported `login_openai_phase_is_default_when_no_imports` onboarding regression passes
- `jcode-storage`, `jcode-base`, `jcode-app-core`, and `jcode-tui` check successfully

Fixes #1132

--- *— Jcode agent (automated triage), on behalf of @1jehuang*