### PR TITLE
feat(anthropic): add claude-fable-5-1 to the direct Anthropic catalog

### DIFF
--- a/crates/jcode-base/src/provider/anthropic.rs
+++ b/crates/jcode-base/src/provider/anthropic.rs
@@ -72,6 +72,7 @@ pub fn apply_oauth_attribution_headers(
 /// Available models
 pub const AVAILABLE_MODELS: &[&str] = &[
     "claude-opus-5",
+    "claude-fable-5-1",
     "claude-fable-5",
     "claude-opus-4-8",
     "claude-opus-4-6",

--- a/crates/jcode-provider-core/src/anthropic.rs
+++ b/crates/jcode-provider-core/src/anthropic.rs
@@ -167,6 +167,7 @@ pub fn anthropic_max_output_tokens(model: &str) -> u32 {
         "claude-sonnet-5",
         "claude-sonnet-4-6",
         "claude-sonnet-4.6",
+        "claude-fable-5-1",
         "claude-fable-5",
         "claude-fable",
         "claude-mythos",
@@ -466,6 +467,7 @@ mod tests {
         // Full ladder: Fable 5 (live 2026-07-01), Sonnet 5 (live 2026-07-07),
         // Opus 5 (live 2026-07-24), Opus 4.7/4.8.
         for model in [
+            "claude-fable-5-1",
             "claude-fable-5",
             "claude-sonnet-5",
             "claude-opus-5",

--- a/crates/jcode-provider-core/src/models.rs
+++ b/crates/jcode-provider-core/src/models.rs
@@ -8,10 +8,11 @@ pub const DEFAULT_OPENAI_MODEL: &str = "gpt-5.6-sol";
 ///
 /// NOTE: The Mythos preview family was retired by Anthropic and 404s, so it is
 /// intentionally NOT listed here. `claude-fable-5` was briefly retired but is
-/// live again. The list is curated best-first; position 0 is the flagship
+/// live again. `claude-fable-5-1` went live 2026-08-28. The list is curated best-first; position 0 is the flagship
 /// used for post-login default selection.
 pub const ALL_CLAUDE_MODELS: &[&str] = &[
     DEFAULT_CLAUDE_MODEL,
+    "claude-fable-5-1",
     "claude-fable-5",
     "claude-opus-4-8",
     "claude-opus-4-6",

--- a/crates/jcode-provider-core/src/pricing.rs
+++ b/crates/jcode-provider-core/src/pricing.rs
@@ -68,6 +68,7 @@ pub fn anthropic_api_pricing_with_tier(
     }
 
     match base {
+        "claude-fable-5-1" => exact(10.0, 50.0, 0.25, "Anthropic API pricing"),
         "claude-fable-5" => exact(10.0, 50.0, 1.0, "Anthropic API pricing"),
         "claude-opus-5" | "claude-opus-4-8" | "claude-opus-4-7" | "claude-opus-4-6"
         | "claude-opus-4-5" => exact(5.0, 25.0, 0.5, "Anthropic API pricing"),
@@ -319,6 +320,11 @@ mod tests {
         assert_eq!(fable.input_price_per_mtok_micros, Some(10_000_000));
         assert_eq!(fable.output_price_per_mtok_micros, Some(50_000_000));
         assert_eq!(fable.cache_read_price_per_mtok_micros, Some(1_000_000));
+
+        let fable_51 = anthropic_api_pricing("claude-fable-5-1").expect("priced model");
+        assert_eq!(fable_51.input_price_per_mtok_micros, Some(10_000_000));
+        assert_eq!(fable_51.output_price_per_mtok_micros, Some(50_000_000));
+        assert_eq!(fable_51.cache_read_price_per_mtok_micros, Some(250_000));
 
         let sonnet = anthropic_api_pricing("claude-sonnet-4-6").expect("priced model");
         assert_eq!(sonnet.input_price_per_mtok_micros, Some(3_000_000));


### PR DESCRIPTION
Anthropic released `claude-fable-5-1` on 2026-08-28. Without a catalog entry, `jcode -m claude-fable-5-1` on a fresh home (no cached live catalog) fails `set_model`, the error is only logged (`agent.rs` attach path), and the session silently runs on the default `claude-opus-5`. Found while pinning a jcode build for the Fable 5.1 jcode-bench campaign: the v0.81.4 release ran Opus 5 when asked for Fable 5.1.

Changes:
- `ALL_CLAUDE_MODELS` / `AVAILABLE_MODELS`: add `claude-fable-5-1` after Opus 5
- 128K max-output prefix list: explicit entry
- Anthropic API pricing: $10/$50, $0.25 cache read (per models.dev)
- Tests: pricing, reasoning caps ladder

Scope is deliberately the direct Anthropic route only. The hosted subscription catalog and Conifer profile are not touched since server-side support is unverified.

Verified: `jcode -p anthropic-api -m claude-fable-5-1 run --ndjson` on a fresh HOME now reports `model: claude-fable-5-1` in start/done events at low and max effort. `jcode-provider-core` suite passes; `jcode-base` has the same 15 environment-dependent failures as untouched master.