### PR TITLE
fix: send x-opencode-session header to OpenCode endpoints (fixes #1167)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3838,6 +3838,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "toml",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/jcode-provider-openrouter-runtime/Cargo.toml
+++ b/crates/jcode-provider-openrouter-runtime/Cargo.toml
@@ -26,6 +26,7 @@ serde_json = { version = "1", features = ["raw_value"] }
 bytes = "1"
 tokio = { version = "1", features = ["sync", "time", "rt"] }
 tokio-stream = "0.1"
+uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]
 # The migrated openrouter tests use jcode-base's test-env sandbox.

--- a/crates/jcode-provider-openrouter-runtime/src/lib.rs
+++ b/crates/jcode-provider-openrouter-runtime/src/lib.rs
@@ -430,6 +430,37 @@ fn apply_kimi_coding_agent_headers(
     }
 }
 
+/// Hosts that require the `x-opencode-session` header (issue #1167).
+fn is_opencode_api_base(api_base: &str) -> bool {
+    let Ok(url) = reqwest::Url::parse(api_base) else {
+        return false;
+    };
+    matches!(
+        url.host_str(),
+        Some(host) if host == "opencode.ai" || host.ends_with(".opencode.ai")
+    )
+}
+
+pub(crate) fn new_conversation_id() -> String {
+    uuid::Uuid::new_v4().to_string()
+}
+
+/// OpenCode Go/Zen require a stable per-conversation `x-opencode-session`
+/// header on inference requests (rejected from 2026-09-05 without it).
+fn apply_opencode_session_header(
+    req: reqwest::RequestBuilder,
+    api_base: &str,
+    conversation_id: &str,
+) -> reqwest::RequestBuilder {
+    if is_opencode_api_base(api_base) {
+        req.header(OPENCODE_SESSION_HEADER, conversation_id)
+    } else {
+        req
+    }
+}
+
+pub(crate) const OPENCODE_SESSION_HEADER: &str = "x-opencode-session";
+
 #[derive(Debug, Clone)]
 enum ProviderAuth {
     AuthorizationBearer {
@@ -895,6 +926,10 @@ pub struct OpenRouterProvider {
     /// Missing entries mean unspecified and preserve the provider-level fallback.
     static_image_input_support: HashMap<String, bool>,
     send_openrouter_headers: bool,
+    /// Stable per-conversation identifier sent as `x-opencode-session` to
+    /// OpenCode (Zen / Go) endpoints, which require it for routing (issue #1167).
+    /// Each provider instance (and each `fork()`) gets a fresh UUID.
+    conversation_id: String,
     models_cache: Arc<RwLock<ModelsCache>>,
     model_catalog_refresh: Arc<Mutex<ModelCatalogRefreshState>>,
     /// Provider routing preferences
@@ -1432,6 +1467,7 @@ impl OpenRouterProvider {
             static_context_limits,
             static_image_input_support,
             send_openrouter_headers: false,
+            conversation_id: new_conversation_id(),
             models_cache: Arc::new(RwLock::new(ModelsCache::default())),
             model_catalog_refresh: Arc::new(Mutex::new(ModelCatalogRefreshState::default())),
             provider_routing: Arc::new(RwLock::new(ProviderRouting::default())),
@@ -1637,6 +1673,7 @@ impl OpenRouterProvider {
             static_context_limits,
             static_image_input_support: HashMap::new(),
             send_openrouter_headers,
+            conversation_id: new_conversation_id(),
             models_cache: Arc::new(RwLock::new(ModelsCache::default())),
             model_catalog_refresh: Arc::new(Mutex::new(ModelCatalogRefreshState::default())),
             provider_routing: Arc::new(RwLock::new(provider_routing)),
@@ -1680,6 +1717,7 @@ impl OpenRouterProvider {
             static_context_limits: HashMap::new(),
             static_image_input_support: HashMap::new(),
             send_openrouter_headers: true,
+            conversation_id: new_conversation_id(),
             models_cache: Arc::new(RwLock::new(ModelsCache::default())),
             model_catalog_refresh: Arc::new(Mutex::new(ModelCatalogRefreshState::default())),
             provider_routing: Arc::new(RwLock::new(Self::parse_provider_routing())),
@@ -1751,6 +1789,7 @@ impl OpenRouterProvider {
             static_context_limits,
             static_image_input_support: HashMap::new(),
             send_openrouter_headers: false,
+            conversation_id: new_conversation_id(),
             models_cache: Arc::new(RwLock::new(ModelsCache::default())),
             model_catalog_refresh: Arc::new(Mutex::new(ModelCatalogRefreshState::default())),
             provider_routing: Arc::new(RwLock::new(ProviderRouting::default())),
@@ -1956,6 +1995,7 @@ impl OpenRouterProvider {
                 static_context_limits: HashMap::new(),
                 static_image_input_support: HashMap::new(),
                 send_openrouter_headers: true,
+                conversation_id: new_conversation_id(),
                 models_cache: Arc::new(RwLock::new(ModelsCache::default())),
                 model_catalog_refresh: Arc::new(Mutex::new(ModelCatalogRefreshState::default())),
                 provider_routing: Arc::new(RwLock::new(ProviderRouting::default())),

--- a/crates/jcode-provider-openrouter-runtime/src/openrouter_provider_impl.rs
+++ b/crates/jcode-provider-openrouter-runtime/src/openrouter_provider_impl.rs
@@ -307,6 +307,7 @@ impl Provider for OpenRouterProvider {
         let api_base = self.api_base.clone();
         let auth = self.auth.clone();
         let send_openrouter_headers = self.send_openrouter_headers;
+        let conversation_id = self.conversation_id.clone();
         let request_for_retries = request;
         let model_for_stream = model.clone();
         let provider_pin = Arc::clone(&self.provider_pin);
@@ -326,6 +327,7 @@ impl Provider for OpenRouterProvider {
                 api_base,
                 auth,
                 send_openrouter_headers,
+                conversation_id,
                 request_for_retries,
                 tx,
                 provider_pin,
@@ -815,6 +817,9 @@ impl Provider for OpenRouterProvider {
             static_context_limits: self.static_context_limits.clone(),
             static_image_input_support: self.static_image_input_support.clone(),
             send_openrouter_headers: self.send_openrouter_headers,
+            // A fork is a new conversation (new session or subagent), so it
+            // gets its own stable id.
+            conversation_id: new_conversation_id(),
             models_cache: Arc::clone(&self.models_cache),
             model_catalog_refresh: Arc::clone(&self.model_catalog_refresh),
             provider_routing: Arc::new(RwLock::new(

--- a/crates/jcode-provider-openrouter-runtime/src/openrouter_sse_stream.rs
+++ b/crates/jcode-provider-openrouter-runtime/src/openrouter_sse_stream.rs
@@ -32,6 +32,7 @@ pub(super) async fn run_stream_with_retries(
     api_base: String,
     auth: ProviderAuth,
     send_openrouter_headers: bool,
+    conversation_id: String,
     request: Value,
     tx: mpsc::Sender<Result<StreamEvent>>,
     provider_pin: Arc<Mutex<Option<ProviderPin>>>,
@@ -92,6 +93,7 @@ pub(super) async fn run_stream_with_retries(
             api_base.clone(),
             auth.clone(),
             send_openrouter_headers,
+            &conversation_id,
             request.clone(),
             attempt_tx,
             Arc::clone(&provider_pin),
@@ -160,6 +162,7 @@ async fn stream_response(
     api_base: String,
     auth: ProviderAuth,
     send_openrouter_headers: bool,
+    conversation_id: &str,
     request: Value,
     tx: mpsc::Sender<Result<StreamEvent>>,
     provider_pin: Arc<Mutex<Option<ProviderPin>>>,
@@ -192,6 +195,7 @@ async fn stream_response(
             .header("HTTP-Referer", "https://github.com/jcode")
             .header("X-Title", "jcode");
     }
+    req = apply_opencode_session_header(req, &api_base, conversation_id);
 
     let response = jcode_provider_core::transport::send_with_initial_response_timeout(
         req.json(&request),

--- a/crates/jcode-provider-openrouter-runtime/src/openrouter_stream_options_tests.rs
+++ b/crates/jcode-provider-openrouter-runtime/src/openrouter_stream_options_tests.rs
@@ -9,6 +9,7 @@ fn direct_openai_compatible_chat_request_requests_usage_chunk() {
         supports_provider_features: false,
         supports_model_catalog: false,
         send_openrouter_headers: false,
+        conversation_id: new_conversation_id(),
         ..make_custom_compatible_provider()
     };
 
@@ -52,6 +53,7 @@ fn direct_openai_compatible_chat_request_allows_stream_options_override() {
         supports_provider_features: false,
         supports_model_catalog: false,
         send_openrouter_headers: false,
+        conversation_id: new_conversation_id(),
         extra_body: Some(serde_json::Map::from_iter([(
             "stream_options".to_string(),
             serde_json::json!({"include_usage": false}),

--- a/crates/jcode-provider-openrouter-runtime/src/openrouter_tests.rs
+++ b/crates/jcode-provider-openrouter-runtime/src/openrouter_tests.rs
@@ -1290,6 +1290,7 @@ fn make_provider() -> OpenRouterProvider {
         static_context_limits: HashMap::new(),
         static_image_input_support: HashMap::new(),
         send_openrouter_headers: true,
+        conversation_id: new_conversation_id(),
         models_cache: Arc::new(RwLock::new(ModelsCache::default())),
         model_catalog_refresh: Arc::new(Mutex::new(ModelCatalogRefreshState::default())),
         endpoint_refresh: Arc::new(Mutex::new(EndpointRefreshTracker::default())),
@@ -1321,6 +1322,7 @@ fn make_custom_compatible_provider() -> OpenRouterProvider {
         static_context_limits: HashMap::new(),
         static_image_input_support: HashMap::new(),
         send_openrouter_headers: false,
+        conversation_id: new_conversation_id(),
         models_cache: Arc::new(RwLock::new(ModelsCache::default())),
         model_catalog_refresh: Arc::new(Mutex::new(ModelCatalogRefreshState::default())),
         endpoint_refresh: Arc::new(Mutex::new(EndpointRefreshTracker::default())),
@@ -1692,6 +1694,7 @@ fn direct_deepseek_chat_request_sends_reasoning_effort() {
         supports_provider_features: false,
         supports_model_catalog: false,
         send_openrouter_headers: false,
+        conversation_id: new_conversation_id(),
         ..make_custom_compatible_provider()
     };
     provider
@@ -1748,6 +1751,7 @@ fn direct_openai_compatible_chat_request_preserves_max_reasoning_effort() {
         supports_provider_features: false,
         supports_model_catalog: false,
         send_openrouter_headers: false,
+        conversation_id: new_conversation_id(),
         ..make_custom_compatible_provider()
     };
     provider
@@ -1817,6 +1821,7 @@ fn openai_compatible_model_catalog_refresh_calls_models_endpoint_and_updates_dis
         reasoning_effort_support: None,
         static_models: vec!["static-login-flow-fallback".to_string()],
         send_openrouter_headers: false,
+        conversation_id: new_conversation_id(),
         ..make_custom_compatible_provider()
     };
 
@@ -1866,6 +1871,7 @@ fn openai_compatible_model_catalog_refresh_calls_models_endpoint_and_updates_dis
         profile_id: None,
         reasoning_effort_support: None,
         send_openrouter_headers: false,
+        conversation_id: new_conversation_id(),
         ..make_custom_compatible_provider()
     };
     assert_eq!(fresh_provider.context_window(), 131_072);
@@ -1902,6 +1908,7 @@ fn built_in_openai_compatible_static_models_drop_out_after_live_catalog() {
         profile_id: Some("cerebras".to_string()),
         static_models: vec!["gpt-oss-120b".to_string(), "zai-glm-4.7".to_string()],
         send_openrouter_headers: false,
+        conversation_id: new_conversation_id(),
         ..make_custom_compatible_provider()
     };
 
@@ -1931,6 +1938,7 @@ fn direct_openai_compatible_static_models_are_marked_as_fallback_before_live_cat
         profile_id: Some("opencode".to_string()),
         static_models: vec!["minimax-m2.7".to_string()],
         send_openrouter_headers: false,
+        conversation_id: new_conversation_id(),
         ..make_custom_compatible_provider()
     };
 
@@ -1956,6 +1964,7 @@ fn cerebras_live_catalog_models_are_selectable_on_explicit_switch() {
         profile_id: Some("cerebras".to_string()),
         static_models: vec!["gpt-oss-120b".to_string()],
         send_openrouter_headers: false,
+        conversation_id: new_conversation_id(),
         ..make_custom_compatible_provider()
     };
 
@@ -2903,6 +2912,7 @@ fn midstream_transport_fault_emits_retry_rollback_before_replay() {
                 label: "test".to_string(),
             },
             false,
+            new_conversation_id(),
             request,
             tx,
             Arc::new(Mutex::new(None)),
@@ -3319,4 +3329,48 @@ fn named_openai_compatible_provider_keeps_stable_name_and_profile_display_name()
     // User-facing identity: the profile the user configured.
     assert_eq!(provider.runtime_display_name(), "example-compat");
     assert_eq!(Provider::display_name(&provider), "example-compat");
+}
+
+/// Issue #1167: OpenCode Go/Zen require a stable per-conversation
+/// `x-opencode-session` header; other OpenAI-compatible hosts must not get it.
+#[test]
+fn opencode_session_header_only_for_opencode_hosts() {
+    assert!(is_opencode_api_base("https://opencode.ai/zen/go/v1"));
+    assert!(is_opencode_api_base("https://opencode.ai/zen/v1"));
+    assert!(is_opencode_api_base("https://api.opencode.ai/v1"));
+    assert!(!is_opencode_api_base("https://openrouter.ai/api/v1"));
+    assert!(!is_opencode_api_base("https://api.deepseek.com/v1"));
+    assert!(!is_opencode_api_base("not a url"));
+
+    let client = reqwest::Client::new();
+    let req = apply_opencode_session_header(
+        client.post("https://opencode.ai/zen/go/v1/chat/completions"),
+        "https://opencode.ai/zen/go/v1",
+        "conv-123",
+    )
+    .build()
+    .unwrap();
+    assert_eq!(
+        req.headers()
+            .get(OPENCODE_SESSION_HEADER)
+            .and_then(|v| v.to_str().ok()),
+        Some("conv-123")
+    );
+
+    let req = apply_opencode_session_header(
+        client.post("https://openrouter.ai/api/v1/chat/completions"),
+        "https://openrouter.ai/api/v1",
+        "conv-123",
+    )
+    .build()
+    .unwrap();
+    assert!(req.headers().get(OPENCODE_SESSION_HEADER).is_none());
+}
+
+#[test]
+fn opencode_session_ids_are_uuids_and_unique() {
+    let a = new_conversation_id();
+    let b = new_conversation_id();
+    assert_ne!(a, b);
+    assert!(uuid::Uuid::parse_str(&a).is_ok());
 }

--- a/crates/jcode-provider-openrouter-runtime/src/openrouter_tests.rs
+++ b/crates/jcode-provider-openrouter-runtime/src/openrouter_tests.rs
@@ -3374,3 +3374,79 @@ fn opencode_session_ids_are_uuids_and_unique() {
     assert_ne!(a, b);
     assert!(uuid::Uuid::parse_str(&a).is_ok());
 }
+
+/// Wire-level check for issue #1167: a real `chat/completions` request whose
+/// api_base host is `opencode.ai` carries `x-opencode-session`, and a
+/// request to another host does not. The DNS override points the hostname at
+/// a local listener, so the full stream path (including retries) is exercised.
+fn spawn_header_capturing_server() -> (std::net::SocketAddr, std::sync::mpsc::Receiver<String>) {
+    use std::io::{Read, Write};
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+    let addr = listener.local_addr().expect("addr");
+    let (tx, rx) = std::sync::mpsc::channel::<String>();
+    std::thread::spawn(move || {
+        let (mut stream, _) = listener.accept().expect("accept");
+        stream
+            .set_read_timeout(Some(Duration::from_secs(5)))
+            .expect("read timeout");
+        let mut buf = vec![0u8; 65536];
+        let n = stream.read(&mut buf).unwrap_or(0);
+        let _ = tx.send(String::from_utf8_lossy(&buf[..n]).to_string());
+        let body = "data: {\"choices\":[{\"delta\":{\"content\":\"ok\"},\"finish_reason\":\"stop\"}]}\n\ndata: [DONE]\n\n";
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            body.len(),
+            body
+        );
+        let _ = stream.write_all(response.as_bytes());
+    });
+    (addr, rx)
+}
+
+fn captured_request_for_host(host: &str, conversation_id: &str) -> String {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("runtime");
+    rt.block_on(async {
+        let (addr, rx) = spawn_header_capturing_server();
+        let client = reqwest::Client::builder()
+            .resolve(host, addr)
+            .build()
+            .expect("client");
+        let api_base = format!("http://{host}:{}/zen/go/v1", addr.port());
+        let (tx, mut events) = tokio::sync::mpsc::channel::<anyhow::Result<StreamEvent>>(64);
+        super::openrouter_sse_stream::run_stream_with_retries(
+            client,
+            api_base,
+            ProviderAuth::None {
+                label: "test".to_string(),
+            },
+            false,
+            conversation_id.to_string(),
+            serde_json::json!({"model": "m", "messages": [], "stream": true}),
+            tx,
+            Arc::new(Mutex::new(None)),
+            "m".to_string(),
+        )
+        .await;
+        while events.recv().await.is_some() {}
+        rx.recv_timeout(Duration::from_secs(5))
+            .expect("server captured request")
+    })
+}
+
+#[test]
+fn opencode_session_header_is_sent_on_the_wire_only_to_opencode_hosts() {
+    let raw = captured_request_for_host("opencode.ai", "conv-wire-1167").to_ascii_lowercase();
+    assert!(
+        raw.contains("x-opencode-session: conv-wire-1167"),
+        "opencode.ai request lacked the header:\n{raw}"
+    );
+
+    let raw = captured_request_for_host("example.test", "conv-wire-1167").to_ascii_lowercase();
+    assert!(
+        !raw.contains("x-opencode-session"),
+        "non-opencode host received the header:\n{raw}"
+    );
+}


### PR DESCRIPTION
Fixes #1167.

OpenCode Go/Zen require a stable per-conversation `x-opencode-session` header on inference requests starting 2026-09-05.

Changes (`jcode-provider-openrouter-runtime`, which serves all OpenAI-compatible profiles including `opencode` and `opencode-go`):
- `OpenRouterProvider` now carries a `conversation_id` (UUID v4), generated at construction and regenerated on `fork()` so each session/subagent gets its own id.
- `chat/completions` requests add `x-opencode-session: <id>` when the `api_base` host is `opencode.ai` (or a subdomain). Other hosts are unchanged.
- Unit tests for host matching, header presence/absence, and id uniqueness.

Verification: `cargo test -p jcode-provider-openrouter-runtime` (129 passed), `cargo check -p jcode --bin jcode`.

---
*— Jcode agent (automated triage), on behalf of @1jehuang*