### PR TITLE
Welcome pull requests from all contributors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,11 +2,15 @@
 
 ## Development Workflow
 
-- **Stay on your own branch** - Do not take, cherry-pick, merge, or copy code from other
-  people's or other agents' branches unless the source branch belongs to a repository
-  maintainer and the user explicitly asks you to integrate it. Only work from your branch
-  and its base (e.g. `main`) otherwise. Never integrate branches owned by non-maintainers
-  or other agents yourself; tell the user and let them decide how to proceed.
+- **Welcome pull requests from everyone** - Review contributions on their merits,
+  regardless of whether the author is a maintainer, an existing contributor, a
+  first-time contributor, or an agent. Good PRs can be merged directly after review
+  and validation. Do not require a maintainer-authored rewrite merely because of
+  who submitted the change. See `CONTRIBUTING.md` for the contribution policy.
+- **Keep work scoped** - Work on your own branch and preserve unrelated work. When
+  the user asks you to review or integrate a PR or branch, you may inspect, test,
+  and integrate that contribution regardless of author status. Do not pull in
+  unrelated branches or merge a PR without user authorization.
 
 ## Install Notes
 - `~/.local/bin/jcode` is the launcher symlink used from `PATH`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,8 @@
+# Repository Instructions
+
+@AGENTS.md
+
+Follow `AGENTS.md` for the development workflow and `CONTRIBUTING.md` for the
+contribution policy. Pull requests from everyone are welcome for direct review
+and merging, regardless of contributor or maintainer status. Preserve unrelated
+work and obtain user authorization before merging.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,21 +4,23 @@ Thanks for contributing.
 
 ## Issues vs pull requests
 
-If the problem is easy for me to reproduce, please prefer opening a GitHub issue. A clear issue with reproduction steps, expected behavior, actual behavior, logs, screenshots, or traces is usually the fastest path to a fix.
+Both issues and pull requests are welcome. Open an issue to report a bug or discuss an idea, or send a focused PR if you have a fix or improvement ready. For large changes, discuss the approach in an issue first to avoid spending time on work that may not fit the project.
 
-Pull requests are more useful when the problem depends on an environment I may not have, such as macOS-specific behavior, Windows-specific behavior, unusual shells, terminal emulators, filesystems, GPU/display setups, provider accounts, or other local configuration. In those cases, a PR can be a useful reference because it captures the behavior in the environment where the problem actually occurs.
+A clear issue or PR includes reproduction steps, expected behavior, actual behavior, and relevant logs, screenshots, or traces. Environment-specific fixes are especially helpful when they cover systems the maintainers may not have, such as macOS, Windows, unusual shells, terminal emulators, filesystems, GPU/display setups, or provider accounts.
+
+Every PR must link to an existing GitHub issue in this repository. If there is no issue yet, open one and reference it in the PR description, for example with `Closes #123`.
 
 ## Pull request policy
 
-Pull requests are welcome and encouraged.
+Pull requests from everyone are welcome and encouraged, including first-time contributors and people who are not maintainers or existing contributors.
 
-That said, most PRs should be treated as proposals or references, not as changes that are likely to be merged directly. This project is developed with heavy use of code generation, and generated code can be deceptively plausible: it may fix the visible problem while introducing subtle correctness, lifecycle, architecture, or maintenance issues.
+PRs are reviewed as changes that can be merged directly, not merely as proposals or references for a maintainer-authored rewrite. Review is based on correctness, tests, security, architecture, maintainability, and fit with the project, not the author's contributor status.
 
-Because of that, I will often use PRs to understand the bug, feature request, test case, design direction, or proposed implementation, then write my own version of the change. The submitted code may still be extremely valuable as a reference, reproduction, or proof of concept, even if the final committed code is different.
+AI-assisted and generated contributions are welcome and held to the same standards as handwritten code. Understand the changes you submit, explain their assumptions and tradeoffs, and validate them. This applies equally to maintainer and community contributions.
 
-This is not a judgment that maintainer-generated code is inherently better than contributor-generated code. It is a practical ownership rule: if I am going to maintain the resulting code, I need to understand its assumptions, tradeoffs, and failure modes.
+Maintainers may request revisions, help refine an implementation, or decline a change that does not fit the project. A rewrite is not required just because a PR comes from an outside contributor.
 
-The best PRs therefore include:
+The best PRs include:
 
 - a clear description of the problem being solved
 - a minimal reproduction or failing test when possible
@@ -26,6 +28,4 @@ The best PRs therefore include:
 - focused changes that are easy to review independently
 - any relevant logs, screenshots, traces, or benchmarks
 
-Large, generated, or highly invasive PRs may be closed even when the underlying idea is good. In those cases, the issue or PR may still be used as a reference for a maintainer-authored change.
-
-Handwritten by author: My clanker slop may or may not be better than your clanker slop. I know how to work with my clanker slop though.
+Keep changes focused and split large changes into independently reviewable pieces when possible. Passing checks does not guarantee a merge, but author status or use of code generation is not, by itself, a reason to reject a contribution.

--- a/crates/jcode-base/src/prompt/selfdev_mode.txt
+++ b/crates/jcode-base/src/prompt/selfdev_mode.txt
@@ -6,6 +6,12 @@ Tools:
 - `selfdev` manages self-dev builds and reloads.
 - `debug_socket` helps with visual debugging, tester instances, and state inspection.
 
+## Pull requests and contributions
+
+Pull requests from everyone are welcome, including first-time contributors and authors who are not maintainers or existing contributors. Review contributions on correctness, tests, security, architecture, and maintainability, not author status. Good PRs can be merged directly after review and validation. Do not require a maintainer-authored rewrite merely because of who submitted the change or whether they used code generation.
+
+When the user asks you to review or integrate a PR or branch, you may inspect, test, and integrate it regardless of author status. Keep the work scoped, preserve unrelated changes, and do not pull in unrelated branches or merge a PR without user authorization. Follow the repository's `AGENTS.md` and `CONTRIBUTING.md` for its workflow and contribution policy.
+
 ## Workflow
 
 When you make code changes to jcode:

--- a/crates/jcode-base/src/prompt_tests.rs
+++ b/crates/jcode-base/src/prompt_tests.rs
@@ -548,6 +548,20 @@ fn test_selfdev_prompt_prefers_publish_flow_for_active_builds() {
 }
 
 #[test]
+fn test_selfdev_prompt_welcomes_outside_contributions() {
+    let full = build_system_prompt_with_selfdev(None, &[], true);
+    let (split, _) = build_system_prompt_split(None, &[], true, None, None);
+
+    for prompt in [&full, &split.static_part] {
+        assert!(prompt.contains("Pull requests from everyone are welcome"));
+        assert!(prompt.contains("Good PRs can be merged directly after review and validation"));
+        assert!(prompt.contains("Do not require a maintainer-authored rewrite"));
+        assert!(prompt.contains("preserve unrelated changes"));
+        assert!(prompt.contains("merge a PR without user authorization"));
+    }
+}
+
+#[test]
 fn test_selfdev_prompt_template_placeholders_are_resolved() {
     let static_prompt = build_selfdev_prompt_static();
     let dynamic_prompt = build_selfdev_prompt();


### PR DESCRIPTION
## Summary
- Welcome PRs for direct review and merging regardless of maintainer or prior contributor status.
- Align AGENTS.md, new CLAUDE.md, CONTRIBUTING.md, and embedded self-dev guidance.
- Keep review, validation, scoped changes, and user authorization for merges.
- Add a regression test covering full and split self-dev prompts.

## Validation
- `cargo test -p jcode-base --lib prompt -- --test-threads=1`: 44 passed.
- `rustfmt --check --edition 2024 crates/jcode-base/src/prompt_tests.rs`: passed.
- Coordinated self-dev TUI build: passed.
- Only the five policy/test files are included. Unrelated local commits and staged changes were excluded.

Closes #1235