### PR TITLE
fix: accept disabled failover aliases

### DIFF
--- a/crates/jcode-base/src/config_tests.rs
+++ b/crates/jcode-base/src/config_tests.rs
@@ -840,6 +840,24 @@ fn test_provider_failover_defaults_match_new_behavior() {
 }
 
 #[test]
+fn test_provider_failover_disabled_aliases_parse_as_manual() {
+    for value in ["off", "false", "disabled", "none"] {
+        let cfg: Config = toml::from_str(&format!(
+            "[provider]\ncross_provider_failover = \"{value}\"\n"
+        ))
+        .unwrap_or_else(|error| panic!("{value} should parse: {error}"));
+        assert_eq!(
+            cfg.provider.cross_provider_failover,
+            super::CrossProviderFailoverMode::Manual
+        );
+        assert_eq!(
+            super::CrossProviderFailoverMode::parse(value),
+            Some(super::CrossProviderFailoverMode::Manual)
+        );
+    }
+}
+
+#[test]
 fn test_native_scrollbars_default_to_enabled() {
     let display = DisplayConfig::default();
     assert!(display.native_scrollbars.chat);

--- a/crates/jcode-config-types/src/lib.rs
+++ b/crates/jcode-config-types/src/lib.rs
@@ -327,6 +327,7 @@ pub enum CrossProviderFailoverMode {
     #[default]
     Countdown,
     /// Do not resend the prompt to another provider automatically.
+    #[serde(alias = "off", alias = "false", alias = "disabled", alias = "none")]
     Manual,
 }
 
@@ -340,7 +341,7 @@ impl CrossProviderFailoverMode {
 
     pub fn parse(value: &str) -> Option<Self> {
         match value.trim().to_ascii_lowercase().as_str() {
-            "manual" => Some(Self::Manual),
+            "manual" | "off" | "false" | "disabled" | "none" => Some(Self::Manual),
             "countdown" | "auto" | "automatic" => Some(Self::Countdown),
             _ => None,
         }


### PR DESCRIPTION
## Summary
- accept `off`, `false`, `disabled`, and `none` as aliases for manual cross-provider failover
- keep the existing countdown default and serialization unchanged
- cover both TOML deserialization and the environment-value parser

## Verification
- alias regression test passes for all four values
- default-behavior regression test passes
- `jcode-config-types` and `jcode-base` check successfully

Fixes #1101

--- *— Jcode agent (automated triage), on behalf of @1jehuang*